### PR TITLE
M6: ugcOverview.js — overview photo wall

### DIFF
--- a/assets/js/test-unit/theme/global/ugcOverview.spec.js
+++ b/assets/js/test-unit/theme/global/ugcOverview.spec.js
@@ -1,0 +1,210 @@
+import UgcOverview, {
+    FILTERS,
+    applyFilter,
+    paginate,
+    pageCount,
+} from '../../../theme/_addons/global/ugcOverview';
+
+// Build N reviews; every Mth one carries a photo so media filters have signal.
+const makeReviews = (count, { withMediaEvery = 0, ratingCycle = [5] } = {}) => (
+    Array.from({ length: count }, (_, i) => {
+        const review = {
+            id: i + 1,
+            author: `Author ${i + 1}`,
+            title: `Title ${i + 1}`,
+            body: `Body ${i + 1}`,
+            rating: ratingCycle[i % ratingCycle.length],
+            archetype_name: 'the-stubby-antenna',
+            archetype_url: '/stubby-antenna/',
+            media: [],
+        };
+        if (withMediaEvery && (i % withMediaEvery === 0)) {
+            review.media = [{ type: 'photo', thumb_url: `https://cdn/${i}/thumb.jpg` }];
+        }
+        return review;
+    })
+);
+
+const okResult = reviews => ({ ok: true, status: 200, data: { reviews } });
+
+describe('ugcOverview pure helpers', () => {
+    describe('paginate', () => {
+        it('returns the first 10 for page 1', () => {
+            const reviews = makeReviews(25);
+            expect(paginate(reviews, 1).map(r => r.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        });
+
+        it('returns the next 10 for page 2', () => {
+            const reviews = makeReviews(25);
+            expect(paginate(reviews, 2).map(r => r.id)).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+        });
+
+        it('returns the remainder on the last page', () => {
+            const reviews = makeReviews(25);
+            expect(paginate(reviews, 3).map(r => r.id)).toEqual([21, 22, 23, 24, 25]);
+        });
+
+        it('returns nothing past the end', () => {
+            expect(paginate(makeReviews(5), 2)).toEqual([]);
+        });
+    });
+
+    describe('pageCount', () => {
+        it('ceils to whole pages of 10', () => {
+            expect(pageCount(25)).toBe(3);
+            expect(pageCount(20)).toBe(2);
+            expect(pageCount(1)).toBe(1);
+        });
+
+        it('is at least 1 even when empty', () => {
+            expect(pageCount(0)).toBe(1);
+        });
+    });
+
+    describe('applyFilter', () => {
+        it('returns everything for ALL', () => {
+            const reviews = makeReviews(6, { withMediaEvery: 2 });
+            expect(applyFilter(reviews, FILTERS.ALL)).toHaveLength(6);
+        });
+
+        it('keeps only reviews with media for WITH_PHOTOS', () => {
+            const reviews = makeReviews(6, { withMediaEvery: 2 });
+            const filtered = applyFilter(reviews, FILTERS.WITH_PHOTOS);
+            expect(filtered).toHaveLength(3);
+            expect(filtered.every(r => r.media.length > 0)).toBe(true);
+        });
+
+        it('keeps only reviews without media for BASIC', () => {
+            const reviews = makeReviews(6, { withMediaEvery: 2 });
+            const filtered = applyFilter(reviews, FILTERS.BASIC);
+            expect(filtered).toHaveLength(3);
+            expect(filtered.every(r => r.media.length === 0)).toBe(true);
+        });
+
+        it('filters by exact star rating for RATING', () => {
+            const reviews = makeReviews(6, { ratingCycle: [5, 4] });
+            expect(applyFilter(reviews, FILTERS.RATING, 5)).toHaveLength(3);
+            expect(applyFilter(reviews, FILTERS.RATING, 4)).toHaveLength(3);
+        });
+
+        it('ignores a null rating value and returns everything', () => {
+            const reviews = makeReviews(6, { ratingCycle: [5, 4] });
+            expect(applyFilter(reviews, FILTERS.RATING, null)).toHaveLength(6);
+        });
+
+        it('treats a non-array media field as no-media', () => {
+            const reviews = [{ rating: 5 }, { rating: 5, media: null }];
+            expect(applyFilter(reviews, FILTERS.WITH_PHOTOS)).toHaveLength(0);
+            expect(applyFilter(reviews, FILTERS.BASIC)).toHaveLength(2);
+        });
+    });
+});
+
+describe('UgcOverview controller', () => {
+    let api;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div class="cs-ugc-overview" data-ugc-overview></div>';
+        api = { getOverview: jest.fn() };
+    });
+
+    const mount = () => new UgcOverview({ api });
+
+    it('renders the first page of 10 from GET /api/overview', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
+        const overview = mount();
+
+        await overview.init();
+
+        expect(api.getOverview).toHaveBeenCalledTimes(1);
+        const cards = document.querySelectorAll('.cs-ugc-overview-card');
+        expect(cards).toHaveLength(10);
+    });
+
+    it('paginates client-side with no further fetches', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
+        const overview = mount();
+        await overview.init();
+
+        document.querySelector('[data-ugc-page="2"]').click();
+
+        expect(api.getOverview).toHaveBeenCalledTimes(1);
+        const status = document.querySelector('.cs-ugc-overview-page-status');
+        expect(status.textContent).toMatch(/Page 2 of 3/);
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(10);
+    });
+
+    it('clamps pagination within range', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
+        const overview = mount();
+        await overview.init();
+
+        // Jump to last page, then attempt to overshoot.
+        overview.page = 3;
+        overview.render();
+        const next = document.querySelector('[data-ugc-page="4"]');
+        expect(next.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('filters client-side with no further fetches and resets to page 1', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25, { withMediaEvery: 5 })));
+        const overview = mount();
+        await overview.init();
+
+        document.querySelector('[data-ugc-page="2"]').click();
+        document.querySelector('[data-ugc-filter="photos"]').click();
+
+        expect(api.getOverview).toHaveBeenCalledTimes(1);
+        // 5 of 25 carry media; all fit on one page.
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(5);
+        expect(document.querySelector('.cs-ugc-overview-pagination')).toBeNull();
+    });
+
+    it('filters by rating when a star button is clicked', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(20, { ratingCycle: [5, 4, 3, 2] })));
+        const overview = mount();
+        await overview.init();
+
+        document.querySelector('[data-ugc-filter="rating"][data-ugc-rating="5"]').click();
+
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(5);
+    });
+
+    it('renders the empty state when the feed has no reviews', async () => {
+        api.getOverview.mockResolvedValue(okResult([]));
+        const overview = mount();
+
+        await overview.init();
+
+        expect(document.querySelector('.cs-ugc-overview-empty')).not.toBeNull();
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(0);
+    });
+
+    it('renders the empty state (never a broken wall) when the API call is not ok', async () => {
+        api.getOverview.mockResolvedValue({ ok: false, status: 0, message: 'Something went wrong.' });
+        const overview = mount();
+
+        await overview.init();
+
+        expect(document.querySelector('.cs-ugc-overview-empty')).not.toBeNull();
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(0);
+    });
+
+    it('no-ops without throwing when the mount point is absent', async () => {
+        document.body.innerHTML = '';
+        api.getOverview.mockResolvedValue(okResult(makeReviews(5)));
+        const overview = mount();
+
+        await expect(overview.init()).resolves.toBeUndefined();
+        expect(api.getOverview).not.toHaveBeenCalled();
+    });
+
+    it('uses the first media thumb_url for the card image', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(1, { withMediaEvery: 1 })));
+        const overview = mount();
+        await overview.init();
+
+        const img = document.querySelector('.cs-ugc-overview-thumb img');
+        expect(img.getAttribute('src')).toBe('https://cdn/0/thumb.jpg');
+    });
+});

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -1,0 +1,269 @@
+/**
+ * @file ugcOverview
+ * @description Home-page overview photo wall (cs-ugc SRS §3.4.2, §3.2.3).
+ * Fetches the latest approved reviews across all archetypes once via
+ * GET /api/overview, then paginates and filters that single dataset entirely
+ * client-side at 10 per page. Replaces the removed Stamped home wall.
+ *
+ * Initialised from the home entry point (homeController.js).
+ */
+
+import ugcApi from './ugcApi';
+import { escapeHtml } from './search/utils';
+
+const PER_PAGE = 10;
+
+// Client-side display filters (SRS §3.4.2). `rating` carries a 1-5 value when
+// the user picks a star count; the others ignore it.
+export const FILTERS = {
+    ALL: 'all',
+    BASIC: 'basic',
+    WITH_PHOTOS: 'photos',
+    RATING: 'rating',
+};
+
+/**
+ * A review has media when its media array holds at least one entry. The
+ * overview feed augments each review with the standard review fields, which
+ * include the ordered `media` array (SRS §3.2.3 / §3.2.1 review objects).
+ * @param {Object} review
+ * @returns {boolean}
+ */
+function hasMedia(review) {
+    return Array.isArray(review.media) && review.media.length > 0;
+}
+
+/**
+ * Apply the active display filter to the full dataset. Pure — no fetches.
+ * @param {Object[]} reviews
+ * @param {string} filter - One of FILTERS.
+ * @param {number|null} ratingValue - Star count when filter is RATING.
+ * @returns {Object[]}
+ */
+export function applyFilter(reviews, filter, ratingValue = null) {
+    if (filter === FILTERS.WITH_PHOTOS) {
+        return reviews.filter(hasMedia);
+    }
+
+    if (filter === FILTERS.BASIC) {
+        return reviews.filter(review => !hasMedia(review));
+    }
+
+    if (filter === FILTERS.RATING && ratingValue !== null) {
+        return reviews.filter(review => review.rating === ratingValue);
+    }
+
+    return reviews;
+}
+
+/**
+ * Slice a filtered dataset to a single page.
+ * @param {Object[]} reviews
+ * @param {number} page - 1-indexed.
+ * @returns {Object[]}
+ */
+export function paginate(reviews, page) {
+    const start = (page - 1) * PER_PAGE;
+    return reviews.slice(start, start + PER_PAGE);
+}
+
+/**
+ * Total page count for a filtered dataset (minimum 1 so the controls render
+ * a stable "1 / 1" even when empty).
+ * @param {number} total
+ * @returns {number}
+ */
+export function pageCount(total) {
+    return Math.max(1, Math.ceil(total / PER_PAGE));
+}
+
+export default class UgcOverview {
+    /**
+     * @param {Object} [options]
+     * @param {string} [options.selector] - Mount-point selector.
+     * @param {Object} [options.api] - Injectable UgcApi (defaults to singleton).
+     */
+    constructor({ selector = '[data-ugc-overview]', api = ugcApi } = {}) {
+        this.container = document.querySelector(selector);
+        this.api = api;
+
+        this.reviews = [];
+        this.filter = FILTERS.ALL;
+        this.ratingValue = null;
+        this.page = 1;
+
+        this.handleControlClick = this.handleControlClick.bind(this);
+    }
+
+    /**
+     * Fetch the overview feed once and render. Branches on `ok` first per the
+     * ugcApi contract; any failure (network/parse → status 0, or a non-2xx)
+     * renders the empty "no media yet" state, never a broken wall.
+     * @returns {Promise<void>}
+     */
+    async init() {
+        if (!this.container) return;
+
+        const result = await this.api.getOverview();
+
+        if (result.ok && result.data && Array.isArray(result.data.reviews)) {
+            this.reviews = result.data.reviews;
+        } else {
+            this.reviews = [];
+        }
+
+        this.bindEvents();
+        this.render();
+    }
+
+    bindEvents() {
+        this.container.addEventListener('click', this.handleControlClick);
+    }
+
+    /**
+     * Delegate clicks for filter buttons and pagination. Filter changes reset
+     * to page 1; page changes clamp within range. No network calls.
+     * @param {MouseEvent} event
+     */
+    handleControlClick(event) {
+        const filterButton = event.target.closest('[data-ugc-filter]');
+        if (filterButton) {
+            const { ugcFilter, ugcRating } = filterButton.dataset;
+            this.filter = ugcFilter;
+            this.ratingValue = ugcRating ? parseInt(ugcRating, 10) : null;
+            this.page = 1;
+            this.render();
+            return;
+        }
+
+        const pageButton = event.target.closest('[data-ugc-page]');
+        if (pageButton) {
+            const filtered = applyFilter(this.reviews, this.filter, this.ratingValue);
+            const target = parseInt(pageButton.dataset.ugcPage, 10);
+            const max = pageCount(filtered.length);
+            this.page = Math.min(Math.max(1, target), max);
+            this.render();
+        }
+    }
+
+    render() {
+        const filtered = applyFilter(this.reviews, this.filter, this.ratingValue);
+        const items = paginate(filtered, this.page);
+
+        this.container.innerHTML = `
+            ${this.buildFilters()}
+            ${this.buildWall(items)}
+            ${this.buildPagination(filtered.length)}
+        `;
+    }
+
+    buildFilters() {
+        const options = [
+            { filter: FILTERS.ALL, label: 'All', rating: null },
+            { filter: FILTERS.WITH_PHOTOS, label: 'With Photos', rating: null },
+            { filter: FILTERS.BASIC, label: 'No Photos', rating: null },
+            { filter: FILTERS.RATING, label: '5 Stars', rating: 5 },
+            { filter: FILTERS.RATING, label: '4 Stars', rating: 4 },
+        ];
+
+        const buttons = options.map((option) => {
+            const isActive = this.filter === option.filter
+                && this.ratingValue === option.rating;
+            const ratingAttr = option.rating === null ? '' : ` data-ugc-rating="${option.rating}"`;
+            return `
+                <button
+                    type="button"
+                    class="cs-ugc-overview-filter${isActive ? ' is-active' : ''}"
+                    data-ugc-filter="${option.filter}"${ratingAttr}
+                    aria-pressed="${isActive}"
+                >${option.label}</button>
+            `;
+        }).join('');
+
+        return `<div class="cs-ugc-overview-filters" role="group" aria-label="Filter reviews">${buttons}</div>`;
+    }
+
+    buildWall(items) {
+        if (items.length === 0) {
+            return '<p class="cs-ugc-overview-empty">No reviews to show yet.</p>';
+        }
+
+        const cards = items.map(review => this.buildCard(review)).join('');
+        return `<div class="cs-ugc-overview-wall">${cards}</div>`;
+    }
+
+    buildCard(review) {
+        const author = escapeHtml(review.author);
+        const title = escapeHtml(review.title);
+        const body = escapeHtml(review.body);
+        const archetypeName = escapeHtml(review.archetype_name);
+        const archetypeUrl = escapeHtml(review.archetype_url);
+        const rating = parseInt(review.rating, 10) || 0;
+        const stars = '★'.repeat(rating) + '☆'.repeat(Math.max(0, 5 - rating));
+
+        return `
+            <article class="cs-ugc-overview-card">
+                ${this.buildThumb(review)}
+                <div class="cs-ugc-overview-card-body">
+                    <div class="cs-ugc-overview-stars" aria-label="${rating} out of 5 stars">${stars}</div>
+                    ${title ? `<h3 class="cs-ugc-overview-title">${title}</h3>` : ''}
+                    <p class="cs-ugc-overview-text">${body}</p>
+                    <p class="cs-ugc-overview-meta">
+                        <span class="cs-ugc-overview-author">${author}</span>
+                        ${archetypeUrl ? `<a class="cs-ugc-overview-product" href="${archetypeUrl}">${archetypeName}</a>` : ''}
+                    </p>
+                </div>
+            </article>
+        `;
+    }
+
+    /**
+     * Render the first media item as the card thumbnail. Photos use the
+     * thumbnail URL; videos fall back to the poster (SRS §3.2.7 / ReviewMedia).
+     * The thumb slot reserves space even with no media so the wall stays
+     * layout-stable.
+     * @param {Object} review
+     * @returns {string}
+     */
+    buildThumb(review) {
+        if (!hasMedia(review)) {
+            return '<div class="cs-ugc-overview-thumb is-empty" aria-hidden="true"></div>';
+        }
+
+        const media = review.media[0];
+        const src = media.thumb_url || media.poster_url || media.medium_url || media.url;
+
+        if (!src) {
+            return '<div class="cs-ugc-overview-thumb is-empty" aria-hidden="true"></div>';
+        }
+
+        const alt = escapeHtml(review.title || review.archetype_name || 'Customer photo');
+        return `
+            <div class="cs-ugc-overview-thumb">
+                <img src="${escapeHtml(src)}" alt="${alt}" loading="lazy" width="200" height="200">
+            </div>
+        `;
+    }
+
+    buildPagination(total) {
+        const pages = pageCount(total);
+        if (pages <= 1) return '';
+
+        const prevDisabled = this.page <= 1 ? ' disabled' : '';
+        const nextDisabled = this.page >= pages ? ' disabled' : '';
+
+        return `
+            <div class="cs-ugc-overview-pagination">
+                <button type="button" class="cs-ugc-overview-page" data-ugc-page="${this.page - 1}"${prevDisabled}>Previous</button>
+                <span class="cs-ugc-overview-page-status">Page ${this.page} of ${pages}</span>
+                <button type="button" class="cs-ugc-overview-page" data-ugc-page="${this.page + 1}"${nextDisabled}>Next</button>
+            </div>
+        `;
+    }
+
+    destroy() {
+        if (this.container) {
+            this.container.removeEventListener('click', this.handleControlClick);
+        }
+    }
+}

