### PR TITLE
M6: review media upload flow (presign → confirm → ordered media_urls) (#9)

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -1473,3 +1473,376 @@ describe('UgcProduct (slice 6f — verified-purchaser token capture)', () => {
         });
     });
 });
+
+describe('UgcProduct (slice #9 — media upload flow)', () => {
+    // Reviews/questions list fetches resolve inertly; presign/confirm/postReview
+    // are injectable spies, and mediaPut stands in for the raw PUT to DO Spaces.
+    const buildMediaApi = ({
+        presignResult = {
+            ok: true,
+            status: 200,
+            data: {
+                presigned_url: 'https://spaces.example/raw/abc?sig=1',
+                raw_url: 'https://cdn.example/ugc/media/raw/abc.jpg',
+            },
+        },
+        confirmResult = {
+            ok: true,
+            status: 200,
+            data: {
+                confirmed: true, type: 'photo', url: 'https://cdn.example/ugc/media/uuid/full.jpg', poster_url: null,
+            },
+        },
+        postResult = { ok: true, status: 201, data: { id: 1 } },
+    } = {}) => ({
+        getReviews: jest.fn(() => Promise.resolve({ ok: true, status: 200, data: buildEnvelope() })),
+        getQuestions: jest.fn(() => Promise.resolve({
+            ok: true, status: 200, data: { items: [], total: 0, page: 1, per_page: 10 },
+        })),
+        presignMedia: jest.fn(() => Promise.resolve(presignResult)),
+        confirmMedia: jest.fn(() => Promise.resolve(confirmResult)),
+        postReview: jest.fn(() => Promise.resolve(postResult)),
+        postQuestion: jest.fn(() => Promise.resolve({ ok: true, status: 201, data: { id: 1 } })),
+    });
+
+    const okPut = jest.fn(() => Promise.resolve({ ok: true, status: 200 }));
+
+    // Build a File of an exact byte size without allocating real bytes, so size
+    // limits can be exercised cheaply. jsdom honours the size of the blob parts,
+    // so we pass a single string part of the requested length when small, else a
+    // fake part whose `size` jsdom reads.
+    const makeFile = (name, type, size = 1024) => {
+        const file = new File(['x'], name, { type });
+        Object.defineProperty(file, 'size', { value: size });
+        return file;
+    };
+
+    const mountMediaScaffold = () => {
+        document.body.innerHTML = `
+            <a id="product-rating" data-product-rating></a>
+            <div data-reviews-toolbar>
+                <button type="button" data-review-modal-open>Write a Review</button>
+            </div>
+            <div id="product-reviews"></div>
+            <div data-reviews-pagination></div>
+
+            <div class="cs-ugc-modal" data-review-modal hidden>
+                <div class="cs-ugc-modal-dialog">
+                    <form data-review-form novalidate>
+                        <p data-review-error hidden></p>
+                        <p data-review-success hidden>Thanks!</p>
+                        <div data-review-fields>
+                            <select name="rating" data-review-field="rating">
+                                <option value="">—</option>
+                                <option value="5">5</option>
+                            </select>
+                            <input type="text" name="title" data-review-field="title">
+                            <textarea name="body" data-review-field="body"></textarea>
+                            <input type="text" name="author" data-review-field="author">
+                            <input type="text" name="vehicle_label" data-review-field="vehicle_label">
+                            <input type="file" name="media" data-review-field="media" multiple>
+                            <p data-review-processing hidden></p>
+                            <label class="cs-ugc-honeypot"><input type="text" name="website" data-review-field="website"></label>
+                            <div data-review-turnstile data-ugc-turnstile-sitekey=""></div>
+                            <input type="hidden" name="cf_turnstile_token" data-review-field="cf_turnstile_token">
+                            <button type="submit" data-review-submit>Submit Review</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        `;
+    };
+
+    const setReviewField = (name, value) => {
+        document.querySelector(`[data-review-form] [name="${name}"]`).value = value;
+    };
+
+    const fillReview = (overrides = {}) => {
+        const values = {
+            rating: '5',
+            title: 'Great product',
+            body: 'Really happy with this.',
+            author: 'Jane D.',
+            vehicle_label: '',
+            website: '',
+            cf_turnstile_token: '0.test-token',
+            ...overrides,
+        };
+        Object.keys(values).forEach(name => setReviewField(name, values[name]));
+    };
+
+    // Seed the file input's FileList with the given files (FileList is read-only,
+    // so define the `files` property directly).
+    const attachFiles = (files) => {
+        const input = document.querySelector('[data-review-form] [name="media"]');
+        Object.defineProperty(input, 'files', { value: files, configurable: true });
+    };
+
+    const submitReview = () => {
+        document.querySelector('[data-review-form]').dispatchEvent(
+            new Event('submit', { bubbles: true, cancelable: true }),
+        );
+    };
+
+    beforeEach(() => {
+        mountMediaScaffold();
+        okPut.mockClear();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    describe('client-side validation (before presign)', () => {
+        it('accepts a valid photo and a valid video', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([
+                makeFile('a.jpg', 'image/jpeg', 1024),
+                makeFile('clip.mp4', 'video/mp4', 1024),
+            ]);
+            submitReview();
+            await flush();
+
+            // Both files were presigned → validation passed.
+            expect(api.presignMedia).toHaveBeenCalledTimes(2);
+            expect(api.postReview).toHaveBeenCalledTimes(1);
+            expect(document.querySelector('[data-review-error]').hidden).toBe(true);
+        });
+
+        it('rejects an unsupported file type before any presign', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([makeFile('doc.pdf', 'application/pdf', 1024)]);
+            submitReview();
+            await flush();
+
+            expect(api.presignMedia).not.toHaveBeenCalled();
+            expect(api.postReview).not.toHaveBeenCalled();
+            const error = document.querySelector('[data-review-error]');
+            expect(error.hidden).toBe(false);
+            expect(error.textContent).toContain('Unsupported file type');
+        });
+
+        it('rejects a photo larger than 10 MB', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([makeFile('big.png', 'image/png', (10 * 1024 * 1024) + 1)]);
+            submitReview();
+            await flush();
+
+            expect(api.presignMedia).not.toHaveBeenCalled();
+            expect(document.querySelector('[data-review-error]').textContent).toContain('10 MB');
+        });
+
+        it('rejects a video larger than 50 MB', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([makeFile('big.mov', 'video/quicktime', (50 * 1024 * 1024) + 1)]);
+            submitReview();
+            await flush();
+
+            expect(api.presignMedia).not.toHaveBeenCalled();
+            expect(document.querySelector('[data-review-error]').textContent).toContain('50 MB');
+        });
+
+        it('rejects more than 3 photos', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([
+                makeFile('1.jpg', 'image/jpeg', 1024),
+                makeFile('2.jpg', 'image/jpeg', 1024),
+                makeFile('3.jpg', 'image/jpeg', 1024),
+                makeFile('4.jpg', 'image/jpeg', 1024),
+            ]);
+            submitReview();
+            await flush();
+
+            expect(api.presignMedia).not.toHaveBeenCalled();
+            expect(document.querySelector('[data-review-error]').textContent).toContain('up to 3 photos');
+        });
+
+        it('rejects more than 1 video', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([
+                makeFile('a.mp4', 'video/mp4', 1024),
+                makeFile('b.mov', 'video/quicktime', 1024),
+            ]);
+            submitReview();
+            await flush();
+
+            expect(api.presignMedia).not.toHaveBeenCalled();
+            expect(document.querySelector('[data-review-error]').textContent).toContain('up to 1 video');
+        });
+    });
+
+    describe('upload pipeline (presign → PUT → confirm)', () => {
+        it('runs presign, raw PUT, then confirm for each file', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            const file = makeFile('a.jpg', 'image/jpeg', 1024);
+            attachFiles([file]);
+            submitReview();
+            await flush();
+
+            expect(api.presignMedia).toHaveBeenCalledWith(file);
+            // Raw PUT targets the absolute presigned URL, not ugcApi's base.
+            expect(okPut).toHaveBeenCalledWith(
+                'https://spaces.example/raw/abc?sig=1',
+                expect.objectContaining({ method: 'PUT', body: file }),
+            );
+            expect(api.confirmMedia).toHaveBeenCalledWith('https://cdn.example/ugc/media/raw/abc.jpg');
+        });
+
+        it('aborts the submit when a raw PUT fails', async () => {
+            const failingPut = jest.fn(() => Promise.resolve({ ok: false, status: 403 }));
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, failingPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([makeFile('a.jpg', 'image/jpeg', 1024)]);
+            submitReview();
+            await flush();
+
+            expect(api.postReview).not.toHaveBeenCalled();
+            expect(document.querySelector('[data-review-error]').textContent).toContain('failed to upload');
+        });
+
+        it('aborts the submit when confirm resolves not-ok', async () => {
+            const api = buildMediaApi({
+                confirmResult: {
+                    ok: false, status: 422, message: 'Media processing failure', error: 'Media processing failure',
+                },
+            });
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([makeFile('a.jpg', 'image/jpeg', 1024)]);
+            submitReview();
+            await flush();
+
+            expect(api.postReview).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('ordered media_urls assembly (SRS §3.4.4)', () => {
+        it('sends media_urls in upload order (photo then video) with index = sort_order', async () => {
+            // Confirm returns a distinct URL per call so order is observable.
+            let confirmCall = 0;
+            const api = buildMediaApi();
+            api.confirmMedia = jest.fn(() => {
+                const urls = [
+                    { ok: true, status: 200, data: { type: 'photo', url: 'https://cdn.example/photo/full.jpg' } },
+                    { ok: true, status: 200, data: { type: 'video', url: 'https://cdn.example/video/video.mp4' } },
+                ];
+                const result = urls[confirmCall];
+                confirmCall += 1;
+                return Promise.resolve(result);
+            });
+
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([
+                makeFile('photo.jpg', 'image/jpeg', 1024),
+                makeFile('clip.mp4', 'video/mp4', 1024),
+            ]);
+            submitReview();
+            await flush();
+
+            expect(api.postReview.mock.calls[0][0].media_urls).toEqual([
+                'https://cdn.example/photo/full.jpg',
+                'https://cdn.example/video/video.mp4',
+            ]);
+        });
+
+        it('omits media_urls entirely when no files are attached', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            submitReview();
+            await flush();
+
+            expect(api.presignMedia).not.toHaveBeenCalled();
+            expect(api.postReview.mock.calls[0][0]).not.toHaveProperty('media_urls');
+        });
+    });
+
+    describe('"Processing…" state', () => {
+        it('shows the processing state during confirm and clears it after', async () => {
+            // Hold confirm open so the processing state is observable mid-flight.
+            let resolveConfirm;
+            const api = buildMediaApi();
+            api.confirmMedia = jest.fn(() => new Promise((resolve) => { resolveConfirm = resolve; }));
+
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            attachFiles([makeFile('a.jpg', 'image/jpeg', 1024)]);
+            submitReview();
+            await flush();
+
+            const processing = document.querySelector('[data-review-processing]');
+            expect(processing.hidden).toBe(false);
+            expect(processing.textContent).toContain('Processing');
+
+            resolveConfirm({ ok: true, status: 200, data: { type: 'photo', url: 'https://cdn.example/full.jpg' } });
+            await flush();
+
+            expect(processing.hidden).toBe(true);
+        });
+
+        it('does not show the processing state when no files are attached', async () => {
+            const api = buildMediaApi();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, okPut);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview();
+            submitReview();
+            await flush();
+
+            expect(document.querySelector('[data-review-processing]').hidden).toBe(true);
+        });
+    });
+});

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -57,12 +57,29 @@
  * (SRS §3.2.4). An invalid/expired token degrades gracefully — submission still
  * proceeds, unverified.
  *
