### PR TITLE
M6: UGC visuals & UI polish — pagination styles, hover/focus states, theme consistency

### DIFF
--- a/assets/js/test-unit/theme/global/ugcOverview.spec.js
+++ b/assets/js/test-unit/theme/global/ugcOverview.spec.js
@@ -1,6 +1,7 @@
 import UgcOverview, {
     FILTERS,
     applyFilter,
+    buildStarIcons,
     paginate,
     pageCount,
 } from '../../../theme/_addons/global/ugcOverview';
@@ -96,6 +97,23 @@ describe('ugcOverview pure helpers', () => {
             const reviews = [{ rating: 5 }, { rating: 5, media: null }];
             expect(applyFilter(reviews, FILTERS.WITH_PHOTOS)).toHaveLength(0);
             expect(applyFilter(reviews, FILTERS.BASIC)).toHaveLength(2);
+        });
+    });
+
+    describe('buildStarIcons', () => {
+        const countOf = (html, needle) => html.split(needle).length - 1;
+
+        it('renders five sprite stars split by rating', () => {
+            const html = buildStarIcons(3);
+            expect(countOf(html, '#icon-star')).toBe(5);
+            expect(countOf(html, 'icon--ratingFull')).toBe(3);
+            expect(countOf(html, 'icon--ratingEmpty')).toBe(2);
+        });
+
+        it('renders all empty stars for a zero rating', () => {
+            const html = buildStarIcons(0);
+            expect(countOf(html, 'icon--ratingFull')).toBe(0);
+            expect(countOf(html, 'icon--ratingEmpty')).toBe(5);
         });
     });
 });