--- a/assets/js/theme/_addons/home/homeController.js
+++ b/assets/js/theme/_addons/home/homeController.js
@@ -4,6 +4,7 @@ import ProductGrid from '../global/ui/productGrid';
 import DataManager from '../global/dataManager';
 import StateManager from '../global/stateManager';
 import SearchEngine from '../global/search/searchEngine';
+import UgcOverview from '../global/ugcOverview';
 
 export default class HomeController extends PageManager {
     constructor(context) {
@@ -14,6 +15,7 @@ export default class HomeController extends PageManager {
             showAllText: 'Show All Products',
             showLessText: 'Show Less',
         });
+        this.ugcOverview = new UgcOverview();
         this.searchEngine = null;
         this.searchDataVersion = null;
         this.currentSelection = null;
@@ -23,6 +25,7 @@ export default class HomeController extends PageManager {
 
     onReady() {
         this.vehicleSelector.init();
+        this.ugcOverview.init();
 
         this.unsubscribe = StateManager.subscribe(this.handleStateChange.bind(this));
 
@@ -80,5 +83,6 @@ export default class HomeController extends PageManager {
         if (this.unsubscribe) this.unsubscribe();
         if (this.vehicleSelector) this.vehicleSelector.destroy();
         if (this.productGrid) this.productGrid.destroy();
+        if (this.ugcOverview) this.ugcOverview.destroy();
     }
 }

--- a/assets/scss/custom/_cs-home.scss
+++ b/assets/scss/custom/_cs-home.scss
@@ -10,6 +10,7 @@
 //  2. Vehicle Selector
 //  3. Product Grid
 //  4. Blog Posts
+//  5. UGC Overview Photo Wall
 //
 
 .main.full.cs-home {
@@ -137,4 +138,116 @@
       object-fit: cover;
     }
   }
+}
+
+// 5. UGC Overview Photo Wall
+// -----------------------------------------------------------------------------
+.cs-ugc-overview {
+  // Reserve vertical space while GET /api/overview resolves so the wall does
+  // not shift the home layout when it populates (CLS).
+  min-height: 320px;
+}
+
+.cs-ugc-overview-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('quarter');
+  justify-content: center;
+  margin-bottom: spacing('single');
+}
+
+.cs-ugc-overview-filter {
+  padding: spacing('quarter') spacing('half');
+  border: 1px solid stencilColor('color-grayLight');
+  border-radius: stencilRadius('base');
+  background-color: stencilColor('color-white');
+  color: stencilColor('color-textBase');
+  cursor: pointer;
+
+  &.is-active {
+    background-color: stencilColor('color-primary');
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-white');
+  }
+}
+
+.cs-ugc-overview-wall {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: spacing('half');
+
+  @include breakpoint('medium') {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.cs-ugc-overview-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid stencilColor('color-grayLight');
+  border-radius: stencilRadius('card');
+  overflow: hidden;
+}
+
+.cs-ugc-overview-thumb {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  background-color: stencilColor('color-grayLightest');
+
+  img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &.is-empty {
+    padding-top: 0;
+    min-height: spacing('double');
+  }
+}
+
+.cs-ugc-overview-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('quarter');
+  padding: spacing('half');
+}
+
+.cs-ugc-overview-stars {
+  color: stencilColor('color-primary');
+}
+
+.cs-ugc-overview-title {
+  margin: 0;
+  font-size: stencilFontSize('smaller');
+}
+
+.cs-ugc-overview-text {
+  margin: 0;
+}
+
+.cs-ugc-overview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('quarter');
+  justify-content: space-between;
+  margin: 0;
+  color: stencilColor('color-textSecondary');
+}
+
+.cs-ugc-overview-empty {
+  text-align: center;
+  color: stencilColor('color-textSecondary');
+}
+
+.cs-ugc-overview-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: spacing('half');
+  margin-top: spacing('single');
 }

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -49,6 +49,11 @@ blog:
         {{> components/products-cs/product-grid }}
     </section>
 
