### PR TITLE
M6: ugcApi.js — shared UGC API helper

### DIFF
--- a/assets/js/test-unit/theme/global/ugcApi.spec.js
+++ b/assets/js/test-unit/theme/global/ugcApi.spec.js
@@ -1,0 +1,224 @@
+import ugcApi, { UgcApi, resolveBaseUrl } from '../../../theme/_addons/global/ugcApi';
+
+const BASE = 'https://ugc.cravenspeed.com';
+const API = `${BASE}/api`;
+
+// Minimal stand-in for a fetch Response.
+const mockResponse = (status, body) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+});
+
+const makeApi = (fetchImpl) => new UgcApi({ baseUrl: BASE, fetchImpl });
+
+describe('ugcApi', () => {
+    describe('resolveBaseUrl', () => {
+        it('targets the dev API on localhost', () => {
+            expect(resolveBaseUrl('localhost')).toEqual('http://localhost:5000');
+        });
+
+        it('targets the dev API on 127.0.0.1', () => {
+            expect(resolveBaseUrl('127.0.0.1')).toEqual('http://localhost:5000');
+        });
+
+        it('defaults to the production API for any other host', () => {
+            expect(resolveBaseUrl('www.cravenspeed.com')).toEqual('https://ugc.cravenspeed.com');
+        });
+    });
+
+    describe('default export', () => {
+        it('is a UgcApi instance', () => {
+            expect(ugcApi).toBeInstanceOf(UgcApi);
+        });
+    });
+
+    describe('GET endpoints', () => {
+        it('getReviews builds the path with query params and returns normalized data', async () => {
+            const body = { items: [], total: 0, archetype_rating_average: null };
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, body)));
+            const api = makeApi(fetchImpl);
+
+            const result = await api.getReviews(12, { page: 2, sort: 'rating_desc', sort_alias: 4821 });
+
+            expect(fetchImpl).toHaveBeenCalledWith(
+                `${API}/reviews/12?page=2&sort=rating_desc&sort_alias=4821`,
+                { cache: 'no-cache' },
+            );
+            expect(result).toEqual({ ok: true, status: 200, data: body });
+        });
+
+        it('getReviews omits null/undefined/empty params', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, {})));
+            const api = makeApi(fetchImpl);
+
+            await api.getReviews(12, {
+                page: 1, rating: null, verified: undefined, media: '',
+            });
+
+            expect(fetchImpl).toHaveBeenCalledWith(`${API}/reviews/12?page=1`, { cache: 'no-cache' });
+        });
+
+        it('getQuestions builds the questions path', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, { items: [] })));
+            const api = makeApi(fetchImpl);
+
+            await api.getQuestions(12, { sort: 'date_asc' });
+
+            expect(fetchImpl).toHaveBeenCalledWith(`${API}/questions/12?sort=date_asc`, { cache: 'no-cache' });
+        });
+
+        it('getOverview hits /overview with no query', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, { reviews: [] })));
+            const api = makeApi(fetchImpl);
+
+            await api.getOverview();
+
+            expect(fetchImpl).toHaveBeenCalledWith(`${API}/overview`, { cache: 'no-cache' });
+        });
+
+        it('validateToken passes the token as ugc_token', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, { archetype_id: 12 })));
+            const api = makeApi(fetchImpl);
+
+            await api.validateToken('abc123');
+
+            expect(fetchImpl).toHaveBeenCalledWith(`${API}/token/validate?ugc_token=abc123`, { cache: 'no-cache' });
+        });
+
+        it('de-dupes identical concurrent GETs into one network call', async () => {
+            let resolveFetch;
+            const fetchImpl = jest.fn(() => new Promise((resolve) => { resolveFetch = resolve; }));
+            const api = makeApi(fetchImpl);
+
+            const first = api.getReviews(12, { page: 1 });
+            const second = api.getReviews(12, { page: 1 });
+            resolveFetch(mockResponse(200, { items: [] }));
+            await Promise.all([first, second]);
+
+            expect(fetchImpl).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('POST endpoints', () => {
+        it('postReview sends a JSON body and returns normalized data on 201', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(201, { id: 99 })));
+            const api = makeApi(fetchImpl);
+            const payload = { archetype_id: 12, rating: 5, body: 'Great' };
+
+            const result = await api.postReview(payload);
+
+            expect(fetchImpl).toHaveBeenCalledWith(`${API}/reviews`, {
+                method: 'POST',
+                cache: 'no-cache',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            expect(result).toEqual({ ok: true, status: 201, data: { id: 99 } });
+        });
+
+        it('postQuestion targets /questions', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(201, { id: 7 })));
+            const api = makeApi(fetchImpl);
+
+            await api.postQuestion({ archetype_id: 12, body: 'Fits F56?' });
+
+            expect(fetchImpl.mock.calls[0][0]).toEqual(`${API}/questions`);
+        });
+
+        it('presignMedia derives filename and content_type from the File', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, { presigned_url: 'x', raw_url: 'y' })));
+            const api = makeApi(fetchImpl);
+            const file = new File(['data'], 'photo.jpg', { type: 'image/jpeg' });
+
+            await api.presignMedia(file);
+
+            expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual({
+                filename: 'photo.jpg',
+                content_type: 'image/jpeg',
+            });
+        });
+
+        it('confirmMedia sends raw_url', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, { confirmed: true })));
+            const api = makeApi(fetchImpl);
+
+            await api.confirmMedia('https://do/raw/uuid.jpg');
+
+            expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual({ raw_url: 'https://do/raw/uuid.jpg' });
+        });
+    });
+
+    describe('§3.6 error handling', () => {
+        it('maps 429 to the too-many-submissions message', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(429, { error: 'rate limited' })));
+            const api = makeApi(fetchImpl);
+
+            const result = await api.postReview({});
+
+            expect(result.ok).toBe(false);
+            expect(result.status).toEqual(429);
+            expect(result.message).toMatch(/too many submissions/i);
+        });
+
+        it('surfaces the envelope error on 400', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(400, { error: 'Turnstile validation failed' })));
+            const api = makeApi(fetchImpl);
+
+            const result = await api.postReview({});
+
+            expect(result).toEqual({
+                ok: false,
+                status: 400,
+                message: 'Turnstile validation failed',
+                error: 'Turnstile validation failed',
+            });
+        });
+
+        it('surfaces the envelope error on 422', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(422, { error: 'Media processing failure' })));
+            const api = makeApi(fetchImpl);
+
+            const result = await api.confirmMedia('https://do/raw/uuid.jpg');
+
+            expect(result.ok).toBe(false);
+            expect(result.message).toEqual('Media processing failure');
+        });
+
+        it('returns a generic message on 500', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(500, { error: 'boom' })));
+            const api = makeApi(fetchImpl);
+
+            const result = await api.getReviews(12);
+
+            expect(result.ok).toBe(false);
+            expect(result.status).toEqual(500);
+            expect(result.message).toMatch(/something went wrong/i);
+        });
+
+        it('falls back to a generic message when an error status has no envelope', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(400, null)));
+            const api = makeApi(fetchImpl);
+
+            const result = await api.postQuestion({});
+
+            expect(result.ok).toBe(false);
+            expect(result.message).toMatch(/something went wrong/i);
+            expect(result.error).toBeNull();
+        });
+
+        it('resolves (does not reject) when fetch itself fails', async () => {
+            const fetchImpl = jest.fn(() => Promise.reject(new Error('network down')));
+            const api = makeApi(fetchImpl);
+
+            const result = await api.getOverview();
+
+            expect(result).toEqual({
+                ok: false,
+                status: 0,
+                message: 'Something went wrong. Please try again.',
+                error: 'network down',
+            });
+        });
+    });
+});

