### PR TITLE
M6: key UGC product reads by qty_archetype_id (not product.id)

### DIFF
--- a/assets/js/theme/_addons/product/productController.js
+++ b/assets/js/theme/_addons/product/productController.js
@@ -74,7 +74,7 @@ export default class ProductController {
             this.badges = new Badges(this.stateManager);
             this.blemProducts = new BlemProducts(this.stateManager);
             this.schemaManager = new SchemaManager(this.stateManager);
-            this.ugcProduct = new UgcProduct(this.context.productId, this.stateManager, ugcApi);
+            this.ugcProduct = new UgcProduct(archetypeData.qty_archetype_id, this.stateManager, ugcApi);
 
             this.unsubscribeLocal = this.stateManager.subscribe(this.handleLocalStateChange.bind(this));
 

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -4,9 +4,11 @@
  * bootstrap, rating-summary override, the reviews list, and server-side sort,
  * filter, and pagination.
  *
- * Initialised by ProductController after archetype data loads, with the
- * archetype id (BigCommerce product.id, injected to context). On init it
- * fetches GET /api/reviews/{archetype_id} via the shared ugcApi helper and:
+ * Initialised by ProductController after archetype data loads, with the QTY
+ * archetype id (`qty_archetype_id` from the archetype JSON — the QTY
+ * ProductArchetypes.id, NOT the BigCommerce product.id; SRS §1.3, §3.1.4). On
+ * init it fetches GET /api/reviews/{archetype_id} via the shared ugcApi helper
+ * and:
  *   - renders the rating summary from the envelope's archetype_rating_average /
  *     archetype_review_count, overriding the (up to 24h stale) archetype-JSON
  *     values for in-page display (SRS §2.2, §3.2.1);
@@ -60,7 +62,8 @@ const MESSAGES = {
 
 export default class UgcProduct {
     /**
-     * @param {number|string} archetypeId - BigCommerce product.id (SRS §3.4.1).
+     * @param {number|string} archetypeId - QTY archetype id, from the archetype
+     *   JSON's `qty_archetype_id` (= ProductArchetypes.id; SRS §1.3, §3.4.1).
      * @param {Object} stateManager - Local product StateManager.
      * @param {Object} api - The ugcApi helper (injectable for tests).
      */


### PR DESCRIPTION
## What

Corrects the UGC product module to key `GET /api/reviews/{archetype_id}` and `GET /api/questions/{archetype_id}` by the **QTY** `archetype_id` (`ProductArchetypes.id`, delivered as `qty_archetype_id` on the archetype JSON) instead of the BigCommerce `product.id`.

## Why

6a (#6) shipped a stopgap wiring `this.context.productId` into `UgcProduct`, because `qty_archetype_id` was not yet published in the archetype JSON. That field is now **live in production** (cs-ugc **#103** closed — QTY publish landed). Per the contract (SRS §1.3, §3.1.4, Pass 17), the surrogate `archetype_id` PK — immune to slug/title/product-id churn — is the single identifier that binds a product page to its pooled UGC, and is the right key. This flips the wiring to it.

## Changes

- `productController.js` — construct `UgcProduct` with `archetypeData.qty_archetype_id`.
- `ugcProduct.js` — JSDoc corrected to the `qty_archetype_id` source (§1.3, §3.1.4, §3.4.1).

## Testing

- Unit tests already model the QTY id (`ARCHETYPE_ID = 12`, matching SRS examples) and the missing-field graceful-degrade case (`new UgcProduct(undefined, …)`); no test changes needed.
- `npx grunt check` passes (ESLint, 205 Jest tests, stylelint).

## Notes

- UGC reads now depend on `qty_archetype_id` being present on the archetype JSON. Confirmed live in production. The existing `update()` guard degrades gracefully (no fetch, no flash) for any archetype missing the field.
- Umbrella tracking: cs-ugc #94.