@@ -197,6 +215,19 @@ describe('UgcOverview controller', () => {
 
         await expect(overview.init()).resolves.toBeUndefined();
         expect(api.getOverview).not.toHaveBeenCalled();
+    });
+
+    it('renders sprite stars on cards matching the product-page markup', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(1, { ratingCycle: [4] })));
+        const overview = mount();
+        await overview.init();
+
+        const stars = document.querySelector('.cs-ugc-overview-stars');
+        expect(stars.getAttribute('role')).toBe('img');
+        expect(stars.getAttribute('aria-label')).toBe('4 out of 5 stars');
+        expect(stars.querySelectorAll('use[href="#icon-star"]')).toHaveLength(5);
+        expect(stars.querySelectorAll('.icon--ratingFull')).toHaveLength(4);
+        expect(stars.querySelectorAll('.icon--ratingEmpty')).toHaveLength(1);
     });
 
     it('uses the first media thumb_url for the card image', async () => {

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -12,6 +12,7 @@ import ugcApi from './ugcApi';
 import { escapeHtml } from './search/utils';
 
 const PER_PAGE = 10;
+const MAX_STARS = 5;
 
 // Client-side display filters (SRS §3.4.2). `rating` carries a 1-5 value when
 // the user picks a star count; the others ignore it.
@@ -54,6 +55,26 @@ export function applyFilter(reviews, filter, ratingValue = null) {
     }
 
     return reviews;
+}
+
+/**
+ * Build the 5-star strip from the shared icon sprite — the same
+ * icon--ratingFull / icon--ratingEmpty + #icon-star markup the product page
+ * renders (ugcProduct.js), so stars look identical on both surfaces. The
+ * sprite is injected unconditionally in layout/base.html, so #icon-star is
+ * available on the home page.
+ * @param {number} rating - Whole stars, 0-5.
+ * @returns {string}
+ */
+export function buildStarIcons(rating) {
+    let stars = '';
+
+    for (let i = 1; i <= MAX_STARS; i += 1) {
+        const modifier = i <= rating ? 'ratingFull' : 'ratingEmpty';
+        stars += `<span class="icon icon--${modifier}"><svg><use href="#icon-star" /></svg></span>`;
+    }
+
+    return stars;
 }
 
 /**
@@ -199,13 +220,13 @@ export default class UgcOverview {
         const archetypeName = escapeHtml(review.archetype_name);
         const archetypeUrl = escapeHtml(review.archetype_url);
         const rating = parseInt(review.rating, 10) || 0;
-        const stars = '★'.repeat(rating) + '☆'.repeat(Math.max(0, 5 - rating));
+        const stars = buildStarIcons(rating);
 
         return `
             <article class="cs-ugc-overview-card">
                 ${this.buildThumb(review)}
                 <div class="cs-ugc-overview-card-body">
-                    <div class="cs-ugc-overview-stars" aria-label="${rating} out of 5 stars">${stars}</div>
+                    <div class="cs-ugc-overview-stars" role="img" aria-label="${rating} out of ${MAX_STARS} stars">${stars}</div>
                     ${title ? `<h3 class="cs-ugc-overview-title">${title}</h3>` : ''}
                     <p class="cs-ugc-overview-text">${body}</p>
                     <p class="cs-ugc-overview-meta">

--- a/assets/scss/custom/_cs-home.scss
+++ b/assets/scss/custom/_cs-home.scss
@@ -157,12 +157,19 @@
 }
 
 .cs-ugc-overview-filter {
+  min-height: 44px;
   padding: spacing('quarter') spacing('half');
-  border: 1px solid stencilColor('color-grayLight');
+  border: 1px solid stencilColor('color-greyLight');
   border-radius: stencilRadius('base');
   background-color: stencilColor('color-white');
   color: stencilColor('color-textBase');
   cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+  }
 
   &.is-active {
     background-color: stencilColor('color-primary');
@@ -184,16 +191,30 @@
 .cs-ugc-overview-card {
   display: flex;
   flex-direction: column;
-  border: 1px solid stencilColor('color-grayLight');
+  border: 1px solid stencilColor('color-greyLight');
   border-radius: stencilRadius('card');
   overflow: hidden;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
+  }
 }
 
 .cs-ugc-overview-thumb {
   position: relative;
   width: 100%;
   padding-top: 100%;
-  background-color: stencilColor('color-grayLightest');
+  background-color: stencilColor('color-greyLightest');
 
   img {
     position: absolute;
@@ -217,8 +238,22 @@
   padding: spacing('half');
 }
 
+// Stars come from the shared icon sprite (icon--ratingFull/Empty fills in
+// components/stencil/rating). The theme has no global .icon sizing, so size
+// the sprite stars here to match the product-page presentation.
 .cs-ugc-overview-stars {
-  color: stencilColor('color-primary');
+  display: inline-flex;
+  align-items: center;
+
+  .icon {
+    width: 1rem;
+    height: 1rem;
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
 }
 
 .cs-ugc-overview-title {
@@ -239,6 +274,16 @@
   color: stencilColor('color-textSecondary');
 }
 
+.cs-ugc-overview-product {
+  color: stencilColor('color-textLink');
+  text-decoration: none;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+  }
+}
+
 .cs-ugc-overview-empty {
   text-align: center;
   color: stencilColor('color-textSecondary');
@@ -250,4 +295,32 @@
   justify-content: center;
   gap: spacing('half');
   margin-top: spacing('single');
+}
+
+// Matches the .cs-reviews-page treatment on the product page: 44px touch
+// targets, bordered buttons, dimmed disabled state.
+.cs-ugc-overview-page {
+  min-width: 44px;
+  height: 44px;
+  padding: 0 spacing('half');
+  border: 1px solid stencilColor('color-greyLightest');
+  background: stencilColor('color-white');
+  color: stencilColor('color-textBase');
+  cursor: pointer;
+
+  &:hover:not(:disabled),
+  &:focus-visible {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+.cs-ugc-overview-page-status {
+  font-size: 0.875rem;
+  color: stencilColor('color-textSecondary');
 }

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -826,7 +826,12 @@ $cs-button-height: 50px;
   padding: 0 spacing('half');
   border: 1px solid stencilColor('color-greyLightest');
 
-  &:focus {
+  &:hover {
+    border-color: stencilColor('color-greyDark');
+  }
+
+  &:focus,
+  &:focus-visible {
     border-color: stencilColor('color-primary');
     outline: none;
   }
@@ -854,6 +859,12 @@ $cs-button-height: 50px;
   background: #fff;
   color: stencilColor('color-textBase');
   cursor: pointer;
+
+  &:hover:not(:disabled),
+  &:focus-visible {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+  }
 
   &.is-current {
     border-color: stencilColor('color-primary');
@@ -906,6 +917,11 @@ $cs-button-height: 50px;
 .cs-review-verified {
   color: stencilColor('color-primary');
   font-weight: 700;
+}
+
+.cs-review-date {
+  font-size: 0.875rem;
+  color: stencilColor('color-textSecondary');
 }
 
 .cs-review-vehicle {
@@ -967,7 +983,12 @@ $cs-button-height: 50px;
   padding: 0 spacing('half');
   border: 1px solid stencilColor('color-greyLightest');
 
-  &:focus {
+  &:hover {
+    border-color: stencilColor('color-greyDark');
+  }
+
+  &:focus,
+  &:focus-visible {
     border-color: stencilColor('color-primary');
     outline: none;
   }
@@ -993,6 +1014,12 @@ $cs-button-height: 50px;
   background: #fff;
   color: stencilColor('color-textBase');
   cursor: pointer;
+
+  &:hover:not(:disabled),
+  &:focus-visible {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+  }
 
   &.is-current {
     border-color: stencilColor('color-primary');
@@ -1023,6 +1050,11 @@ $cs-button-height: 50px;
 
 .cs-question-author {
   font-weight: 700;
+}
+
+.cs-question-date {
+  font-size: 0.875rem;
+  color: stencilColor('color-textSecondary');
 }
 
 .cs-question-vehicle {
@@ -1065,8 +1097,17 @@ $cs-button-height: 50px;
   padding: spacing('single');
   overflow-y: auto;
 
+  // Fade in each time ugcProduct.js removes the `hidden` attribute — the
+  // display: none -> flex flip restarts the animation, so the show/hide
+  // contract stays attribute-driven with no JS changes.
+  animation: fadeIn 0.2s ease;
+
   &[hidden] {
     display: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 }
 
@@ -1083,9 +1124,9 @@ $cs-button-height: 50px;
   max-width: 32rem;
   margin: spacing('single') 0;
   padding: spacing('double') spacing('single') spacing('single');
-  background: #fff;
+  background: stencilColor('color-white');
   border-radius: 4px;
-  color: #333;
+  color: stencilColor('color-textBase');
 
   @include breakpoint('medium') {
     padding: spacing('double');
@@ -1095,7 +1136,7 @@ $cs-button-height: 50px;
     margin: 0 0 spacing('single');
     padding-right: spacing('double');
     font-weight: 700;
-    color: #000;
+    color: stencilColor('color-textHeading');
   }
 }
 
@@ -1108,10 +1149,20 @@ $cs-button-height: 50px;
   padding: 0;
   font-size: 1.5rem;
   line-height: 1;
-  color: #333;
+  color: stencilColor('color-textBase');
   background: transparent;
   border: 0;
   cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    color: stencilColor('color-primary');
+  }
+
+  &:focus-visible {
+    outline: 2px solid stencilColor('color-primary');
+    outline-offset: 2px;
+  }
 }
 
 .cs-ugc-fields {
@@ -1192,7 +1243,7 @@ $cs-button-height: 50px;
 .cs-ugc-form-error {
   margin: 0 0 spacing('single');
   padding: spacing('half');
-  color: #fff;
+  color: stencilColor('color-white');
   background: stencilColor('color-error');
 
   &[hidden] {


### PR DESCRIPTION
Refs #31

## Acceptance criteria

### A. Unstyled elements
- [x] 1. `.cs-ugc-overview-page` pagination buttons styled to match `.cs-reviews-page`: 44px touch targets, border, disabled state, hover/focus-visible — `assets/scss/custom/_cs-home.scss:302`
- [x] 2. `.cs-ugc-overview-page-status` given explicit type treatment consistent with the meta text (`0.875rem`, `color-textSecondary`) — `_cs-home.scss:323`
- [x] 3. `.cs-ugc-overview-product` link affordance: `color-textLink`, underline on hover/focus-visible — `_cs-home.scss:277`

### B. Interaction states
- [x] 4. `:hover` + `:focus-visible` added to `.cs-reviews-page` (`_cs-product.scss:863`), `.cs-questions-page` (`:1018`), `.cs-ugc-overview-filter` (`_cs-home.scss:166`), `.cs-reviews-select` / `.cs-questions-select` (hover border + focus-visible alongside the existing `:focus`), and `.cs-ugc-modal-close` (hover color + focus-visible outline, `_cs-product.scss:1156`). Page-button hover uses `:not(:disabled)` so disabled prev/next don't react.

### C. Theme consistency
- [x] 5. Modal hard-coded hex replaced with `stencilColor()`: dialog `#fff`→`color-white`, `#333`→`color-textBase` (exact value matches in active config), h4 `#000`→`color-textHeading`, close `#333`→`color-textBase`, and form-error `#fff`→`color-white` (same modal block, just below the surveyed range). Note: `color-textHeading` is `#444444` in active config, so the modal heading shifts from pure black to the theme heading color — `color-black` was not an option (it is `#ffffff` in config.json:165).
- [x] 6. **Sprite-availability verdict: AVAILABLE on home.** `templates/layout/base.html:78` injects `img/icon-sprite.svg` unconditionally (before the product/body page-type branch), and the sprite contains `<symbol viewBox="0 0 26 28" id="icon-star">`. The overview wall now renders the same `icon icon--ratingFull/ratingEmpty` + `<use href="#icon-star">` markup as `_buildStars` in ugcProduct.js, via a new exported `buildStarIcons()` helper (`assets/js/theme/_addons/global/ugcOverview.js:69`), plus `role="img"` on the star container to match product-page semantics. Sizing caveat: this theme's fork of `citadel/icons/_icons.scss` has no base `.icon` width/height (upstream Cornerstone's 1rem square was removed), so `.cs-ugc-overview-stars` sizes the icons explicitly (`_cs-home.scss:244`).
- [x] 7. `.cs-review-date` / `.cs-question-date` explicit rules (`_cs-product.scss:922`, `:1055`) instead of inheriting from the meta row.

### D. Polish
- [x] 8. Restrained `.cs-ugc-overview-card` hover: subtle shadow + 2px lift, transition disabled and lift removed under `prefers-reduced-motion` — `_cs-home.scss:191`
- [x] 9. Modal open fade-in via the existing `fadeIn` keyframes; the `display: none → flex` flip on `hidden`-attribute removal restarts the animation, so the ugcProduct.js show/hide contract is untouched (no JS changes); `animation: none` under `prefers-reduced-motion` — `_cs-product.scss:1100`
- [x] 10. Touch targets: overview pagination buttons 44px, `.cs-ugc-overview-filter` gains `min-height: 44px`; product-page pagination/selects were already 44px.

## Decisions the issue left open
- **`color-gray*` → `color-grey*` in the UGC overview block** (`_cs-home.scss` filter border, card border, thumb background): the American-spelling settings don't exist in config.json, so those `stencilColor()` lookups never resolved to the intended colors. Corrected for the three UGC rules this PR touches. The same misspelling exists at `_cs-home.scss:75` (`.cs-car-selection-dropdown`, non-UGC) — left alone, flagged for the PM.
- Left `background: #fff` on `.cs-reviews-page` / `.cs-questions-page` as-is — not itemized, and keeping the diff minimal against #30.

## Out-of-scope observations (for PM)
- Product-page sprite stars (`.cs-rating-stars` from ugcProduct.js `_buildStars`) also have no explicit `.icon` sizing anywhere in SCSS; with no global `.icon` dimensions in this theme they may render at browser-default SVG size. Worth a quick visual check on the live product page.

## Testing
- `npx grunt check`: ESLint green, stylelint green (197 files), Jest 250/250 tests green including 3 new star-markup tests in `ugcOverview.spec.js`.
- Caveat: the `carousel.spec.js` *suite* fails to load in my sandbox worktree only, because its partial `node_modules` is missing `slick-carousel` (a declared dependency present in the main checkout); sandbox permissions blocked reinstalling. Unrelated to this diff — CI on a full install is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)