### PR TITLE
M6: ugc_token capture, validate & URL strip (#10)

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -1269,3 +1269,207 @@ describe('UgcProduct (slice 6e — submission modal)', () => {
         expect(document.querySelector('[data-review-modal]').hidden).toBe(true);
     });
 });
+
+describe('UgcProduct (slice 6f — verified-purchaser token capture)', () => {
+    // Reviews/questions list fetches resolve inertly; validateToken and postReview
+    // are injectable spies for the capture and submit paths.
+    const buildTokenApi = ({
+        validateResult = { ok: true, status: 200, data: { archetype_id: ARCHETYPE_ID, alias_id: 4821 } },
+        postResult = { ok: true, status: 201, data: { id: 1 } },
+    } = {}) => ({
+        getReviews: jest.fn(() => Promise.resolve({ ok: true, status: 200, data: buildEnvelope() })),
+        getQuestions: jest.fn(() => Promise.resolve({
+            ok: true, status: 200, data: { items: [], total: 0, page: 1, per_page: 10 },
+        })),
+        validateToken: jest.fn(() => Promise.resolve(validateResult)),
+        postReview: jest.fn(() => Promise.resolve(postResult)),
+        postQuestion: jest.fn(() => Promise.resolve(postResult)),
+    });
+
+    const mountTokenScaffold = () => {
+        document.body.innerHTML = `
+            <a id="product-rating" data-product-rating></a>
+            <div data-reviews-toolbar>
+                <button type="button" data-review-modal-open>Write a Review</button>
+            </div>
+            <div id="product-reviews"></div>
+            <div data-reviews-pagination></div>
+
+            <div class="cs-ugc-modal" data-review-modal hidden>
+                <div class="cs-ugc-modal-dialog">
+                    <form data-review-form novalidate>
+                        <p data-review-error hidden></p>
+                        <p data-review-success hidden>Thanks!</p>
+                        <div data-review-fields>
+                            <select name="rating" data-review-field="rating">
+                                <option value="">—</option>
+                                <option value="5">5</option>
+                            </select>
+                            <input type="text" name="title" data-review-field="title">
+                            <textarea name="body" data-review-field="body"></textarea>
+                            <input type="text" name="author" data-review-field="author">
+                            <input type="text" name="vehicle_label" data-review-field="vehicle_label">
+                            <label class="cs-ugc-honeypot"><input type="text" name="website" data-review-field="website"></label>
+                            <div data-review-turnstile data-ugc-turnstile-sitekey=""></div>
+                            <input type="hidden" name="cf_turnstile_token" data-review-field="cf_turnstile_token">
+                            <button type="submit" data-review-submit>Submit Review</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        `;
+    };
+
+    const setReviewField = (name, value) => {
+        document.querySelector(`[data-review-form] [name="${name}"]`).value = value;
+    };
+
+    const fillReview = (overrides = {}) => {
+        const values = {
+            rating: '5',
+            title: 'Great product',
+            body: 'Really happy with this.',
+            author: 'Jane D.',
+            vehicle_label: '',
+            website: '',
+            cf_turnstile_token: '0.test-token',
+            ...overrides,
+        };
+        Object.keys(values).forEach(name => setReviewField(name, values[name]));
+    };
+
+    const submitReview = () => {
+        fillReview();
+        document.querySelector('[data-review-form]').dispatchEvent(
+            new Event('submit', { bubbles: true, cancelable: true }),
+        );
+    };
+
+    // Point window.location at a URL carrying the given query string, without a
+    // navigation, then spy on replaceState so the strip can be asserted.
+    const setUrl = (search) => {
+        window.history.replaceState({}, '', `/products/platypus-mount${search}`);
+        return jest.spyOn(window.history, 'replaceState');
+    };
+
+    beforeEach(() => {
+        mountTokenScaffold();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        window.history.replaceState({}, '', '/');
+        jest.restoreAllMocks();
+    });
+
+    describe('URL strip (SRS §3.4.1)', () => {
+        it('strips ugc_token from the URL via history.replaceState', async () => {
+            const spy = setUrl('?ugc_token=abc123');
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildTokenApi());
+            await flush();
+
+            expect(spy).toHaveBeenCalled();
+            expect(window.location.search).not.toContain('ugc_token');
+        });
+
+        it('preserves other query params and the path when stripping', async () => {
+            const spy = setUrl('?utm=email&ugc_token=abc123');
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildTokenApi());
+            await flush();
+
+            const newUrl = spy.mock.calls[0][2];
+            expect(newUrl).toBe('/products/platypus-mount?utm=email');
+            expect(window.location.search).toContain('utm=email');
+            expect(window.location.search).not.toContain('ugc_token');
+        });
+
+        it('validates the captured token via GET /api/token/validate', async () => {
+            setUrl('?ugc_token=abc123');
+            const api = buildTokenApi();
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(api.validateToken).toHaveBeenCalledWith('abc123');
+        });
+
+        it('does not touch the URL or validate when no token is present', async () => {
+            const spy = setUrl('');
+            const api = buildTokenApi();
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(api.validateToken).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('token on submit (SRS §3.2.4)', () => {
+        it('sends ugc_token on review submit after a valid token is captured', async () => {
+            setUrl('?ugc_token=abc123');
+            const api = buildTokenApi();
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            submitReview();
+            await flush();
+
+            expect(api.postReview.mock.calls[0][0].ugc_token).toBe('abc123');
+        });
+    });
+
+    describe('graceful degradation', () => {
+        it('omits ugc_token when the token is invalid/expired (submission proceeds unverified)', async () => {
+            setUrl('?ugc_token=expired');
+            const api = buildTokenApi({
+                validateResult: {
+                    ok: false, status: 400, message: 'Invalid', error: 'Invalid',
+                },
+            });
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            submitReview();
+            await flush();
+
+            expect(api.postReview).toHaveBeenCalledTimes(1);
+            expect(api.postReview.mock.calls[0][0]).not.toHaveProperty('ugc_token');
+        });
+
+        it('still strips an invalid token from the URL', async () => {
+            const spy = setUrl('?ugc_token=expired');
+            const api = buildTokenApi({
+                validateResult: {
+                    ok: false, status: 400, message: 'Invalid', error: 'Invalid',
+                },
+            });
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(spy).toHaveBeenCalled();
+            expect(window.location.search).not.toContain('ugc_token');
+        });
+
+        it('omits ugc_token on submit when no token was in the URL', async () => {
+            setUrl('');
+            const api = buildTokenApi();
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            submitReview();
+            await flush();
+
+            expect(api.postReview.mock.calls[0][0]).not.toHaveProperty('ugc_token');
+        });
+    });
+});

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -50,8 +50,14 @@
  * (HITL #13 is a cutover gate, not a dev blocker). Submission outcomes are
  * surfaced inline per the §3.6 status branches normalized by ugcApi.
  *
- * Media upload (#9) and verified-purchaser token capture (#10) are separate
- * slices and intentionally out of scope here.
+ * Slice 6f (#10) adds verified-purchaser token capture: when `ugc_token` is in
+ * the URL it is stripped via history.replaceState (SRS §3.4.1) and validated via
+ * GET /api/token/validate (SRS §3.2.8); on success the token is held in memory
+ * and sent as `ugc_token` on review submit so the server sets verified_purchaser
+ * (SRS §3.2.4). An invalid/expired token degrades gracefully — submission still
+ * proceeds, unverified.
+ *
+ * Media upload (#9) is a separate slice and intentionally out of scope here.
  */
 
 const MAX_STARS = 5;
@@ -139,6 +145,13 @@ export default class UgcProduct {
         // §3.2.4, §3.2.5 — both optional). Null when no alias is selected.
         this.vehicleLabel = null;
 
+        // Verified-purchaser token (SRS §3.4.1, §3.2.8). Held in memory for the
+        // session only once GET /api/token/validate confirms it; sent as
+        // `ugc_token` on review submit so the server stamps verified_purchaser=true.
+        // Stays null on absent/invalid/expired token — submission still proceeds,
+        // just unverified.
+        this.verifiedPurchaserToken = null;
+
         // Turnstile widget ids returned by window.turnstile.render, per modal.
         // Tracked so the widget is rendered once and reset after each submit.
         this.reviewTurnstileId = null;
@@ -176,6 +189,7 @@ export default class UgcProduct {
             this.unsubscribe = this.stateManager.subscribe(this.update.bind(this));
             this.bindControls();
             this.bindModals();
+            this.captureVerifiedPurchaserToken();
 
             if (hasReviewsDom) {
                 this.init();
@@ -342,11 +356,54 @@ export default class UgcProduct {
     }
 
     /**
+     * Verified-purchaser token capture (SRS §3.4.1, §3.2.8). If `ugc_token` is
+     * present in the URL, strip it immediately via history.replaceState so it
+     * never lingers in the address bar / shareable URL, then validate it. The
+     * token is held in memory only after GET /api/token/validate confirms it
+     * (HTTP 200); an invalid/expired token (HTTP 400) leaves it null so the
+     * session stays unverified and submission still proceeds.
+     *
+     * The strip happens before the async validate resolves — the contract is
+     * "strip the param", independent of validity — and a held token is never
+     * exposed back into the URL.
+     * @returns {Promise<void>}
+     */
+    async captureVerifiedPurchaserToken() {
+        const params = new URLSearchParams(window.location.search);
+        const token = params.get('ugc_token');
+
+        if (!token) {
+            return;
+        }
+
+        this.stripTokenFromUrl(params);
+
+        const result = await this.api.validateToken(token);
+        if (result.ok) {
+            this.verifiedPurchaserToken = token;
+        }
+    }
+
+    /**
+     * Remove the `ugc_token` query param from the current URL without a reload,
+     * preserving any other params, path, and hash (SRS §3.4.1).
+     * @param {URLSearchParams} params - Parsed copy of window.location.search.
+     */
+    stripTokenFromUrl(params) {
+        params.delete('ugc_token');
+        const query = params.toString();
+        const { pathname, hash } = window.location;
+        const newUrl = `${pathname}${query ? `?${query}` : ''}${hash}`;
+        window.history.replaceState(window.history.state, '', newUrl);
+    }
+
+    /**
      * Shape the review submission body to the frozen SRS §3.2.4 contract. Optional
-     * fields (`alias_id`, `vehicle_label`) are included only when present so the
-     * API receives a clean body; the honeypot `website` and `cf_turnstile_token`
-     * are always sent. Verified-purchaser `ugc_token` and `media_urls` are added by
-     * separate slices (#9, #10) and intentionally omitted here.
+     * fields (`alias_id`, `vehicle_label`, `ugc_token`) are included only when
+     * present so the API receives a clean body; the honeypot `website` and
+     * `cf_turnstile_token` are always sent. A held verified-purchaser token
+     * (SRS §3.4.1) rides along as `ugc_token` so the server sets
+     * verified_purchaser=true. `media_urls` is added by slice #9.
      * @param {Object} fields
      * @param {string} token
      * @returns {Object}
@@ -368,6 +425,10 @@ export default class UgcProduct {
 
         if (fields.vehicle_label) {
             payload.vehicle_label = fields.vehicle_label;
+        }
+
+        if (this.verifiedPurchaserToken) {
+            payload.ugc_token = this.verifiedPurchaserToken;
         }
 
         return payload;


### PR DESCRIPTION
## What

Slice 6f of `ugcProduct.js` — verified-purchaser token capture (SRS §3.4.1, §3.2.8, §3.2.4). Builds on the submission modal from slice 6e (#8, PR #26); the existing review submission path and `buildReviewPayload` are reused, not rebuilt.

On mount, if `ugc_token` is present in `window.location.search`:
- Strip it from the URL via `history.replaceState` (preserving other params, path, and hash) so it never lingers in a shareable URL.
- Validate it via `GET /api/token/validate` through the shared `ugcApi` helper (`validateToken` already existed there — single fetch path, single base URL).
- Hold the token in memory for the session only on a `200`.

`buildReviewPayload` now appends the held token as `ugc_token` (SRS §3.2.4) only when present, so the server sets `verified_purchaser=true`.

## Why

M6 DoD #3: a review submitted within a verified-purchaser session is stamped `verified_purchaser=true`, while the token never persists in the URL. Token validate signals verified-purchaser status only — fitment/vehicle selection stays in `urlResolver.js` and is untouched.

## Acceptance criteria (Refs #10)

- [x] `?ugc_token=…` is stripped from the URL via `history.replaceState` — `ugcProduct.js` `captureVerifiedPurchaserToken` / `stripTokenFromUrl`.
- [x] A submission within that session sets `verified_purchaser=true` (token sent on submit) — `buildReviewPayload` appends `ugc_token` when held.
- [x] Invalid/expired token handled gracefully (submission proceeds unverified) — a `400` from `validateToken` leaves `verifiedPurchaserToken` null; payload omits `ugc_token`. The URL is still stripped regardless of validity.
- [x] Jest tests cover param strip + token-on-submit (mocked) — 8 new tests in the slice 6f block: URL strip, param/path preservation, validate call, no-token no-op, token-on-submit, invalid-token degrade (no `ugc_token` sent), invalid-token still stripped, no-token-no-`ugc_token`.
- [x] `npx grunt check` passes — ESLint + 229 Jest tests + stylelint all green.

## Testing

- `npx grunt check`: ESLint clean, 229/229 Jest pass, stylelint clean.
- All `fetch`/API access is mocked (injected `validateToken` / `postReview` spies); no live API calls. URL state driven via jsdom `history.replaceState` with a spy to assert the strip.
- Slices 6a–6e unchanged and still passing.

## Notes

No new theme config value introduced. The Turnstile site key remains the only config-driven value (from slice 6e).