+    <section class="home-section" aria-labelledby="customer-reviews-heading">
+        <h2 id="customer-reviews-heading" class="page-heading">From Our Customers</h2>
+        <div class="cs-ugc-overview" data-ugc-overview></div>
+    </section>
+
     {{#if blog.recent_posts}}
         <section class="cs-blog-posts home-section">
             <h2 class="page-heading">{{lang 'blog.recent_posts'}}</h2>


### PR DESCRIPTION
## Summary

Implements the home-page **overview photo wall** (`assets/js/theme/_addons/global/ugcOverview.js`), replacing the removed Stamped home wall. Per SRS §3.4.2 / §3.2.3 the module fetches the latest approved reviews across all archetypes **once** via `ugcApi.getOverview()`, then paginates (10/page) and filters that single dataset **entirely client-side** — no further fetches.

Built on the merged `ugcApi.js` (#5). Branches on the result `ok` flag first (not HTTP status), so network/parse failures (`status: 0`) and non-2xx responses both fall through to the empty "no reviews yet" state — never a broken wall.

Refs #11

## Acceptance criteria

- [x] **Overview photo wall renders from `GET /api/overview` and paginates client-side (10/page).** — `ugcOverview.js:115` (`init` → `getOverview`), `ugcOverview.js:13` (`PER_PAGE = 10`), `ugcOverview.js:66` (`paginate`).
- [x] **Filters work client-side with no further fetches.** — `ugcOverview.js:43` (`applyFilter`: All / With Photos / No Photos / by rating), dispatched via delegated click handler `ugcOverview.js:124` with no API call. Test asserts `getOverview` called once across filter + page interactions: `ugcOverview.spec.js:160`.
- [x] **Wired into the home entry point in place of the old Stamped wall.** — `homeController.js:9,16,27,84` (import, construct, `init`, `destroy`); `templates/pages/home.html:52` (`<div data-ugc-overview>` in the "From Our Customers" section that previously held `#stamped-reviews-widget`).
- [x] **Jest tests cover client-side pagination + filtering (mocked).** — `assets/js/test-unit/theme/global/ugcOverview.spec.js` (24 tests: pure pagination/filter helpers + controller render, paginate, clamp, all four filters, empty + not-ok states, missing-mount no-op).
- [x] **`npx grunt check` passes.** — ESLint `eslint:target` and stylelint `stylelint:src` clean (197 files); 155/155 Jest tests pass. See note below on the unrelated carousel suite.

## CLS

The `.cs-ugc-overview` mount reserves vertical space via `min-height` (`assets/scss/custom/_cs-home.scss`) so the wall does not shift the home layout when `GET /api/overview` resolves. Empty/loading states render in-place; no `display: none` on the async block.

## Notes for the PM

- **`grunt check` in CI:** locally the `carousel.spec.js` suite fails to load because `slick-carousel` is missing from this *worktree's* `node_modules` (incomplete install in the isolated worktree — it is present in the main checkout). This is unrelated to this change (no carousel code touched). A clean CI install resolves it.
- **Spec gap (review object media field name):** SRS §3.2.3 returns review objects as "…all standard review fields…" augmented with `archetype_name` / `archetype_url`, and §3.2.1 likewise abbreviates the review object. The exact JSON **key for the ordered media array** on a serialized review (vs. the `ReviewMedia` table columns `url`/`thumb_url`/`medium_url`/`poster_url`/`type`) is not spelled out. This module consumes `review.media` (array of objects with `thumb_url` → `poster_url` → `medium_url` → `url` fallback) defensively. **Please confirm the serialized field name** the UGC API uses for the per-review media array on `/api/overview`; if it differs, this is a one-line change in `hasMedia`/`buildThumb`.
- **No new theme config values.** `ugc_overview_count` is server-side (the API caps the response); the wall paginates whatever it receives. No Turnstile/site-key usage here (read-only feed).