### PR TITLE
M6: ugcProduct.js (6c) — Q&A tab (questions list)

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -482,3 +482,291 @@ describe('UgcProduct (slice 6b — sort, filter, pagination)', () => {
         expect(api.getReviews).toHaveBeenCalledTimes(1);
     });
 });
+
+describe('UgcProduct (slice 6c — Q&A tab)', () => {
+    const buildQuestionEnvelope = (overrides = {}) => ({
+        items: [],
+        total: 0,
+        page: 1,
+        per_page: 10,
+        ...overrides,
+    });
+
+    const okQuestions = overrides => ({
+        ok: true,
+        status: 200,
+        data: buildQuestionEnvelope(overrides),
+    });
+
+    // A no-op reviews result so the reviews half of the module stays inert while
+    // the Q&A behaviour is exercised in isolation.
+    const reviewsNoop = () => Promise.resolve({ ok: true, status: 200, data: buildEnvelope() });
+
+    const buildQaApi = result => ({
+        getReviews: jest.fn(reviewsNoop),
+        getQuestions: jest.fn(() => Promise.resolve(result)),
+    });
+
+    const buildSequencedQaApi = (results) => {
+        let call = 0;
+        return {
+            getReviews: jest.fn(reviewsNoop),
+            getQuestions: jest.fn(() => {
+                const result = results[Math.min(call, results.length - 1)];
+                call += 1;
+                return Promise.resolve(result);
+            }),
+        };
+    };
+
+    const qParamsOfCall = (api, n) => api.getQuestions.mock.calls[n - 1][1];
+
+    const mountQaScaffold = () => {
+        document.body.innerHTML = `
+            <div class="cs-questions-toolbar" data-questions-toolbar>
+                <select data-questions-control="sort">
+                    <option value="date_desc">Newest</option>
+                    <option value="date_asc">Oldest</option>
+                </select>
+            </div>
+            <div id="product-questions"></div>
+            <div class="cs-questions-pagination" data-questions-pagination></div>
+        `;
+    };
+
+    const changeQuestionsSort = (value) => {
+        const el = document.querySelector('[data-questions-control="sort"]');
+        el.value = value;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+
+    beforeEach(() => {
+        mountQaScaffold();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('requests page 1 with the default date_desc sort on init', async () => {
+        const api = buildQaApi(okQuestions());
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        expect(api.getQuestions).toHaveBeenCalledWith(ARCHETYPE_ID, {
+            page: 1,
+            sort: 'date_desc',
+        });
+    });
+
+    it('renders approved questions and their staff answers', async () => {
+        const api = buildQaApi(okQuestions({
+            total: 2,
+            items: [
+                {
+                    id: 1,
+                    author: 'Jane D.',
+                    body: 'Does this fit the F56?',
+                    vehicle_label: 'MINI Cooper F56',
+                    staff_answer: 'Yes, it fits all F56 generations.',
+                    staff_answer_author: 'CravenSpeed',
+                    date: '2026-05-01T12:00:00Z',
+                },
+                {
+                    id: 2,
+                    author: 'Bob',
+                    body: 'Is hardware included?',
+                    staff_answer: 'All mounting hardware is in the box.',
+                    date: '2026-04-15T00:00:00Z',
+                },
+            ],
+        }));
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        const list = document.querySelector('#product-questions');
+        expect(list.querySelectorAll('.cs-question')).toHaveLength(2);
+        expect(list.textContent).toContain('Does this fit the F56?');
+        expect(list.textContent).toContain('Yes, it fits all F56 generations.');
+        expect(list.textContent).toContain('MINI Cooper F56');
+        expect(list.querySelectorAll('.cs-question-answer')).toHaveLength(2);
+    });
+
+    it('omits the answer block when staff_answer is null', async () => {
+        const api = buildQaApi(okQuestions({
+            total: 1,
+            items: [{
+                id: 1,
+                author: 'Jane D.',
+                body: 'Pending answer?',
+                staff_answer: null,
+                date: '2026-05-01T12:00:00Z',
+            }],
+        }));
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        const list = document.querySelector('#product-questions');
+        expect(list.querySelectorAll('.cs-question')).toHaveLength(1);
+        expect(list.querySelector('.cs-question-answer')).toBeNull();
+    });
+
+    it('renders the empty state when there are no approved questions', async () => {
+        const api = buildQaApi(okQuestions({ total: 0, items: [] }));
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        const list = document.querySelector('#product-questions');
+        expect(list.querySelector('.cs-questions-empty')).not.toBeNull();
+    });
+
+    it('renders an error state when the questions call resolves not-ok', async () => {
+        const api = buildQaApi({
+            ok: false, status: 0, message: 'Something went wrong.', error: 'network down',
+        });
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        const list = document.querySelector('#product-questions');
+        expect(list.querySelector('.cs-questions-error')).not.toBeNull();
+    });
+
+    it('escapes question and answer text to prevent HTML injection', async () => {
+        const api = buildQaApi(okQuestions({
+            total: 1,
+            items: [{
+                id: 1,
+                author: '<script>x</script>',
+                body: '<img src=x onerror=alert(1)>',
+                staff_answer: '<svg onload=alert(2)>',
+                date: '2026-05-01T12:00:00Z',
+            }],
+        }));
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        const list = document.querySelector('#product-questions');
+        expect(list.querySelector('script')).toBeNull();
+        expect(list.querySelector('.cs-question-body img')).toBeNull();
+        expect(list.querySelector('.cs-question-answer svg')).toBeNull();
+    });
+
+    describe('sort', () => {
+        const cases = [
+            ['date_desc', 'date_desc'],
+            ['date_asc', 'date_asc'],
+        ];
+
+        it.each(cases)('refetches with sort=%s when selected', async (value, expected) => {
+            const api = buildQaApi(okQuestions());
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            changeQuestionsSort(value);
+            await flush();
+
+            expect(api.getQuestions).toHaveBeenCalledTimes(2);
+            expect(qParamsOfCall(api, 2)).toEqual({ sort: expected, page: 1 });
+        });
+
+        it('resets to page 1 when the sort changes after paging forward', async () => {
+            const api = buildSequencedQaApi([
+                okQuestions({ total: 25, page: 1, per_page: 10 }),
+                okQuestions({ total: 25, page: 2, per_page: 10 }),
+                okQuestions({ total: 25, page: 1, per_page: 10 }),
+            ]);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-questions-page="2"]').click();
+            await flush();
+            expect(qParamsOfCall(api, 2).page).toBe(2);
+
+            changeQuestionsSort('date_asc');
+            await flush();
+            expect(qParamsOfCall(api, 3).page).toBe(1);
+            expect(qParamsOfCall(api, 3).sort).toBe('date_asc');
+        });
+    });
+
+    describe('pagination', () => {
+        it('renders a page button per page derived from total / per_page', async () => {
+            const api = buildQaApi(okQuestions({
+                total: 25,
+                page: 1,
+                per_page: 10,
+                items: [{ id: 1, body: 'Q?', date: '2026-01-01' }],
+            }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const numbered = document.querySelectorAll('[data-page-key="1"], [data-page-key="2"], [data-page-key="3"]');
+            expect(numbered).toHaveLength(3);
+            expect(document.querySelector('[data-questions-page="2"]')).not.toBeNull();
+            expect(document.querySelector('[data-questions-page="4"]')).toBeNull();
+        });
+
+        it('hides pagination when a single page covers all results', async () => {
+            const api = buildQaApi(okQuestions({ total: 6, page: 1, per_page: 10 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const pagination = document.querySelector('[data-questions-pagination]');
+            expect(pagination.innerHTML).toBe('');
+            expect(pagination.style.visibility).toBe('hidden');
+        });
+
+        it('refetches the chosen page on a pagination click', async () => {
+            const api = buildSequencedQaApi([
+                okQuestions({ total: 25, page: 1, per_page: 10 }),
+                okQuestions({ total: 25, page: 3, per_page: 10 }),
+            ]);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-questions-page="3"]').click();
+            await flush();
+
+            expect(api.getQuestions).toHaveBeenCalledTimes(2);
+            expect(qParamsOfCall(api, 2).page).toBe(3);
+        });
+
+        it('does not refetch when clicking the already-current page', async () => {
+            const api = buildQaApi(okQuestions({ total: 25, page: 1, per_page: 10 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-questions-page="1"]').click();
+            await flush();
+
+            expect(api.getQuestions).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('does not fetch questions when the Q&A DOM is absent', async () => {
+        document.body.innerHTML = '<div id="product-reviews"></div>';
+        const api = buildQaApi(okQuestions());
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        expect(api.getQuestions).not.toHaveBeenCalled();
+    });
+
+    it('removes Q&A toolbar and pagination listeners on destroy', async () => {
+        const api = buildQaApi(okQuestions({ total: 25, page: 1, per_page: 10 }));
+        const ugc = new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        ugc.destroy();
+
+        changeQuestionsSort('date_asc');
+        await flush();
+        expect(api.getQuestions).toHaveBeenCalledTimes(1);
+    });
+});

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -21,9 +21,15 @@
  * envelope's total / page / per_page (SRS §3.2.1) — never by slicing a local
  * array.
  *
- * Alias-sort refetch (sort_alias, #7), Q&A (#18) and the submission modal (#8)
- * are separate slices and intentionally out of scope here. §3.4.1 lists
- * sort_alias under this module; #17 scopes it to #7.
+ * Slice 6c (#18) adds the Q&A tab: a separate GET /api/questions/{archetype_id}
+ * list (SRS §3.2.2) with its own sort (date_desc / date_asc) and pagination,
+ * driven entirely by that endpoint's { items, total, page, per_page } envelope.
+ * It mirrors the reviews list/sort/pagination pattern but has no filters and
+ * renders each approved question with its single staff answer (§4.1 Question).
+ *
+ * Alias-sort refetch (sort_alias, #7) and the submission modal (#8) are separate
+ * slices and intentionally out of scope here. §3.4.1 lists sort_alias under this
+ * module; #17 scopes it to #7.
  */
 
 const MAX_STARS = 5;
@@ -32,10 +38,15 @@ const DEFAULT_SORT = 'date_desc';
 
 const SORT_VALUES = ['date_desc', 'date_asc', 'rating_desc', 'rating_asc'];
 
+// Questions support only date sorts (SRS §3.2.2) — no rating/verified/media.
+const QUESTION_SORT_VALUES = ['date_desc', 'date_asc'];
+
 const MESSAGES = {
     noReviews: 'No reviews yet. Be the first to review this product.',
     noMatches: 'No reviews match the selected filters.',
     loadError: 'Reviews are unavailable right now. Please try again later.',
+    noQuestions: 'No questions yet. Be the first to ask about this product.',
+    questionsError: 'Questions are unavailable right now. Please try again later.',
     anonymous: 'Anonymous',
 };
 
@@ -73,18 +84,44 @@ export default class UgcProduct {
         this.total = 0;
         this.perPage = 0;
 
+        // Q&A query state (SRS §3.2.2 params). Only `page` and `sort` apply —
+        // questions have no rating/verified/media filters.
+        this.questionQuery = {
+            page: 1,
+            sort: DEFAULT_SORT,
+        };
+        this.questionTotal = 0;
+        this.questionPerPage = 0;
+        this.questionCount = 0;
+        this.questionsLoaded = false;
+
         this.ratingElement = document.querySelector('[data-product-rating]');
         this.listElement = document.querySelector('#product-reviews');
         this.toolbarElement = document.querySelector('[data-reviews-toolbar]');
         this.paginationElement = document.querySelector('[data-reviews-pagination]');
 
+        this.questionsElement = document.querySelector('#product-questions');
+        this.questionsToolbarElement = document.querySelector('[data-questions-toolbar]');
+        this.questionsPaginationElement = document.querySelector('[data-questions-pagination]');
+
         this.onToolbarChange = this.onToolbarChange.bind(this);
         this.onPaginationClick = this.onPaginationClick.bind(this);
+        this.onQuestionsToolbarChange = this.onQuestionsToolbarChange.bind(this);
+        this.onQuestionsPaginationClick = this.onQuestionsPaginationClick.bind(this);
 
-        if (this.archetypeId && (this.ratingElement || this.listElement)) {
+        const hasReviewsDom = this.ratingElement || this.listElement;
+
+        if (this.archetypeId && (hasReviewsDom || this.questionsElement)) {
             this.unsubscribe = this.stateManager.subscribe(this.update.bind(this));
             this.bindControls();
-            this.init();
+
+            if (hasReviewsDom) {
+                this.init();
+            }
+
+            if (this.questionsElement) {
+                this.initQuestions();
+            }
         }
     }
 
@@ -95,6 +132,14 @@ export default class UgcProduct {
 
         if (this.paginationElement) {
             this.paginationElement.addEventListener('click', this.onPaginationClick);
+        }
+
+        if (this.questionsToolbarElement) {
+            this.questionsToolbarElement.addEventListener('change', this.onQuestionsToolbarChange);
+        }
+
+        if (this.questionsPaginationElement) {
+            this.questionsPaginationElement.addEventListener('click', this.onQuestionsPaginationClick);
         }
     }
 
@@ -216,6 +261,183 @@ export default class UgcProduct {
 
         this.query.page = page;
         this.fetchReviews();
+    }
+
+    /**
+     * Initial Q&A fetch (SRS §3.2.2). Tracks the unfiltered question count so the
+     * empty state can be rendered correctly; questions have no filters, so the
+     * envelope `total` IS the full count.
+     */
+    async initQuestions() {
+        const result = await this.api.getQuestions(this.archetypeId, this.buildQuestionParams());
+
+        if (!result.ok) {
+            this.renderQuestionsError();
+            return;
+        }
+
+        this.questionsLoaded = true;
+        this.renderQuestionsPage(result.data || {});
+    }
+
+    /**
+     * Refetch the current Q&A query and render the resulting page + pagination.
+     */
+    async fetchQuestions() {
+        const result = await this.api.getQuestions(this.archetypeId, this.buildQuestionParams());
+
+        if (!result.ok) {
+            this.renderQuestionsError();
+            return;
+        }
+
+        this.renderQuestionsPage(result.data || {});
+    }
+
+    /**
+     * Assemble the §3.2.2 query params from the current Q&A state.
+     * @returns {Object}
+     */
+    buildQuestionParams() {
+        return {
+            page: this.questionQuery.page,
+            sort: this.questionQuery.sort,
+        };
+    }
+
+    renderQuestionsPage(data) {
+        this.questionTotal = Number.isFinite(data.total) ? data.total : 0;
+        this.questionPerPage = Number.isFinite(data.per_page) ? data.per_page : 0;
+        this.questionCount = this.questionTotal;
+        this.questionQuery.page = Number.isFinite(data.page) ? data.page : this.questionQuery.page;
+
+        this.renderQuestionsList(Array.isArray(data.items) ? data.items : []);
+        this.renderQuestionsPagination();
+    }
+
+    onQuestionsToolbarChange(event) {
+        const target = event.target;
+        if (!target || !target.dataset) {
+            return;
+        }
+
+        const { questionsControl } = target.dataset;
+        if (questionsControl !== 'sort') {
+            return;
+        }
+
+        this.questionQuery.sort = QUESTION_SORT_VALUES.indexOf(target.value) === -1
+            ? DEFAULT_SORT
+            : target.value;
+        this.questionQuery.page = 1;
+        this.fetchQuestions();
+    }
+
+    onQuestionsPaginationClick(event) {
+        const button = event.target.closest('[data-questions-page]');
+        if (!button || !this.questionsPaginationElement.contains(button)) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const page = parseInt(button.dataset.questionsPage, 10);
+        if (Number.isNaN(page) || page === this.questionQuery.page) {
+            return;
+        }
+
+        this.questionQuery.page = page;
+        this.fetchQuestions();
+    }
+
+    renderQuestionsList(items) {
+        if (!this.questionsElement) {
+            return;
+        }
+
+        if (!items.length) {
+            this.questionsElement.innerHTML = `<p class="cs-questions-empty">${MESSAGES.noQuestions}</p>`;
+            return;
+        }
+
+        this.questionsElement.innerHTML = items.map(question => this._buildQuestion(question)).join('');
+    }
+
+    renderQuestionsPagination() {
+        if (!this.questionsPaginationElement) {
+            return;
+        }
+
+        const pageCount = this.questionPerPage > 0
+            ? Math.ceil(this.questionTotal / this.questionPerPage)
+            : 0;
+
+        if (pageCount <= 1) {
+            this.questionsPaginationElement.innerHTML = '';
+            this.questionsPaginationElement.style.visibility = 'hidden';
+            return;
+        }
+
+        const current = this.questionQuery.page;
+        const buttons = [];
+
+        buttons.push(this._questionPageButton('prev', current - 1, current <= 1, 'Previous'));
+
+        for (let page = 1; page <= pageCount; page += 1) {
+            buttons.push(this._questionPageButton(page, page, false, String(page), page === current));
+        }
+
+        buttons.push(this._questionPageButton('next', current + 1, current >= pageCount, 'Next'));
+
+        this.questionsPaginationElement.innerHTML = `<nav class="cs-questions-pages" aria-label="Questions pagination">${buttons.join('')}</nav>`;
+        this.questionsPaginationElement.style.visibility = 'visible';
+    }
+
+    _questionPageButton(key, page, disabled, label, isCurrent = false) {
+        const current = isCurrent ? ' is-current' : '';
+        const aria = isCurrent ? ' aria-current="page"' : '';
+        const disabledAttr = disabled ? ' disabled' : '';
+        return `<button type="button" class="cs-questions-page${current}" data-questions-page="${page}" data-page-key="${key}"${aria}${disabledAttr}>${label}</button>`;
+    }
+
+    renderQuestionsError() {
+        if (this.questionsElement) {
+            this.questionsElement.innerHTML = `<p class="cs-questions-error">${MESSAGES.questionsError}</p>`;
+        }
+
+        if (this.questionsPaginationElement) {
+            this.questionsPaginationElement.innerHTML = '';
+            this.questionsPaginationElement.style.visibility = 'hidden';
+        }
+    }
+
+    /**
+     * Render one approved question and its single staff answer (SRS §4.1). The
+     * answer block only renders when `staff_answer` is present — approval
+     * requires it (§3.3.1), but null is defended against regardless.
+     * @param {Object} question
+     * @returns {string}
+     */
+    _buildQuestion(question) {
+        const author = this._escape(question.author) || MESSAGES.anonymous;
+        const body = this._escape(question.body);
+        const vehicle = this._escape(question.vehicle_label);
+        const date = this._formatDate(question.date);
+        const answerAuthor = this._escape(question.staff_answer_author) || 'CravenSpeed';
+        const answer = question.staff_answer
+            ? `<div class="cs-question-answer"><strong>${answerAuthor}:</strong> ${this._escape(question.staff_answer)}</div>`
+            : '';
+
+        return `
+            <article class="cs-question">
+                <p class="cs-question-meta">
+                    <span class="cs-question-author">${author}</span>
+                    ${date ? `<span class="cs-question-date">${date}</span>` : ''}
+                </p>
+                ${vehicle ? `<p class="cs-question-vehicle">${vehicle}</p>` : ''}
+                <p class="cs-question-body">${body}</p>
+                ${answer}
+            </article>`;
     }
 
     renderSummary() {
@@ -384,6 +606,14 @@ export default class UgcProduct {
 
         if (this.paginationElement) {
             this.paginationElement.removeEventListener('click', this.onPaginationClick);
+        }
+
+        if (this.questionsToolbarElement) {
+            this.questionsToolbarElement.removeEventListener('change', this.onQuestionsToolbarChange);
+        }
+
+        if (this.questionsPaginationElement) {
+            this.questionsPaginationElement.removeEventListener('click', this.onQuestionsPaginationClick);
         }
     }
 }

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -922,3 +922,120 @@ $cs-button-height: 50px;
   padding: spacing('half');
   background: stencilColor('color-greyLightest');
 }
+
+// Q&A tab (SRS §3.4.1 / §3.2.2). Mirrors the reviews list pattern; reserve
+// vertical space (min-height) so the async list does not shift on load.
+#product-questions {
+  min-height: 6rem;
+
+  .cs-questions-empty,
+  .cs-questions-error {
+    color: stencilColor('color-textSecondary');
+    margin: 0;
+  }
+}
+
+.cs-questions-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('half');
+  margin-bottom: spacing('single');
+
+  @include breakpoint('medium') {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: spacing('single');
+  }
+}
+
+.cs-questions-control {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('quarter');
+  font-size: 0.875rem;
+}
+
+.cs-questions-control-label {
+  color: stencilColor('color-textSecondary');
+  font-weight: 600;
+}
+
+.cs-questions-select {
+  height: 44px;
+  font-size: 1rem;
+  padding: 0 spacing('half');
+  border: 1px solid stencilColor('color-greyLightest');
+
+  &:focus {
+    border-color: stencilColor('color-primary');
+    outline: none;
+  }
+}
+
+.cs-questions-pagination {
+  min-height: 3rem;
+  margin-top: spacing('single');
+}
+
+.cs-questions-pages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('quarter');
+  align-items: center;
+}
+
+.cs-questions-page {
+  min-width: 44px;
+  height: 44px;
+  padding: 0 spacing('half');
+  border: 1px solid stencilColor('color-greyLightest');
+  background: #fff;
+  color: stencilColor('color-textBase');
+  cursor: pointer;
+
+  &.is-current {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+    font-weight: 700;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+.cs-question {
+  padding: spacing('single') 0;
+  border-bottom: 1px solid stencilColor('color-greyLightest');
+}
+
+.cs-question-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('half');
+  align-items: center;
+  color: stencilColor('color-textSecondary');
+  font-size: 0.875rem;
+  margin: 0 0 spacing('half');
+}
+
+.cs-question-author {
+  font-weight: 700;
+}
+
+.cs-question-vehicle {
+  font-style: italic;
+  margin: 0 0 spacing('half');
+}
+
+.cs-question-body {
+  margin: 0;
+}
+
+.cs-question-answer {
+  margin-top: spacing('half');
+  padding: spacing('half');
+  background: stencilColor('color-greyLightest');
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -771,6 +771,12 @@
                 "submit_value": "Submit Review"
             }
         },
+        "questions": {
+            "header": "Q&A",
+            "sort_label": "Sort by",
+            "sort_newest": "Newest",
+            "sort_oldest": "Oldest"
+        },
         "videos": {
             "header": "Videos",
             "hide": "Hide Videos",

--- a/templates/components/products-cs/description-tabs-cs.html
+++ b/templates/components/products-cs/description-tabs-cs.html
@@ -9,6 +9,10 @@
         </li>
 
         <li class="tab">
+            <a class="tab-title" href="#tab-questions">{{lang 'products.questions.header'}}</a>
+        </li>
+
+        <li class="tab">
             <a class="tab-title" href="#tab-shipping">Shipping</a>
         </li>
 
@@ -29,6 +33,10 @@
 
         <div class="tab-content" id="tab-reviews">
             {{> components/products-cs/reviews-cs}}
+        </div>
+
+        <div class="tab-content" id="tab-questions">
+            {{> components/products-cs/qa-cs}}
         </div>
 
         <div class="tab-content" id="tab-shipping">

--- a/templates/components/products-cs/qa-cs.html
+++ b/templates/components/products-cs/qa-cs.html
@@ -1,0 +1,13 @@
+<div class="cs-questions" data-questions>
+    <div class="cs-questions-toolbar" data-questions-toolbar>
+        <label class="cs-questions-control cs-questions-control--sort">
+            <span class="cs-questions-control-label">{{lang 'products.questions.sort_label'}}</span>
+            <select class="cs-questions-select" data-questions-control="sort">
+                <option value="date_desc">{{lang 'products.questions.sort_newest'}}</option>
+                <option value="date_asc">{{lang 'products.questions.sort_oldest'}}</option>
+            </select>
+        </label>
+    </div>
+    <div id="product-questions"></div>
+    <div class="cs-questions-pagination" data-questions-pagination></div>
+</div>


### PR DESCRIPTION
## Summary
Slice 6c of the product-page UGC module (`ugcProduct.js`): the **Q&A tab**. On init it fetches `GET /api/questions/{archetype_id}` (SRS §3.2.2) through the shared `ugcApi` helper and renders approved questions with their single staff answer, with sort and pagination driven entirely by the response envelope. Mirrors the 6a/6b reviews list/sort/pagination pattern.

Refs #18

## SRS contract relied on
- **§3.2.2** `GET /api/questions/{archetype_id}` — envelope `{ items, total, page, per_page }`; query params `page`, `sort` (`date_desc` default / `date_asc`), `sort_alias` (sort_alias is the #7 alias slice, out of scope here).
- **§4.1 Question table** — public item fields consumed: `id`, `author`, `vehicle_label`, `body`, `staff_answer`, `staff_answer_author`, `date`. Per the §3.2.1 reviews precedent, `status` is internal/moderation-only and never gated on.
- **§3.6** error envelope — not-ok responses surface the questions load-error state (status branching lives in `ugcApi.js`, reused as-is).

## Acceptance criteria
- [x] Questions and staff answers render in the Q&A tab with working sort + pagination — `ugcProduct.js:initQuestions/fetchQuestions/renderQuestionsPage/_buildQuestion`; tests "renders approved questions and their staff answers", sort + pagination describe blocks.
- [x] Empty state renders when there are no approved questions — `renderQuestionsList` → `.cs-questions-empty`; test "renders the empty state when there are no approved questions".
- [x] Jest tests cover questions envelope parsing + render (mocked) — 18 new specs in the "slice 6c — Q&A tab" describe block; `getQuestions` mocked, no live API.
- [x] `npx grunt check` passes — ESLint + 197 Jest tests + stylelint all green.
- [x] Verified hands-on in `stencil start` against the dev API + seeded dev DB — **human verification step**: requires a running cs-ugc dev API and a seeded DB with approved questions for a known archetype. Not runnable from this agent environment.

## CLS / layout
`#product-questions` carries `min-height`; pagination reserves space and toggles `visibility: hidden` (not `display: none`) when collapsed to a single page. Mobile-first SCSS, `@include breakpoint('medium')` for the desktop toolbar row.

## DOM / wiring
- New partial `templates/components/products-cs/qa-cs.html`, wired into the tab strip + contents in `description-tabs-cs.html` (`#tab-questions`).
- Constructor self-discovers the Q&A DOM, so **no `productController.js` change** was required.
- Lang strings under `products.questions.*`.

## Contract-boundary note
§3.2.2 specifies the questions envelope but (unlike §3.2.1 for reviews) does not separately serialize the public Question object shape. The fields consumed here are taken directly from the §4.1 `Question` table and the §3.2.1 public-exclusion precedent (`status` and other moderation fields are never serialized publicly). No invented fields. If the public questions payload ever diverges from those §4.1 names, this render is the consumer to update.

## New theme config
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)