- * Media upload (#9) is a separate slice and intentionally out of scope here.
+ * Slice #9 adds the review media-upload flow (SRS §3.4.4, §3.2.6, §3.2.7). Files
+ * attached to the review form are validated client-side (type/size/count) BEFORE
+ * any network call, then per accepted file: POST /api/media/presign → PUT the raw
+ * bytes directly to the returned DO Spaces presigned URL (a raw fetch, NOT through
+ * ugcApi's base) → POST /api/media/confirm. The confirmed canonical `url` + `type`
+ * are held in upload order and sent as the ordered `media_urls` array on review
+ * submit (array index = sort_order; index 0 = first displayed). Media is
+ * reviews-only — questions carry none. The confirm call can take 10-30s for video,
+ * so a "Processing…" state is surfaced (CLS-safe) while it runs.
  */
 
 const MAX_STARS = 5;
 
 const DEFAULT_SORT = 'date_desc';
+
+// Client-side media constraints (SRS §3.4.4). Enforced before any presign so an
+// invalid file never touches the network.
+const PHOTO_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const VIDEO_TYPES = ['video/mp4', 'video/quicktime'];
+const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
+const MAX_VIDEO_BYTES = 50 * 1024 * 1024;
+const MAX_PHOTOS = 3;
+const MAX_VIDEOS = 1;
 
 // Cloudflare Turnstile always-passes test site key (SRS dev environment / issue
 // #8). Used as the dev fallback when no prod key is configured on the widget
@@ -86,6 +103,13 @@ const MESSAGES = {
     requiredError: 'Please fill in all required fields.',
     turnstileError: 'Please complete the verification challenge.',
     submitting: 'Submitting…',
+    mediaType: 'Unsupported file type. Photos must be JPEG, PNG, GIF, or WebP; video must be MP4 or MOV.',
+    mediaPhotoSize: 'Each photo must be 10 MB or smaller.',
+    mediaVideoSize: 'The video must be 50 MB or smaller.',
+    mediaPhotoCount: 'You can attach up to 3 photos.',
+    mediaVideoCount: 'You can attach up to 1 video.',
+    mediaUploadError: 'A file failed to upload. Please remove it and try again.',
+    mediaProcessing: 'Processing media… this can take up to 30 seconds for video.',
 };
 
 export default class UgcProduct {
@@ -94,11 +118,15 @@ export default class UgcProduct {
      *   JSON's `qty_archetype_id` (= ProductArchetypes.id; SRS §1.3, §3.4.1).
      * @param {Object} stateManager - Local product StateManager.
      * @param {Object} api - The ugcApi helper (injectable for tests).
+     * @param {Function} [mediaPut] - fetch impl for the raw PUT to the DO Spaces
+     *   presigned URL. Bypasses ugcApi's base entirely (the URL is absolute and
+     *   external); injectable so tests never hit the network.
      */
-    constructor(archetypeId, stateManager, api) {
+    constructor(archetypeId, stateManager, api, mediaPut) {
         this.archetypeId = archetypeId;
         this.stateManager = stateManager;
         this.api = api;
+        this.mediaPut = mediaPut || ((...args) => fetch(...args));
         this.unsubscribe = null;
 
         // Cached unfiltered aggregates from the reviews envelope. Constant under
@@ -166,6 +194,11 @@ export default class UgcProduct {
         this.questionsElement = document.querySelector('#product-questions');
         this.questionsToolbarElement = document.querySelector('[data-questions-toolbar]');
         this.questionsPaginationElement = document.querySelector('[data-questions-pagination]');
+
+        // Confirmed media held in upload order (SRS §3.4.4): each entry is the
+        // canonical { url, type } returned by /api/media/confirm. Sent verbatim as
+        // the ordered `media_urls` array on submit; index = sort_order.
+        this.confirmedMedia = [];
 
         this.reviewModalElement = document.querySelector('[data-review-modal]');
         this.reviewFormElement = document.querySelector('[data-review-form]');
@@ -288,6 +321,11 @@ export default class UgcProduct {
         this._setFieldsHidden(modal, false);
         this._prefillVehicle(form);
 
+        if (modal === this.reviewModalElement) {
+            this.confirmedMedia = [];
+            this._setProcessing(false);
+        }
+
         modal.hidden = false;
     }
 
@@ -313,6 +351,168 @@ export default class UgcProduct {
         }
     }
 
+    /**
+     * Gather the files attached to the review form's media input into a plain
+     * ordered array. The input order is the user's intended display order
+     * (SRS §3.4.4). Returns [] when there is no input or no selection.
+     * @returns {File[]}
+     */
+    _collectMediaFiles() {
+        const form = this.reviewFormElement;
+        const input = form ? form.querySelector('[name="media"]') : null;
+        if (!input || !input.files) {
+            return [];
+        }
+
+        return Array.from(input.files);
+    }
+
+    /**
+     * Classify a file as 'photo' / 'video' / null from its MIME type against the
+     * SRS §3.4.4 allowed sets.
+     * @param {File} file
+     * @returns {string|null}
+     */
+    _mediaKind(file) {
+        if (PHOTO_TYPES.indexOf(file.type) !== -1) {
+            return 'photo';
+        }
+
+        if (VIDEO_TYPES.indexOf(file.type) !== -1) {
+            return 'video';
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate the attached files against the SRS §3.4.4 type, size, and count
+     * limits before any presign. Returns the first user-facing error message, or
+     * null when every file is acceptable.
+     * @param {File[]} files
+     * @returns {string|null}
+     */
+    _validateMediaFiles(files) {
+        let photoCount = 0;
+        let videoCount = 0;
+
+        for (let i = 0; i < files.length; i += 1) {
+            const file = files[i];
+            const kind = this._mediaKind(file);
+
+            if (kind === null) {
+                return MESSAGES.mediaType;
+            }
+
+            if (kind === 'photo') {
+                if (file.size > MAX_PHOTO_BYTES) {
+                    return MESSAGES.mediaPhotoSize;
+                }
+                photoCount += 1;
+            } else {
+                if (file.size > MAX_VIDEO_BYTES) {
+                    return MESSAGES.mediaVideoSize;
+                }
+                videoCount += 1;
+            }
+        }
+
+        if (photoCount > MAX_PHOTOS) {
+            return MESSAGES.mediaPhotoCount;
+        }
+
+        if (videoCount > MAX_VIDEOS) {
+            return MESSAGES.mediaVideoCount;
+        }
+
+        return null;
+    }
+
+    /**
+     * Run the presign → PUT → confirm pipeline for each accepted file in order
+     * (SRS §3.4.4 / §3.2.6 / §3.2.7), appending each confirmed { url, type } to
+     * confirmedMedia so upload order is preserved as sort_order. Returns true when
+     * every file confirmed, false on the first failure (leaving the partial set in
+     * confirmedMedia is harmless — submit is aborted by the caller).
+     * @param {File[]} files
+     * @returns {Promise<boolean>}
+     */
+    async _uploadMediaFiles(files) {
+        this.confirmedMedia = [];
+
+        for (let i = 0; i < files.length; i += 1) {
+            // Intentionally sequential: confirm blocks for the duration of the
+            // server-side pipeline (SRS §3.2.7), and one failure must abort the
+            // rest rather than fan out parallel uploads behind it.
+            // eslint-disable-next-line no-await-in-loop
+            const confirmed = await this._uploadOne(files[i]);
+            if (!confirmed) {
+                return false;
+            }
+
+            this.confirmedMedia.push(confirmed);
+        }
+
+        return true;
+    }
+
+    /**
+     * Presign, PUT to DO Spaces, and confirm a single file. The PUT goes directly
+     * to the absolute presigned URL via the injected mediaPut (NOT ugcApi's base).
+     * Resolves to the canonical { url, type } on success, or null on any failure
+     * (presign not-ok, PUT non-2xx / network error, confirm not-ok).
+     * @param {File} file
+     * @returns {Promise<Object|null>}
+     */
+    async _uploadOne(file) {
+        const presign = await this.api.presignMedia(file);
+        if (!presign.ok || !presign.data || !presign.data.presigned_url) {
+            return null;
+        }
+
+        const { presigned_url: presignedUrl, raw_url: rawUrl } = presign.data;
+
+        try {
+            const putResponse = await this.mediaPut(presignedUrl, {
+                method: 'PUT',
+                body: file,
+                headers: { 'Content-Type': file.type },
+            });
+
+            if (!putResponse || !putResponse.ok) {
+                return null;
+            }
+        } catch (error) {
+            return null;
+        }
+
+        const confirm = await this.api.confirmMedia(rawUrl);
+        if (!confirm.ok || !confirm.data || !confirm.data.url) {
+            return null;
+        }
+
+        return { url: confirm.data.url, type: confirm.data.type };
+    }
+
+    /**
+     * Toggle the "Processing…" state during the confirm pipeline (SRS §3.4.4 —
+     * video can take 10-30s). Reveals the always-present, space-reserving status
+     * element via the `hidden` attribute so layout does not shift (CLS-safe).
+     * @param {boolean} processing
+     */
+    _setProcessing(processing) {
+        const modal = this.reviewModalElement;
+        if (!modal) {
+            return;
+        }
+
+        const el = modal.querySelector('[data-review-processing]');
+        if (el) {
+            el.textContent = processing ? MESSAGES.mediaProcessing : '';
+            el.hidden = !processing;
+        }
+    }
+
     async onReviewSubmit(event) {
         event.preventDefault();
 
@@ -328,6 +528,35 @@ export default class UgcProduct {
         if (!token) {
             this._setError(modal, MESSAGES.turnstileError);
             return;
+        }
+
+        // Validate any attached files client-side before touching the network
+        // (SRS §3.4.4). A validation failure surfaces inline and aborts submit.
+        const files = this._collectMediaFiles();
+        const validationError = this._validateMediaFiles(files);
+        if (validationError) {
+            this._setError(modal, validationError);
+            return;
+        }
+
+        // Upload + confirm each accepted file in order, surfacing the "Processing…"
+        // state for the duration. Any per-file failure aborts the whole submit so
+        // the user never posts a review referencing media that never landed.
+        if (files.length) {
+            this._setError(modal, '');
+            this._setSubmitting(modal, true);
+            this._setProcessing(true);
+
+            const uploaded = await this._uploadMediaFiles(files);
+
+            this._setProcessing(false);
+            this._setSubmitting(modal, false);
+
+            if (!uploaded) {
+                this._setError(modal, MESSAGES.mediaUploadError);
+                this.resetTurnstile('review');
+                return;
+            }
         }
 
         const payload = this.buildReviewPayload(fields, token);
@@ -403,7 +632,9 @@ export default class UgcProduct {
      * present so the API receives a clean body; the honeypot `website` and
      * `cf_turnstile_token` are always sent. A held verified-purchaser token
      * (SRS §3.4.1) rides along as `ugc_token` so the server sets
-     * verified_purchaser=true. `media_urls` is added by slice #9.
+     * verified_purchaser=true. Confirmed media (SRS §3.4.4) rides along as the
+     * ordered `media_urls` array — array index = sort_order — and the field is
+     * omitted entirely when no files were attached.
      * @param {Object} fields
      * @param {string} token
      * @returns {Object}
@@ -429,6 +660,10 @@ export default class UgcProduct {
 
         if (this.verifiedPurchaserToken) {
             payload.ugc_token = this.verifiedPurchaserToken;
+        }
+
+        if (this.confirmedMedia.length) {
+            payload.media_urls = this.confirmedMedia.map(media => media.url);
         }
 
         return payload;

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1143,6 +1143,34 @@ $cs-button-height: 50px;
   border-radius: 2px;
 }
 
+.cs-ugc-input--file {
+  padding: spacing('quarter') 0;
+  font-size: 0.875rem;
+  border: 0;
+}
+
+.cs-ugc-field-hint {
+  font-size: 0.75rem;
+  color: stencilColor('color-greyDark');
+}
+
+// Processing state during the media confirm pipeline (SRS §3.4.4). Reserves
+// vertical space so toggling it on/off never shifts the form (CLS-safe): the
+// element keeps its min-height when hidden rather than collapsing to display:none.
+.cs-ugc-processing {
+  min-height: 1.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+  font-style: italic;
+  color: stencilColor('color-greyDark');
+  visibility: visible;
+
+  &[hidden] {
+    display: block;
+    visibility: hidden;
+  }
+}
+
 // Honeypot (SRS §3.4.5): present in the DOM and to automated form-fillers, but
 // visually removed via CSS — NOT type=hidden — and pulled from the tab order.
 .cs-ugc-honeypot {

--- a/lang/en.json
+++ b/lang/en.json
@@ -779,6 +779,8 @@
                 "body_label": "Your Review",
                 "author_label": "Your Name",
                 "vehicle_label": "Vehicle (optional)",
+                "media_label": "Photos or Video (optional)",
+                "media_hint": "Up to 3 photos (JPEG, PNG, GIF, WebP — 10 MB each) and 1 video (MP4, MOV — 50 MB).",
                 "website_label": "Leave this field empty",
                 "submit_value": "Submit Review",
                 "submitting": "Submitting…",

--- a/templates/components/products-cs/reviews-cs.html
+++ b/templates/components/products-cs/reviews-cs.html
@@ -72,6 +72,13 @@
                         <span class="cs-ugc-field-label">{{lang 'products.reviews.submit.vehicle_label'}}</span>
                         <input class="cs-ugc-input" type="text" name="vehicle_label" data-review-field="vehicle_label">
                     </label>
+                    <label class="cs-ugc-field cs-ugc-field--media">
+                        <span class="cs-ugc-field-label">{{lang 'products.reviews.submit.media_label'}}</span>
+                        <input class="cs-ugc-input cs-ugc-input--file" type="file" name="media" data-review-field="media" accept="image/jpeg,image/png,image/gif,image/webp,video/mp4,video/quicktime" multiple>
+                        <span class="cs-ugc-field-hint">{{lang 'products.reviews.submit.media_hint'}}</span>
+                    </label>
+
+                    <p class="cs-ugc-processing" data-review-processing role="status" aria-live="polite" hidden></p>
 
                     <label class="cs-ugc-honeypot" aria-hidden="true">
                         <span>{{lang 'products.reviews.submit.website_label'}}</span>


### PR DESCRIPTION
## What

Adds the client-side review media upload flow to the submission modal (`ugcProduct.js`, slice #9), per SRS §3.4.4, §3.2.6, §3.2.7. Builds on the slice-6e/6f review modal (#8/#10).

- **Client-side validation before presign** (`_validateMediaFiles`, `ugcProduct.js`): per file, photos JPEG/PNG/GIF/WebP ≤10 MB (≤3 per review) and video MP4/MOV ≤50 MB (≤1 per review). Rejections surface inline and abort the submit before any network call.
- **Per accepted file** (`_uploadOne`, `_uploadMediaFiles`): `presignMedia` → raw `PUT` directly to the returned DO Spaces presigned URL → `confirmMedia`. Confirmed `{ url, type }` held in upload order.
- The raw `PUT` is a direct fetch to the absolute presigned URL, **bypassing `ugcApi`'s base** — injected as a `mediaPut` constructor arg (defaults to `fetch`) so the single-base-URL rule holds and tests never hit the network.
- **`buildReviewPayload`** now wires the held media in as an ordered `media_urls` array (array index = `sort_order`, index 0 = first displayed) when present, and **omits the field entirely** when no files are attached.
- **"Processing…" state** during the confirm pipeline (video can take 10-30s), rendered via a `min-height` / `visibility:hidden` element so toggling it never shifts layout (CLS-safe). New `name="media"` file input + `[data-review-processing]` status block in `templates/components/products-cs/reviews-cs.html`; supporting SCSS in `_cs-product.scss`; lang strings in `lang/en.json`.

`presignMedia` / `confirmMedia` already existed on `ugcApi.js` (added in an earlier slice) and follow the shared method + `handleResponse` pattern — reused as-is.

## Why

M6 DoD #2 — review media upload. Media is reviews-only per §3.4.4 (questions carry none), so the flow lives entirely in the review modal.

## Testing

`npx grunt check` passes (ESLint airbnb/base, 249 Jest tests, stylelint).

New Jest suite `UgcProduct (slice #9 — media upload flow)` covers, against mocked `fetch`/api responses:

- **Validation** (accept + each reject path): valid photo+video accepted; unsupported type, photo >10 MB, video >50 MB, >3 photos, >1 video each rejected before presign.
- **Pipeline**: presign → raw PUT (asserted against the absolute presigned URL, not `ugcApi`'s base) → confirm sequence; submit aborts on a failing PUT and on a not-ok confirm.
- **Ordered `media_urls`**: 1 photo + 1 video → `media_urls` in upload order; field omitted when no files attached.
- **"Processing…"**: shown during confirm (held open mid-flight), cleared after; not shown when no files attached.

### Verification deferred

End-to-end upload **cannot be verified locally or against cs-ugc dev** — dev boots with dummy DO Spaces + Rekognition creds, so the `PUT` fails against a fake bucket and presign/confirm can't round-trip. There is no dev media bucket planned. Built and unit-tested against mocks accordingly; **live verification against prod is pending DO Spaces CORS allowing `PUT` from `https://www.cravenspeed.com`**.

### Verifiable now

The client-side validation half is real browser logic that runs before any network call (type/size/count gating, inline error messaging) and is fully covered by the unit suite.

Refs #9