--- a/assets/js/theme/_addons/global/ugcApi.js
+++ b/assets/js/theme/_addons/global/ugcApi.js
@@ -1,0 +1,237 @@
+/**
+ * @file ugcApi
+ * @description Shared helper for the CravenSpeed UGC API (reviews, questions,
+ * overview, verified-purchaser token validation, and media presign/confirm).
+ * Imported by ugcProduct.js and ugcOverview.js. See cs-ugc SRS §3.2, §3.4.3, §3.6.
+ *
+ * This module is the SINGLE source of the UGC API base URL — no other module
+ * hardcodes it. The base resolves per environment (SRS §3.4.3): localhost dev
+ * points at the local cs-ugc Flask app; everything else points at production.
+ */
+
+// The base URL literals live here and nowhere else.
+const PROD_BASE_URL = 'https://ugc.cravenspeed.com';
+const DEV_BASE_URL = 'http://localhost:5000';
+
+// User-facing messages for the §3.6 status branches.
+const MESSAGES = {
+    rateLimit: 'You\'ve made too many submissions. Please try again later.',
+    generic: 'Something went wrong. Please try again.',
+};
+
+/**
+ * Resolve the API base URL for the current environment. Defaults to production;
+ * only a local Stencil dev host (localhost / 127.0.0.1) targets the dev API.
+ * @param {string} [hostname] - Host to test; defaults to the live location host.
+ * @returns {string}
+ */
+export function resolveBaseUrl(hostname = window.location.hostname) {
+    const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+    return isLocal ? DEV_BASE_URL : PROD_BASE_URL;
+}
+
+/**
+ * Build a query string from a params object, skipping null/undefined/empty
+ * values so optional filters are simply omitted.
+ * @param {Object} [params]
+ * @returns {string} A leading-`?` query string, or '' when there are no params.
+ */
+function buildQuery(params = {}) {
+    const search = new URLSearchParams();
+    Object.keys(params).forEach((key) => {
+        const value = params[key];
+        if (value !== null && value !== undefined && value !== '') {
+            search.append(key, value);
+        }
+    });
+    const queryString = search.toString();
+    return queryString ? `?${queryString}` : '';
+}
+
+export class UgcApi {
+    /**
+     * @param {Object} [options]
+     * @param {string} [options.baseUrl] - Override the resolved base URL.
+     * @param {Function} [options.fetchImpl] - Injectable fetch (for tests).
+     */
+    constructor({ baseUrl = resolveBaseUrl(), fetchImpl } = {}) {
+        this.baseUrl = baseUrl;
+        this.apiBase = `${baseUrl}/api`;
+        this.fetch = fetchImpl || ((...args) => fetch(...args));
+
+        // De-dupe identical in-flight GETs (mirrors DataManager). Results are
+        // never cached past resolution — reviews/questions must stay fresh.
+        this.pendingRequests = new Map();
+    }
+
+    /**
+     * Normalize a fetch Response into the discriminated result shape callers
+     * branch on. Applies the §3.6 status→message mapping.
+     * @param {Response} response
+     * @returns {Promise<Object>}
+     */
+    async handleResponse(response) {
+        const { status } = response;
+        let payload = null;
+
+        try {
+            payload = await response.json();
+        } catch (e) {
+            payload = null;
+        }
+
+        if (response.ok) {
+            return { ok: true, status, data: payload };
+        }
+
+        const envelopeError = payload && payload.error ? payload.error : null;
+        let message;
+
+        if (status === 429) {
+            message = MESSAGES.rateLimit;
+        } else if (status === 400 || status === 422) {
+            // Surface the human-readable message from the {"error":"..."} envelope.
+            message = envelopeError || MESSAGES.generic;
+        } else {
+            message = MESSAGES.generic;
+        }
+
+        return {
+            ok: false, status, message, error: envelopeError,
+        };
+    }
+
+    /**
+     * Issue a GET, de-duping identical concurrent requests. Resolves to the
+     * normalized result shape; network/parse failures resolve as ok:false too.
+     * @param {string} path - Path under the API base, e.g. '/reviews/12'.
+     * @returns {Promise<Object>}
+     */
+    async get(path) {
+        const url = `${this.apiBase}${path}`;
+        if (this.pendingRequests.has(url)) {
+            return this.pendingRequests.get(url);
+        }
+
+        const requestPromise = (async () => {
+            try {
+                const response = await this.fetch(url, { cache: 'no-cache' });
+                return await this.handleResponse(response);
+            } catch (error) {
+                return {
+                    ok: false, status: 0, message: MESSAGES.generic, error: error.message,
+                };
+            } finally {
+                this.pendingRequests.delete(url);
+            }
+        })();
+
+        this.pendingRequests.set(url, requestPromise);
+        return requestPromise;
+    }
+
+    /**
+     * Issue a POST with a JSON body. Resolves to the normalized result shape.
+     * @param {string} path
+     * @param {Object} body
+     * @returns {Promise<Object>}
+     */
+    async post(path, body) {
+        const url = `${this.apiBase}${path}`;
+        try {
+            const response = await this.fetch(url, {
+                method: 'POST',
+                cache: 'no-cache',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            return await this.handleResponse(response);
+        } catch (error) {
+            return {
+                ok: false, status: 0, message: MESSAGES.generic, error: error.message,
+            };
+        }
+    }
+
+    /**
+     * Approved reviews for an archetype, pooled across its aliases (SRS §3.2.1).
+     * @param {number|string} archetypeId
+     * @param {Object} [params] - page, sort, rating, verified, media, sort_alias.
+     * @returns {Promise<Object>}
+     */
+    getReviews(archetypeId, params = {}) {
+        return this.get(`/reviews/${archetypeId}${buildQuery(params)}`);
+    }
+
+    /**
+     * Approved questions and staff answers for an archetype (SRS §3.2.2).
+     * @param {number|string} archetypeId
+     * @param {Object} [params] - page, sort, sort_alias.
+     * @returns {Promise<Object>}
+     */
+    getQuestions(archetypeId, params = {}) {
+        return this.get(`/questions/${archetypeId}${buildQuery(params)}`);
+    }
+
+    /**
+     * Latest approved reviews across all archetypes for the photo wall (SRS §3.2.3).
+     * @returns {Promise<Object>}
+     */
+    getOverview() {
+        return this.get('/overview');
+    }
+
+    /**
+     * Validate a verified-purchaser token (SRS §3.2.8).
+     * @param {string} token
+     * @returns {Promise<Object>}
+     */
+    validateToken(token) {
+        return this.get(`/token/validate${buildQuery({ ugc_token: token })}`);
+    }
+
+    /**
+     * Submit a review (SRS §3.2.4).
+     * @param {Object} payload
+     * @returns {Promise<Object>}
+     */
+    postReview(payload) {
+        return this.post('/reviews', payload);
+    }
+
+    /**
+     * Submit a question (SRS §3.2.5).
+     * @param {Object} payload
+     * @returns {Promise<Object>}
+     */
+    postQuestion(payload) {
+        return this.post('/questions', payload);
+    }
+
+    /**
+     * Request a presigned DO Spaces URL for a direct browser upload (SRS §3.2.6).
+     * The actual PUT to DO Spaces is handled by the media-upload flow, not here.
+     * @param {File} file
+     * @returns {Promise<Object>}
+     */
+    presignMedia(file) {
+        return this.post('/media/presign', {
+            filename: file.name,
+            content_type: file.type,
+        });
+    }
+
+    /**
+     * Confirm an uploaded raw file and trigger server-side processing (SRS §3.2.7).
+     * @param {string} rawUrl
+     * @returns {Promise<Object>}
+     */
+    confirmMedia(rawUrl) {
+        return this.post('/media/confirm', { raw_url: rawUrl });
+    }
+}
+
+// Default export: a ready-to-use singleton bound to the resolved environment.
+const ugcApi = new UgcApi();
+
+export default ugcApi;


### PR DESCRIPTION
Refs #5

Shared UGC API helper at `assets/js/theme/_addons/global/ugcApi.js`, imported by `ugcProduct.js` and `ugcOverview.js` (SRS §3.4.3, §3.6).

## Acceptance criteria
- [x] **Base URL defined exactly once, in `ugcApi.js`** — `PROD_BASE_URL`/`DEV_BASE_URL` literals live only here; `resolveBaseUrl()` picks dev (`http://localhost:5000`) for `localhost`/`127.0.0.1`, prod (`https://ugc.cravenspeed.com`) otherwise, defaulting to prod (`ugcApi.js:13-35`).
- [x] **All listed endpoint methods present with SRS-correct paths, params, bodies** — `getReviews` (§3.2.1), `getQuestions` (§3.2.2), `getOverview` (§3.2.3), `postReview` (§3.2.4), `postQuestion` (§3.2.5), `presignMedia` (§3.2.6), `confirmMedia` (§3.2.7), `validateToken` (§3.2.8) (`ugcApi.js:150-247`).
- [x] **Status→message error mapping per §3.6, surfacing the envelope `error`** — 429 → "too many submissions"; 400/422 → envelope `error`; 500/other/network → generic. Every call resolves (never rejects) to `{ ok:true, status, data }` or `{ ok:false, status, message, error }` (`ugcApi.js:71-103`).
- [x] **Jest tests mock `fetch`, happy path + each §3.6 branch, no live calls** — 20 tests via injected `fetchImpl` (`ugcApi.spec.js`).
- [x] **`npx grunt check` passes** — eslint clean, 14 suites / 136 tests pass (20 new), stylelint 197 files clean.

## Conventions / notes
- Mirrors `DataManager`: `cache: 'no-cache'`, in-flight GET de-dup via a `pendingRequests` Map; injectable `fetchImpl` so tests never touch the network. Default export is a singleton bound to the resolved env.
- **Scope:** the direct PUT to DO Spaces (media-flow step 3, §3.4.4) is intentionally **not** here — it belongs to #9. This helper only does presign/confirm, matching the issue's method list.
- Tests placed in the repo's established `assets/js/test-unit/.../global/` location (`grunt check` already runs it and excludes `*.spec.js` from eslint), rather than introducing a new `__tests__` dir.
- No new theme config values introduced.