### PR TITLE
M6: ugcProduct.js (#30) — review media display (photo grid + per-review thumbs)

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -1846,3 +1846,315 @@ describe('UgcProduct (slice #9 — media upload flow)', () => {
         });
     });
 });
+
+describe('UgcProduct (#30 — review media display)', () => {
+    // §3.2.1 media item fixtures. Photo: thumb_url/medium_url set, poster_url
+    // null. Video: poster_url set, thumb_url/medium_url null.
+    const photoMedia = (overrides = {}) => ({
+        id: 9,
+        url: 'https://cdn.example/ugc/media/u1/full.jpg',
+        thumb_url: 'https://cdn.example/ugc/media/u1/thumb.jpg',
+        medium_url: 'https://cdn.example/ugc/media/u1/medium.jpg',
+        poster_url: null,
+        type: 'photo',
+        sort_order: 0,
+        ...overrides,
+    });
+
+    const videoMedia = (overrides = {}) => ({
+        id: 10,
+        url: 'https://cdn.example/ugc/media/u2/video.mp4',
+        thumb_url: null,
+        medium_url: null,
+        poster_url: 'https://cdn.example/ugc/media/u2/poster.jpg',
+        type: 'video',
+        sort_order: 1,
+        ...overrides,
+    });
+
+    const reviewWith = (media, overrides = {}) => ({
+        id: 1,
+        author: 'Jane D.',
+        rating: 5,
+        title: 'Great product',
+        body: 'Really happy with this.',
+        date: '2026-01-15T00:00:00Z',
+        media,
+        ...overrides,
+    });
+
+    const mountDisplayScaffold = () => {
+        document.body.innerHTML = `
+            <a id="product-rating" data-product-rating></a>
+            <div data-reviews-toolbar>
+                <select data-reviews-control="sort">
+                    <option value="date_desc">Newest</option>
+                    <option value="date_asc">Oldest</option>
+                </select>
+            </div>
+            <section data-ugc-media-grid></section>
+            <div id="product-reviews"></div>
+            <div data-reviews-pagination></div>
+            <div data-ugc-lightbox hidden>
+                <div data-ugc-lightbox-close></div>
+                <button type="button" data-ugc-lightbox-close>&times;</button>
+                <div data-ugc-lightbox-content></div>
+            </div>
+        `;
+    };
+
+    const grid = () => document.querySelector('[data-ugc-media-grid]');
+    const lightbox = () => document.querySelector('[data-ugc-lightbox]');
+    const lightboxContent = () => document.querySelector('[data-ugc-lightbox-content]');
+
+    beforeEach(() => {
+        mountDisplayScaffold();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    describe('per-review thumbnail strip', () => {
+        it('renders a lazy-loaded photo thumbnail with descriptive alt text after the body', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([photoMedia()])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const strip = document.querySelector('#product-reviews .cs-review-media');
+            expect(strip).not.toBeNull();
+
+            const img = strip.querySelector('.cs-media-tile img');
+            expect(img.getAttribute('src')).toEqual('https://cdn.example/ugc/media/u1/thumb.jpg');
+            expect(img.getAttribute('loading')).toEqual('lazy');
+            expect(img.getAttribute('alt')).toEqual("Photo from Jane D.'s review");
+        });
+
+        it('renders a video tile as its poster frame with a play affordance and aria label', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([videoMedia()])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const tile = document.querySelector('#product-reviews .cs-media-tile--video');
+            expect(tile).not.toBeNull();
+            expect(tile.getAttribute('aria-label')).toEqual("Play video from Jane D.'s review");
+            expect(tile.querySelector('img').getAttribute('src')).toEqual('https://cdn.example/ugc/media/u2/poster.jpg');
+            expect(tile.querySelector('.cs-media-tile-play')).not.toBeNull();
+        });
+
+        it('renders no media strip when the review has an empty media array', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(document.querySelector('.cs-review-media')).toBeNull();
+        });
+
+        it('preserves the server-supplied sort_order array ordering (index 0 first)', async () => {
+            const items = [reviewWith([
+                photoMedia({ thumb_url: 'https://cdn.example/first.jpg', sort_order: 0 }),
+                videoMedia({ sort_order: 1 }),
+                photoMedia({ id: 11, thumb_url: 'https://cdn.example/third.jpg', sort_order: 2 }),
+            ])];
+            const api = buildApi(okEnvelope({ items, total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const srcs = Array.from(document.querySelectorAll('.cs-review-media img'))
+                .map(img => img.getAttribute('src'));
+            expect(srcs).toEqual([
+                'https://cdn.example/first.jpg',
+                'https://cdn.example/ugc/media/u2/poster.jpg',
+                'https://cdn.example/third.jpg',
+            ]);
+        });
+
+        it('falls down the thumb_url → poster_url → medium_url → url chain', async () => {
+            const items = [reviewWith([
+                photoMedia({ thumb_url: null }),
+                photoMedia({ id: 12, thumb_url: null, medium_url: null, url: 'https://cdn.example/only-full.jpg' }),
+            ])];
+            const api = buildApi(okEnvelope({ items, total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const srcs = Array.from(document.querySelectorAll('.cs-review-media img'))
+                .map(img => img.getAttribute('src'));
+            // First photo: thumb null, poster null (photo) → medium_url. Second:
+            // thumb/medium null → url.
+            expect(srcs).toEqual([
+                'https://cdn.example/ugc/media/u1/medium.jpg',
+                'https://cdn.example/only-full.jpg',
+            ]);
+        });
+
+        it('drops media entries without a url and labels missing authors generically', async () => {
+            const items = [reviewWith(
+                [photoMedia({ url: null }), photoMedia({ id: 13 })],
+                { author: '' },
+            )];
+            const api = buildApi(okEnvelope({ items, total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const imgs = document.querySelectorAll('.cs-review-media img');
+            expect(imgs).toHaveLength(1);
+            expect(imgs[0].getAttribute('alt')).toEqual('Photo from a customer review');
+        });
+    });
+
+    describe('top-level photo thumbnail grid', () => {
+        it('sources tiles from the media of the fetched reviews, in review order', async () => {
+            const items = [
+                reviewWith([photoMedia()], { id: 1 }),
+                reviewWith([videoMedia()], { id: 2, author: 'Bob' }),
+            ];
+            const api = buildApi(okEnvelope({ items, total: 2 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const tiles = grid().querySelectorAll('[data-ugc-media-tile]');
+            expect(tiles).toHaveLength(2);
+            expect(tiles[0].dataset.ugcMediaType).toEqual('photo');
+            expect(tiles[1].dataset.ugcMediaType).toEqual('video');
+            expect(grid().style.visibility).toEqual('visible');
+        });
+
+        it('stays hidden (space reserved) when no fetched review has media', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(grid().innerHTML).toEqual('');
+            expect(grid().style.visibility).toEqual('hidden');
+        });
+
+        it('hides the grid when the reviews fetch fails', async () => {
+            const api = buildApi({ ok: false, status: 0, message: 'down' });
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(grid().innerHTML).toEqual('');
+            expect(grid().style.visibility).toEqual('hidden');
+        });
+
+        it('caps the grid with a "+N" tile and expands in place on click', async () => {
+            const media = [];
+            for (let i = 0; i < 10; i += 1) {
+                media.push(photoMedia({ id: i, sort_order: i, thumb_url: `https://cdn.example/t${i}.jpg` }));
+            }
+            const api = buildApi(okEnvelope({ items: [reviewWith(media)], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(8);
+            const expand = grid().querySelector('[data-ugc-media-expand]');
+            expect(expand.textContent).toEqual('+2');
+
+            expand.click();
+
+            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(10);
+            expect(grid().querySelector('[data-ugc-media-expand]')).toBeNull();
+        });
+
+        it('rebuilds (collapsed) from the new envelope on every refetch render pass', async () => {
+            const firstMedia = [];
+            for (let i = 0; i < 9; i += 1) {
+                firstMedia.push(photoMedia({ id: i, sort_order: i }));
+            }
+            const api = buildSequencedApi([
+                okEnvelope({ items: [reviewWith(firstMedia)], total: 1 }),
+                okEnvelope({ items: [reviewWith([videoMedia()])], total: 1 }),
+            ]);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-expand]').click();
+            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(9);
+
+            changeSelect('sort', 'date_asc');
+            await flush();
+
+            const tiles = grid().querySelectorAll('[data-ugc-media-tile]');
+            expect(tiles).toHaveLength(1);
+            expect(tiles[0].dataset.ugcMediaType).toEqual('video');
+            expect(grid().querySelector('[data-ugc-media-expand]')).toBeNull();
+        });
+    });
+
+    describe('lightbox', () => {
+        it('opens a clicked photo tile at medium size with alt text', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([photoMedia()])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('.cs-review-media [data-ugc-media-tile]').click();
+
+            expect(lightbox().hidden).toBe(false);
+            const img = lightboxContent().querySelector('img');
+            expect(img.getAttribute('src')).toEqual('https://cdn.example/ugc/media/u1/medium.jpg');
+            expect(img.getAttribute('alt')).toEqual("Photo from Jane D.'s review");
+        });
+
+        it('opens a clicked video tile as a playable video with the poster frame', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([videoMedia()])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-tile]').click();
+
+            const video = lightboxContent().querySelector('video');
+            expect(video.getAttribute('src')).toEqual('https://cdn.example/ugc/media/u2/video.mp4');
+            expect(video.getAttribute('poster')).toEqual('https://cdn.example/ugc/media/u2/poster.jpg');
+            expect(video.hasAttribute('controls')).toBe(true);
+        });
+
+        it('closes and clears the content (stopping playback) on a close click', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([videoMedia()])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-tile]').click();
+            expect(lightbox().hidden).toBe(false);
+
+            lightbox().querySelector('button[data-ugc-lightbox-close]').click();
+
+            expect(lightbox().hidden).toBe(true);
+            expect(lightboxContent().innerHTML).toEqual('');
+        });
+    });
+
+    describe('escaping', () => {
+        it('escapes URLs so a quoted payload cannot break out of the attribute', async () => {
+            const hostile = 'https://cdn.example/x.jpg" onerror="alert(1)';
+            const items = [reviewWith([photoMedia({
+                thumb_url: hostile,
+                medium_url: hostile,
+            })])];
+            const api = buildApi(okEnvelope({ items, total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const img = document.querySelector('.cs-review-media img');
+            expect(img.getAttribute('src')).toEqual(hostile);
+            expect(img.hasAttribute('onerror')).toBe(false);
+
+            // The same holds after the round-trip through the tile dataset into
+            // the lightbox markup.
+            document.querySelector('.cs-review-media [data-ugc-media-tile]').click();
+            const large = lightboxContent().querySelector('img');
+            expect(large.getAttribute('src')).toEqual(hostile);
+            expect(large.hasAttribute('onerror')).toBe(false);
+        });
+
+        it('escapes author-derived labels to prevent HTML injection', async () => {
+            const items = [reviewWith([photoMedia()], { author: '<script>x</script>' })];
+            const api = buildApi(okEnvelope({ items, total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(grid().querySelector('script')).toBeNull();
+            expect(document.querySelector('.cs-review-media script')).toBeNull();
+        });
+    });
+});

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -66,6 +66,19 @@
  * submit (array index = sort_order; index 0 = first displayed). Media is
  * reviews-only — questions carry none. The confirm call can take 10-30s for video,
  * so a "Processing…" state is surfaced (CLS-safe) while it runs.
+ *
+ * Slice #30 adds review media DISPLAY (SRS §3.4.1, §3.2.1): a top-level photo
+ * thumbnail grid between the rating summary and the review/question tabs,
+ * sourced from the media of the fetched reviews, plus a per-review thumbnail
+ * strip inside each review. Each review's `media` array arrives ordered by
+ * sort_order (index 0 first; SRS §3.2.1) and that order is preserved. A media
+ * item's `type` is "photo" or "video" (NOT "image"); the single-thumbnail
+ * fallback chain is thumb_url → poster_url → medium_url → url. The grid caps at
+ * MEDIA_GRID_MAX tiles with a "+N" tile that expands it; clicking any tile opens
+ * the shared lightbox (photo → medium_url/url, video → plays with poster_url as
+ * poster). Both the grid and per-review strips rebuild on every render pass, so
+ * alias-aware refetches stay consistent. Only the §3.2.1 public payload fields
+ * are consumed — never `status` or other internal fields.
  */
 
 const MAX_STARS = 5;
@@ -92,6 +105,10 @@ const SORT_VALUES = ['date_desc', 'date_asc', 'rating_desc', 'rating_asc'];
 
 // Questions support only date sorts (SRS §3.2.2) — no rating/verified/media.
 const QUESTION_SORT_VALUES = ['date_desc', 'date_asc'];
+
+// Top-level photo grid cap (issue #30): at most this many media tiles render
+// before the trailing "+N" tile that expands the grid to show the rest.
+const MEDIA_GRID_MAX = 8;
 
 const MESSAGES = {
     noReviews: 'No reviews yet. Be the first to review this product.',
@@ -195,6 +212,15 @@ export default class UgcProduct {
         this.questionsToolbarElement = document.querySelector('[data-questions-toolbar]');
         this.questionsPaginationElement = document.querySelector('[data-questions-pagination]');
 
+        // Review media display (issue #30, SRS §3.4.1): the top-level thumbnail
+        // grid container and the shared lightbox. gridMedia is the flattened
+        // media of the latest fetched reviews page, rebuilt on every render
+        // pass; gridExpanded tracks the "+N" tile state and resets per pass.
+        this.mediaGridElement = document.querySelector('[data-ugc-media-grid]');
+        this.lightboxElement = document.querySelector('[data-ugc-lightbox]');
+        this.gridMedia = [];
+        this.gridExpanded = false;
+
         // Confirmed media held in upload order (SRS §3.4.4): each entry is the
         // canonical { url, type } returned by /api/media/confirm. Sent verbatim as
         // the ordered `media_urls` array on submit; index = sort_order.
@@ -215,6 +241,8 @@ export default class UgcProduct {
         this.onQuestionSubmit = this.onQuestionSubmit.bind(this);
         this.onReviewOpenClick = this.onReviewOpenClick.bind(this);
         this.onQuestionOpenClick = this.onQuestionOpenClick.bind(this);
+        this.onMediaTileClick = this.onMediaTileClick.bind(this);
+        this.onLightboxClick = this.onLightboxClick.bind(this);
 
         const hasReviewsDom = this.ratingElement || this.listElement;
 
@@ -249,6 +277,20 @@ export default class UgcProduct {
 
         if (this.questionsPaginationElement) {
             this.questionsPaginationElement.addEventListener('click', this.onQuestionsPaginationClick);
+        }
+
+        // Media tile clicks are delegated so per-review strips and the grid
+        // survive every innerHTML re-render without rebinding (issue #30).
+        if (this.listElement) {
+            this.listElement.addEventListener('click', this.onMediaTileClick);
+        }
+
+        if (this.mediaGridElement) {
+            this.mediaGridElement.addEventListener('click', this.onMediaTileClick);
+        }
+
+        if (this.lightboxElement) {
+            this.lightboxElement.addEventListener('click', this.onLightboxClick);
         }
     }
 
@@ -944,7 +986,9 @@ export default class UgcProduct {
         this.perPage = Number.isFinite(data.per_page) ? data.per_page : 0;
         this.query.page = Number.isFinite(data.page) ? data.page : this.query.page;
 
-        this.renderList(Array.isArray(data.items) ? data.items : []);
+        const items = Array.isArray(data.items) ? data.items : [];
+        this.renderList(items);
+        this.renderMediaGrid(items);
         this.renderPagination();
     }
 
@@ -1320,6 +1364,194 @@ export default class UgcProduct {
         return `<button type="button" class="cs-reviews-page${current}" data-reviews-page="${page}" data-page-key="${key}"${aria}${disabledAttr}>${label}</button>`;
     }
 
+    /**
+     * Rebuild the top-level thumbnail grid from the media of the fetched
+     * reviews (issue #30, SRS §3.4.1). Runs on every render pass — including
+     * alias-aware refetches — so the grid always mirrors the current list. The
+     * "+N" expansion collapses back on each rebuild.
+     * @param {Object[]} items - The current page of review objects (§3.2.1).
+     */
+    renderMediaGrid(items) {
+        this.gridExpanded = false;
+        this.gridMedia = this._collectGridMedia(items);
+        this._paintMediaGrid();
+    }
+
+    /**
+     * Flatten the reviews' media arrays into grid entries, preserving review
+     * order and each array's server-supplied sort_order ordering (index 0
+     * first; SRS §3.2.1). Items without a usable `url` are dropped defensively.
+     * @param {Object[]} items
+     * @returns {Object[]} Entries of { media, author }.
+     */
+    _collectGridMedia(items) {
+        const collected = [];
+
+        items.forEach((review) => {
+            const media = Array.isArray(review.media) ? review.media : [];
+            media.forEach((item) => {
+                if (item && item.url) {
+                    collected.push({ media: item, author: review.author });
+                }
+            });
+        });
+
+        return collected;
+    }
+
+    /**
+     * Paint the grid from gridMedia / gridExpanded. Empty media keeps the
+     * container's reserved space but hides it via visibility (CLS rule — the
+     * grid populates async, so it never collapses with display:none). When more
+     * than MEDIA_GRID_MAX items exist and the grid is collapsed, a trailing
+     * "+N" tile expands it in place.
+     */
+    _paintMediaGrid() {
+        if (!this.mediaGridElement) {
+            return;
+        }
+
+        const total = this.gridMedia.length;
+
+        if (!total) {
+            this.mediaGridElement.innerHTML = '';
+            this.mediaGridElement.style.visibility = 'hidden';
+            return;
+        }
+
+        const overflow = !this.gridExpanded && total > MEDIA_GRID_MAX;
+        const visible = overflow ? this.gridMedia.slice(0, MEDIA_GRID_MAX) : this.gridMedia;
+        const tiles = visible.map(entry => this._buildMediaTile(entry.media, entry.author));
+
+        if (overflow) {
+            const hidden = total - MEDIA_GRID_MAX;
+            const label = hidden === 1 ? 'Show 1 more media item' : `Show ${hidden} more media items`;
+            tiles.push(`<button type="button" class="cs-media-tile cs-media-tile--more" data-ugc-media-expand aria-label="${label}">+${hidden}</button>`);
+        }
+
+        this.mediaGridElement.innerHTML = tiles.join('');
+        this.mediaGridElement.style.visibility = 'visible';
+    }
+
+    /**
+     * Build one clickable media tile (shared by the top-level grid and the
+     * per-review strips). The thumbnail uses the §3.2.1 single-thumbnail
+     * fallback chain thumb_url → poster_url → medium_url → url; the dataset
+     * carries what the lightbox needs (photo → medium_url/url, video → url +
+     * poster_url). Photos get descriptive alt text; videos a play affordance
+     * with an aria-label, since the poster image alone names nothing.
+     * @param {Object} media - A §3.2.1 media item.
+     * @param {string} [author] - The owning review's author, for labels.
+     * @returns {string}
+     */
+    _buildMediaTile(media, author) {
+        const isVideo = media.type === 'video';
+        const thumb = media.thumb_url || media.poster_url || media.medium_url || media.url;
+        const src = isVideo ? media.url : (media.medium_url || media.url);
+        const source = author ? `${author}'s review` : 'a customer review';
+        const label = isVideo ? `Video from ${source}` : `Photo from ${source}`;
+        const escapedLabel = this._escapeAttr(label);
+        const common = `data-ugc-media-tile data-ugc-media-type="${isVideo ? 'video' : 'photo'}" data-ugc-media-src="${this._escapeAttr(src)}" data-ugc-media-label="${escapedLabel}"`;
+
+        if (isVideo) {
+            const poster = media.poster_url ? ` data-ugc-media-poster="${this._escapeAttr(media.poster_url)}"` : '';
+            const playLabel = this._escapeAttr(`Play video from ${source}`);
+            return `<button type="button" class="cs-media-tile cs-media-tile--video" ${common}${poster} aria-label="${playLabel}"><img class="cs-media-tile-thumb" src="${this._escapeAttr(thumb)}" alt="" loading="lazy"><span class="cs-media-tile-play" aria-hidden="true"></span></button>`;
+        }
+
+        return `<button type="button" class="cs-media-tile" ${common}><img class="cs-media-tile-thumb" src="${this._escapeAttr(thumb)}" alt="${escapedLabel}" loading="lazy"></button>`;
+    }
+
+    /**
+     * Build the per-review thumbnail strip rendered after the review body
+     * (issue #30). Empty string when the review carries no media, so reviews
+     * without media render exactly as before.
+     * @param {Object} review - A §3.2.1 review object.
+     * @returns {string}
+     */
+    _buildReviewMedia(review) {
+        const media = Array.isArray(review.media) ? review.media : [];
+        const tiles = media
+            .filter(item => item && item.url)
+            .map(item => this._buildMediaTile(item, review.author));
+
+        if (!tiles.length) {
+            return '';
+        }
+
+        return `<div class="cs-review-media">${tiles.join('')}</div>`;
+    }
+
+    /**
+     * Delegated click handler for media tiles in the grid and the per-review
+     * strips. The "+N" tile expands the grid in place; any other tile opens
+     * the lightbox from its dataset.
+     * @param {MouseEvent} event
+     */
+    onMediaTileClick(event) {
+        if (event.target.closest('[data-ugc-media-expand]')) {
+            this.gridExpanded = true;
+            this._paintMediaGrid();
+            return;
+        }
+
+        const tile = event.target.closest('[data-ugc-media-tile]');
+        if (tile) {
+            this.openLightbox(tile.dataset);
+        }
+    }
+
+    onLightboxClick(event) {
+        if (event.target.closest('[data-ugc-lightbox-close]')) {
+            this.closeLightbox();
+        }
+    }
+
+    /**
+     * Show the clicked media large in the shared lightbox: photos render the
+     * medium-size image (already resolved into the tile's dataset), videos play
+     * with the extracted poster frame as poster (SRS §3.2.1). Dataset values
+     * come back browser-decoded, so they are re-escaped here before insertion.
+     * @param {DOMStringMap} dataset - The clicked tile's dataset.
+     */
+    openLightbox(dataset) {
+        const content = this.lightboxElement
+            ? this.lightboxElement.querySelector('[data-ugc-lightbox-content]')
+            : null;
+        if (!content) {
+            return;
+        }
+
+        const src = this._escapeAttr(dataset.ugcMediaSrc || '');
+        const label = this._escapeAttr(dataset.ugcMediaLabel || '');
+
+        if (dataset.ugcMediaType === 'video') {
+            const poster = dataset.ugcMediaPoster ? ` poster="${this._escapeAttr(dataset.ugcMediaPoster)}"` : '';
+            content.innerHTML = `<video class="cs-ugc-lightbox-video" src="${src}"${poster} controls autoplay playsinline aria-label="${label}"></video>`;
+        } else {
+            content.innerHTML = `<img class="cs-ugc-lightbox-img" src="${src}" alt="${label}">`;
+        }
+
+        this.lightboxElement.hidden = false;
+    }
+
+    /**
+     * Hide the lightbox and clear its content — emptying the container is what
+     * stops a playing video, not just hiding it.
+     */
+    closeLightbox() {
+        if (!this.lightboxElement) {
+            return;
+        }
+
+        const content = this.lightboxElement.querySelector('[data-ugc-lightbox-content]');
+        if (content) {
+            content.innerHTML = '';
+        }
+
+        this.lightboxElement.hidden = true;
+    }
+
     renderError() {
         if (this.ratingElement) {
             this.ratingElement.innerHTML = '';
@@ -1338,6 +1570,9 @@ export default class UgcProduct {
             this.paginationElement.innerHTML = '';
             this.paginationElement.style.visibility = 'hidden';
         }
+
+        // No fetched reviews means no media to source — clear the grid too.
+        this.renderMediaGrid([]);
     }
 
     _buildStars(average) {
@@ -1368,6 +1603,7 @@ export default class UgcProduct {
         const staff = review.staff_response
             ? `<div class="cs-review-staff"><strong>CravenSpeed:</strong> ${this._escape(review.staff_response)}</div>`
             : '';
+        const media = this._buildReviewMedia(review);
 
         return `
             <article class="cs-review">
@@ -1380,6 +1616,7 @@ export default class UgcProduct {
                 </p>
                 ${vehicle ? `<p class="cs-review-vehicle">${vehicle}</p>` : ''}
                 <p class="cs-review-body">${body}</p>
+                ${media}
                 ${staff}
             </article>`;
     }
@@ -1411,6 +1648,17 @@ export default class UgcProduct {
         return div.innerHTML;
     }
 
+    /**
+     * Escape a value for a double-quoted HTML attribute context. _escape covers
+     * & < > via textContent, but NOT double quotes — a URL or label containing
+     * `"` would otherwise break out of the attribute (issue #30).
+     * @param {*} value
+     * @returns {string}
+     */
+    _escapeAttr(value) {
+        return this._escape(value).replace(/"/g, '&quot;');
+    }
+
     destroy() {
         if (this.unsubscribe) this.unsubscribe();
 
@@ -1428,6 +1676,18 @@ export default class UgcProduct {
 
         if (this.questionsPaginationElement) {
             this.questionsPaginationElement.removeEventListener('click', this.onQuestionsPaginationClick);
+        }
+
+        if (this.listElement) {
+            this.listElement.removeEventListener('click', this.onMediaTileClick);
+        }
+
+        if (this.mediaGridElement) {
+            this.mediaGridElement.removeEventListener('click', this.onMediaTileClick);
+        }
+
+        if (this.lightboxElement) {
+            this.lightboxElement.removeEventListener('click', this.onLightboxClick);
         }
 
         const reviewOpen = document.querySelector('[data-review-modal-open]');

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1214,3 +1214,124 @@ $cs-button-height: 50px;
   display: flex;
   justify-content: flex-end;
 }
+
+// =============================================================================
+// UGC review media display (issue #30, SRS §3.4.1 / §3.2.1): the top-level
+// photo thumbnail grid, the per-review thumbnail strips, and the shared media
+// lightbox.
+// =============================================================================
+
+// Populated async from fetched review media, so one tile row of space is
+// reserved and the container is revealed via visibility, never display:none
+// (CLS rule). Stays hidden — space intact — when no review carries media.
+.cs-ugc-media-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('quarter');
+  margin: spacing('single') 0;
+  min-height: 4.5rem;
+  visibility: hidden;
+
+  @include breakpoint('medium') {
+    min-height: 6rem;
+  }
+}
+
+// Per-review strip after the review body. Renders only when the review has
+// media, inside an already-async list, so no space reservation is needed here.
+.cs-review-media {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('quarter');
+  margin-top: spacing('half');
+}
+
+.cs-media-tile {
+  position: relative;
+  width: 4.5rem;
+  height: 4.5rem;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid stencilColor('color-greyLightest');
+  background: stencilColor('color-greyLightest');
+  cursor: pointer;
+
+  @include breakpoint('medium') {
+    width: 6rem;
+    height: 6rem;
+  }
+
+  &:hover,
+  &:focus-visible {
+    border-color: stencilColor('color-primary');
+    outline: none;
+  }
+}
+
+.cs-media-tile-thumb {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+// Play affordance overlaid on a video tile's poster thumbnail.
+.cs-media-tile-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2rem;
+  height: 2rem;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 55%;
+    transform: translate(-50%, -50%);
+    border-style: solid;
+    border-width: 0.4rem 0 0.4rem 0.65rem;
+    border-color: transparent transparent transparent #fff;
+  }
+}
+
+// The trailing "+N" overflow tile that expands the grid in place.
+.cs-media-tile--more {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 700;
+  color: stencilColor('color-textBase');
+}
+
+// Shared media lightbox: reuses the cs-ugc-modal shell; centers the media and
+// widens the dialog so photos/video get room on desktop.
+.cs-ugc-lightbox {
+  align-items: center;
+}
+
+.cs-ugc-lightbox-dialog {
+  max-width: 48rem;
+  padding: spacing('double') spacing('half') spacing('half');
+
+  @include breakpoint('medium') {
+    padding: spacing('double') spacing('single') spacing('single');
+  }
+}
+
+.cs-ugc-lightbox-content {
+  display: flex;
+  justify-content: center;
+  min-height: 4.5rem;
+}
+
+.cs-ugc-lightbox-img,
+.cs-ugc-lightbox-video {
+  display: block;
+  max-width: 100%;
+  max-height: 80vh;
+}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -91,6 +91,24 @@
 
 
         {{!-- =====================================================================
+        // UGC review media (SRS §3.4.1 ordering: rating summary → photo
+        // thumbnail grid → review/question tabs). Populated async from fetched
+        // review media by ugcProduct.js; space is reserved via min-height +
+        // visibility:hidden in SCSS so the late paint never shifts layout.
+        // ===================================================================== --}}
+        <section class="cs-ugc-media-grid" aria-label="Customer photos and videos" data-ugc-media-grid></section>
+
+        {{!-- Shared media lightbox for the grid and per-review thumbnails.
+        Toggled via the `hidden` attribute from ugcProduct.js. --}}
+        <div class="cs-ugc-modal cs-ugc-lightbox" data-ugc-lightbox hidden>
+            <div class="cs-ugc-modal-overlay" data-ugc-lightbox-close></div>
+            <div class="cs-ugc-modal-dialog cs-ugc-lightbox-dialog" role="dialog" aria-modal="true" aria-label="Review media">
+                <button type="button" class="cs-ugc-modal-close" data-ugc-lightbox-close aria-label="Close">&times;</button>
+                <div class="cs-ugc-lightbox-content" data-ugc-lightbox-content></div>
+            </div>
+        </div>
+
+        {{!-- =====================================================================
         // "BELOW THE FOLD" CONTENT
         // Cornerstone tabs for Description, Reviews, etc.
         // ===================================================================== --}}


### PR DESCRIPTION
Refs #30

Renders the review media that #9 uploads but nothing displayed (SRS §3.4.1 / §3.2.1).

## Acceptance criteria

- [x] **Top-level photo thumbnail grid** between the rating summary and the review/question tabs (§3.4.1 ordering) — new `[data-ugc-media-grid]` section in `templates/pages/product.html:99`, rendered by `renderMediaGrid()` (`assets/js/theme/_addons/product/ui/ugcProduct.js:1374`) / `_paintMediaGrid()` (`ugcProduct.js:1409`). Sourced from the media of the fetched reviews, capped at 8 tiles with a "+N" tile that expands the grid in place; clicking a tile opens the media (photo → `medium_url`/`url`, video → plays with `poster_url` as poster) via the shared lightbox (`openLightbox`, `ugcProduct.js:1517`). Empty when no fetched review has media — space reserved via `min-height` + `visibility: hidden`, never `display: none` (CLS rule).
- [x] **Per-review thumbnails** in `_buildReview()` (`ugcProduct.js:1594`) — `.cs-review-media` strip after the body, built by `_buildReviewMedia()` (`ugcProduct.js:1472`) from the shared `_buildMediaTile()` (`ugcProduct.js:1447`): photos as lazy-loaded `<img src="{thumb_url}">` with descriptive alt text, videos as their `poster_url` frame with a play affordance and aria-label; clicking opens the lightbox.
- [x] **SCSS** — self-contained block appended at the end of `assets/scss/custom/_cs-product.scss:1218-1334` (kept separate to minimize merge friction with the parallel #31 styling PR): mobile-first, `min-height` reservations, `:hover`/`:focus-visible` states on tiles, lightbox sizing on top of the existing `cs-ugc-modal` shell.
- [x] **Tests** — new `#30` suite in `assets/js/test-unit/theme/product/ugcProduct.spec.js:1850`: photo vs video tile branches, the `thumb_url → poster_url → medium_url → url` fallback chain, server-supplied `sort_order` ordering preserved, empty `media`, grid sourcing/overflow/expansion, rebuild-collapsed on every refetch render pass (alias-aware constraint), lightbox open/close lifecycle (close clears content to stop playback), and attribute-context escaping of URLs and author-derived labels.

## Contract notes

- `type` is `"photo"`/`"video"` per §3.2.1 — never `"image"`. Only public payload fields are consumed; `status` and other internal fields are never referenced.
- The fallback chain uses `||` (the SRS writes it with `??`, which this repo's ESLint cannot parse).
- New `_escapeAttr()` helper (`ugcProduct.js:1658`): the existing `_escape()` covers `& < >` via `textContent` but not `"`, which would let a hostile URL break out of a double-quoted attribute. Covered by tests.

## Decisions the issue left open

- **Grid placement in page geometry:** the rating summary lives in the above-fold product header and the tabs are the below-fold `cs-product-tabs-container`, so the grid section sits directly between the above-fold layout and the tabs section — matching the §3.4.1 ordering as the page actually flows.
- **Grid cap:** 8 tiles (`MEDIA_GRID_MAX`); the "+N" tile expands the grid in place (collapses again on the next render pass).
- **Grid scope:** sourced from the *currently fetched* page of reviews (per the issue wording), so it reflects active filters/sort/page and rebuilds on alias-aware refetches.

## Verification

`npx grunt check`: ESLint clean, stylelint clean (197 files), **263/263 tests pass**. One suite (`carousel.spec.js`, untouched by this PR) fails *only in the agent worktree* with a Jest configuration error — the worktree has no `node_modules`, so the `moduleNameMapper` absolute path for `slick-carousel` can't resolve. It is environmental, not a test failure; it passes wherever `node_modules` exists (main checkout / CI).

No new theme config values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)