### PR TITLE
M6: visuals/UI iteration pass on UGC modules (live QA session 2026-06-05)

### DIFF
--- a/assets/js/test-unit/theme/product/tabDeepLink.spec.js
+++ b/assets/js/test-unit/theme/product/tabDeepLink.spec.js
@@ -1,0 +1,73 @@
+import initTabDeepLink from '../../../theme/_addons/product/utils/tabDeepLink';
+
+describe('tabDeepLink', () => {
+    const mountTabs = (activeTab = 'description') => {
+        document.body.innerHTML = `
+            <ul class="tabs" data-tab>
+                <li class="tab ${activeTab === 'description' ? 'is-active' : ''}">
+                    <a class="tab-title" href="#tab-description">Description</a>
+                </li>
+                <li class="tab ${activeTab === 'reviews' ? 'is-active' : ''}">
+                    <a class="tab-title" href="#tab-reviews">Reviews</a>
+                </li>
+            </ul>
+            <div class="tabs-contents">
+                <div class="tab-content is-active" id="tab-description"></div>
+                <div class="tab-content" id="tab-reviews"></div>
+            </div>
+        `;
+    };
+
+    beforeEach(() => {
+        Element.prototype.scrollIntoView = jest.fn();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        window.location.hash = '';
+        delete Element.prototype.scrollIntoView;
+    });
+
+    it('clicks the matching tab link for the location hash on init', () => {
+        mountTabs();
+        window.location.hash = '#tab-reviews';
+        const link = () => document.querySelector('a[href="#tab-reviews"]');
+        const onClick = jest.fn();
+        link().addEventListener('click', onClick);
+
+        initTabDeepLink();
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
+
+    it('does nothing when the hash tab is already active', () => {
+        mountTabs('reviews');
+        window.location.hash = '#tab-reviews';
+        const onClick = jest.fn();
+        document.querySelector('a[href="#tab-reviews"]').addEventListener('click', onClick);
+
+        initTabDeepLink();
+
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('ignores hashes with no matching tab and malformed hashes', () => {
+        mountTabs();
+        window.location.hash = '#some-other-anchor';
+        expect(() => initTabDeepLink()).not.toThrow();
+    });
+
+    it('activates tabs on in-page hash changes', () => {
+        mountTabs();
+        window.location.hash = '';
+        initTabDeepLink();
+
+        const onClick = jest.fn();
+        document.querySelector('a[href="#tab-reviews"]').addEventListener('click', onClick);
+        window.location.hash = '#tab-reviews';
+        window.dispatchEvent(new window.HashChangeEvent('hashchange'));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -49,6 +49,7 @@ const mountScaffold = () => {
             </select>
             <input type="checkbox" data-reviews-control="verified">
             <input type="checkbox" data-reviews-control="media">
+            <input type="checkbox" data-reviews-control="vehicle_first" disabled>
         </div>
         <div id="product-reviews"></div>
         <div class="cs-reviews-pagination" data-reviews-pagination></div>
@@ -529,6 +530,7 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
                     <option value="date_desc">Newest</option>
                     <option value="date_asc">Oldest</option>
                 </select>
+                <input type="checkbox" data-questions-control="vehicle_first" disabled>
             </div>
             <div id="product-questions"></div>
             <div class="cs-questions-pagination" data-questions-pagination></div>
@@ -750,24 +752,36 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
         });
     });
 
-    it('floats alias-matching questions on alias select and drops sort_alias on deselect', async () => {
+    it('floats alias-matching questions only when the vehicle-first toggle is on', async () => {
         const stateManager = buildStateManager();
         const api = buildQaApi(okQuestions());
         new UgcProduct(ARCHETYPE_ID, stateManager, api);
         await flush();
 
-        // Initial Q&A fetch carries no sort_alias.
+        // Initial Q&A fetch carries no sort_alias; the toggle is disabled.
         expect(qParamsOfCall(api, 1).sort_alias).toBeNull();
+        const toggle = document.querySelector('[data-questions-control="vehicle_first"]');
+        expect(toggle.disabled).toBe(true);
 
+        // Selecting an alias enables the toggle but does NOT refetch — the
+        // float is opt-in.
         stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        await flush();
+        expect(api.getQuestions).toHaveBeenCalledTimes(1);
+        expect(toggle.disabled).toBe(false);
+
+        toggle.checked = true;
+        toggle.dispatchEvent(new Event('change', { bubbles: true }));
         await flush();
         expect(api.getQuestions).toHaveBeenCalledTimes(2);
         expect(qParamsOfCall(api, 2).sort_alias).toBe(4821);
 
+        // Deselecting the alias drops the param and disables the toggle.
         stateManager._emit({ aliasData: null });
         await flush();
         expect(api.getQuestions).toHaveBeenCalledTimes(3);
         expect(qParamsOfCall(api, 3).sort_alias).toBeNull();
+        expect(toggle.disabled).toBe(true);
     });
 
     it('does not fetch questions when the Q&A DOM is absent', async () => {
@@ -818,13 +832,18 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
         expect(paramsOfCall(api, 1).sort_alias).toBeNull();
     });
 
-    it('refetches reviews with sort_alias when an alias is selected', async () => {
+    it('refetches reviews with sort_alias when the toggle is on and an alias is selected', async () => {
         const stateManager = buildStateManager();
         const api = buildReviewsApi();
         new UgcProduct(ARCHETYPE_ID, stateManager, api);
         await flush();
 
+        // Alias selection alone never refetches — floating is opt-in.
         stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        await flush();
+        expect(api.getReviews).toHaveBeenCalledTimes(1);
+
+        toggleCheckbox('vehicle_first', true);
         await flush();
 
         expect(api.getReviews).toHaveBeenCalledTimes(2);
@@ -839,6 +858,10 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
 
         stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
         await flush();
+        toggleCheckbox('vehicle_first', true);
+        await flush();
+        expect(paramsOfCall(api, 2).sort_alias).toBe(4821);
+
         stateManager._emit({ aliasData: null });
         await flush();
 
@@ -863,6 +886,8 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
 
         stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
         await flush();
+        toggleCheckbox('vehicle_first', true);
+        await flush();
 
         const last = paramsOfCall(api, api.getReviews.mock.calls.length);
         expect(last).toEqual({
@@ -883,14 +908,20 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
         new UgcProduct(ARCHETYPE_ID, stateManager, api);
         await flush();
 
+        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        toggleCheckbox('vehicle_first', true);
+        await flush();
+        expect(paramsOfCall(api, 2).sort_alias).toBe(4821);
+
         document.querySelector('[data-reviews-page="3"]').click();
         await flush();
-        expect(paramsOfCall(api, 2).page).toBe(3);
+        expect(paramsOfCall(api, 3).page).toBe(3);
 
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        // Switching to a different alias re-floats and resets the page.
+        stateManager._emit({ aliasData: { qty_alias_index: 7777 } });
         await flush();
-        expect(paramsOfCall(api, 3).page).toBe(1);
-        expect(paramsOfCall(api, 3).sort_alias).toBe(4821);
+        expect(paramsOfCall(api, 4).page).toBe(1);
+        expect(paramsOfCall(api, 4).sort_alias).toBe(7777);
     });
 
     it('does not refetch when an unrelated state notification leaves the alias unchanged', async () => {
@@ -900,6 +931,7 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
         await flush();
 
         stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        toggleCheckbox('vehicle_first', true);
         await flush();
         expect(api.getReviews).toHaveBeenCalledTimes(2);
 
@@ -1102,6 +1134,9 @@ describe('UgcProduct (slice 6e — submission modal)', () => {
             expect(payload).not.toHaveProperty('alias_id');
         });
 
+        // The vehicle-first float toggle is OFF throughout this test — the
+        // selected alias must still ride on the submission as alias_id (the
+        // float preference and the selection are independent).
         it('includes alias_id from the selected alias index', async () => {
             const stateManager = buildStateManager();
             const api = buildSubmitApi();
@@ -1900,10 +1935,17 @@ describe('UgcProduct (#30 — review media display)', () => {
                 <button type="button" data-ugc-lightbox-close>&times;</button>
                 <div data-ugc-lightbox-content></div>
             </div>
+            <div data-ugc-gallery hidden>
+                <div data-ugc-gallery-close></div>
+                <button type="button" data-ugc-gallery-close>&times;</button>
+                <div data-ugc-gallery-grid></div>
+                <button type="button" data-ugc-gallery-more hidden>Load more</button>
+            </div>
         `;
     };
 
     const grid = () => document.querySelector('[data-ugc-media-grid]');
+    const galleryModal = () => document.querySelector('[data-ugc-gallery]');
     const lightbox = () => document.querySelector('[data-ugc-lightbox]');
     const lightboxContent = () => document.querySelector('[data-ugc-lightbox-content]');
 
@@ -2020,8 +2062,71 @@ describe('UgcProduct (#30 — review media display)', () => {
             expect(grid().style.visibility).toEqual('visible');
         });
 
-        it('stays hidden (space reserved) when no fetched review has media', async () => {
+        it('shows the rating summary alone when no fetched review has media', async () => {
             const api = buildApi(okEnvelope({ items: [reviewWith([])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const summary = grid().querySelector('.cs-ugc-media-grid-summary');
+            expect(summary).not.toBeNull();
+            expect(summary.querySelector('.cs-ugc-summary-average').textContent).toEqual('4.7');
+            expect(summary.querySelector('.cs-ugc-summary-count').textContent).toEqual('36 reviews');
+            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(0);
+            expect(grid().querySelector('.cs-ugc-media-grid-title')).toBeNull();
+            expect(grid().style.visibility).toEqual('visible');
+        });
+
+        it('renders the per-score histogram from archetype_rating_breakdown (§3.2.1)', async () => {
+            const api = buildApi(okEnvelope({
+                items: [reviewWith([])],
+                total: 1,
+                archetype_review_count: 36,
+                archetype_rating_breakdown: {
+                    1: 0, 2: 1, 3: 2, 4: 5, 5: 28,
+                },
+            }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const rows = grid().querySelectorAll('.cs-ugc-breakdown-row');
+            expect(rows).toHaveLength(5);
+            // Rendered 5★ down to 1★, bars proportional to count / total.
+            expect(rows[0].getAttribute('aria-label')).toEqual('28 reviews at 5 stars');
+            expect(rows[0].querySelector('.cs-ugc-breakdown-fill').style.width).toEqual('78%');
+            expect(rows[0].querySelector('.cs-ugc-breakdown-count').textContent).toEqual('28');
+            expect(rows[3].getAttribute('aria-label')).toEqual('1 review at 2 stars');
+            expect(rows[4].getAttribute('aria-label')).toEqual('0 reviews at 1 star');
+            expect(rows[4].querySelector('.cs-ugc-breakdown-fill').style.width).toEqual('0%');
+        });
+
+        it('renders no histogram while the envelope lacks archetype_rating_breakdown', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(grid().querySelector('.cs-ugc-media-grid-summary')).not.toBeNull();
+            expect(grid().querySelector('.cs-ugc-summary-breakdown')).toBeNull();
+        });
+
+        it('renders the rating summary above the gallery when media exists', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([photoMedia()])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const children = grid().children;
+            expect(children[0].className).toEqual('cs-ugc-media-grid-summary');
+            expect(children[1].className).toEqual('cs-ugc-media-gallery');
+            expect(children[1].querySelector('.cs-ugc-media-grid-title')).not.toBeNull();
+            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(1);
+        });
+
+        it('stays hidden (space reserved) when the archetype has no reviews at all', async () => {
+            const api = buildApi(okEnvelope({
+                items: [],
+                total: 0,
+                archetype_rating_average: null,
+                archetype_review_count: 0,
+            }));
             new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
             await flush();
 
@@ -2038,7 +2143,7 @@ describe('UgcProduct (#30 — review media display)', () => {
             expect(grid().style.visibility).toEqual('hidden');
         });
 
-        it('caps the grid with a "+N" tile and expands in place on click', async () => {
+        it('caps the band with a "+N" tile that opens the gallery modal', async () => {
             const media = [];
             for (let i = 0; i < 10; i += 1) {
                 media.push(photoMedia({ id: i, sort_order: i, thumb_url: `https://cdn.example/t${i}.jpg` }));
@@ -2053,32 +2158,236 @@ describe('UgcProduct (#30 — review media display)', () => {
 
             expand.click();
 
-            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(10);
-            expect(grid().querySelector('[data-ugc-media-expand]')).toBeNull();
+            // The band does not grow — the gallery modal opens with the full
+            // batch, and Load more stays hidden (batch exhausted).
+            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(8);
+            expect(galleryModal().hidden).toBe(false);
+            expect(galleryModal().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(10);
+            expect(galleryModal().querySelector('[data-ugc-gallery-more]').hidden).toBe(true);
+
+            galleryModal().querySelector('[data-ugc-gallery-close]').click();
+            expect(galleryModal().hidden).toBe(true);
         });
 
-        it('rebuilds (collapsed) from the new envelope on every refetch render pass', async () => {
-            const firstMedia = [];
-            for (let i = 0; i < 9; i += 1) {
-                firstMedia.push(photoMedia({ id: i, sort_order: i }));
-            }
+        it('pages further media into the gallery modal via Load more', async () => {
+            const pageOf = (start) => {
+                const items = [];
+                for (let i = 0; i < 10; i += 1) {
+                    items.push(reviewWith([photoMedia({ id: start + i, sort_order: 0 })], { id: start + i }));
+                }
+                return items;
+            };
             const api = buildSequencedApi([
-                okEnvelope({ items: [reviewWith(firstMedia)], total: 1 }),
-                okEnvelope({ items: [reviewWith([videoMedia()])], total: 1 }),
+                okEnvelope({ items: [reviewWith([])], total: 1 }),
+                okEnvelope({ items: pageOf(0), total: 20, per_page: 10 }),
+                okEnvelope({ items: pageOf(100), total: 20, per_page: 10 }),
             ]);
             new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
             await flush();
 
             grid().querySelector('[data-ugc-media-expand]').click();
-            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(9);
+            const more = galleryModal().querySelector('[data-ugc-gallery-more]');
+            expect(galleryModal().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(10);
+            expect(more.hidden).toBe(false);
+
+            more.click();
+            await flush();
+
+            expect(api.getReviews).toHaveBeenCalledTimes(3);
+            expect(api.getReviews.mock.calls[2][1]).toEqual({ media: true, sort: 'date_desc', page: 2 });
+            expect(galleryModal().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(20);
+            expect(more.hidden).toBe(true);
+        });
+
+        it('shows the full owning review under the media for band tiles', async () => {
+            const review = reviewWith([photoMedia({ medium_url: 'https://cdn.example/m.jpg' })], {
+                author: 'Dave',
+                title: 'Great mount',
+                body: 'Fits my F56 perfectly.',
+                rating: 5,
+            });
+            const api = buildApi(okEnvelope({ items: [review], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-tile]').click();
+
+            const content = document.querySelector('[data-ugc-lightbox-content]');
+            expect(content.querySelector('img').src).toEqual('https://cdn.example/m.jpg');
+            const shown = content.querySelector('.cs-ugc-lightbox-review .cs-review');
+            expect(shown).not.toBeNull();
+            expect(shown.querySelector('.cs-review-title').textContent).toEqual('Great mount');
+            expect(shown.querySelector('.cs-review-body').textContent).toEqual('Fits my F56 perfectly.');
+            // The review's own media strip is not duplicated inside the lightbox.
+            expect(shown.querySelector('.cs-review-media')).toBeNull();
+        });
+
+        it('keeps per-review strip tiles media-only in the lightbox', async () => {
+            const review = reviewWith([photoMedia()], { title: 'Great mount' });
+            const api = buildApi(okEnvelope({ items: [review], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('#product-reviews [data-ugc-media-tile]').click();
+
+            const content = document.querySelector('[data-ugc-lightbox-content]');
+            expect(content.querySelector('img')).not.toBeNull();
+            expect(content.querySelector('.cs-ugc-lightbox-review')).toBeNull();
+        });
+
+        it('opens the lightbox above the gallery modal from one of its tiles', async () => {
+            const media = [];
+            for (let i = 0; i < 10; i += 1) {
+                media.push(photoMedia({ id: i, sort_order: i, medium_url: `https://cdn.example/m${i}.jpg` }));
+            }
+            const api = buildApi(okEnvelope({ items: [reviewWith(media)], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-expand]').click();
+            galleryModal().querySelectorAll('[data-ugc-media-tile]')[3].click();
+
+            const lightboxEl = document.querySelector('[data-ugc-lightbox]');
+            expect(lightboxEl.hidden).toBe(false);
+            expect(lightboxEl.querySelector('img').src).toEqual('https://cdn.example/m3.jpg');
+            // The gallery modal stays open underneath.
+            expect(galleryModal().hidden).toBe(false);
+        });
+
+        it('tops up the gallery batch when a wider band wants more tiles', async () => {
+            const observers = [];
+            global.ResizeObserver = class {
+                constructor(callback) {
+                    this.callback = callback;
+                    observers.push(this);
+                }
+
+                observe() {}
+
+                disconnect() {}
+            };
+            let columns = 6;
+            const realGetComputedStyle = window.getComputedStyle.bind(window);
+            const styleSpy = jest.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+                if (el.hasAttribute && el.hasAttribute('data-ugc-media-gallery')) {
+                    return { gridTemplateColumns: Array(columns).fill('100px').join(' ') };
+                }
+                return realGetComputedStyle(el);
+            });
+
+            try {
+                const pageOf = (start) => {
+                    const items = [];
+                    for (let i = 0; i < 10; i += 1) {
+                        items.push(reviewWith([photoMedia({ id: start + i, sort_order: 0 })], { id: start + i }));
+                    }
+                    return items;
+                };
+                const api = buildSequencedApi([
+                    okEnvelope({ items: [reviewWith([])], total: 1 }),
+                    okEnvelope({ items: pageOf(0), total: 20, per_page: 10 }),
+                    okEnvelope({ items: pageOf(100), total: 20, per_page: 10 }),
+                ]);
+                new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+                await flush();
+
+                // 6 columns → capacity 9: page 1's ten items suffice, page 2
+                // is not fetched.
+                observers[0].callback();
+                await flush();
+                expect(api.getReviews).toHaveBeenCalledTimes(2);
+                expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(8);
+
+                // 12 columns → capacity 21: the batch tops up with page 2.
+                columns = 12;
+                observers[0].callback();
+                await flush();
+                expect(api.getReviews).toHaveBeenCalledTimes(3);
+                expect(api.getReviews.mock.calls[2][1]).toEqual({ media: true, sort: 'date_desc', page: 2 });
+                expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(20);
+                expect(grid().querySelector('[data-ugc-media-expand]')).toBeNull();
+            } finally {
+                styleSpy.mockRestore();
+                delete global.ResizeObserver;
+            }
+        });
+
+        it('fills the measured two-row band exactly and re-caps on resize', async () => {
+            const observers = [];
+            global.ResizeObserver = class {
+                constructor(callback) {
+                    this.callback = callback;
+                    observers.push(this);
+                }
+
+                observe() {}
+
+                disconnect() {}
+            };
+            let columns = 6;
+            const realGetComputedStyle = window.getComputedStyle.bind(window);
+            const styleSpy = jest.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+                if (el.hasAttribute && el.hasAttribute('data-ugc-media-gallery')) {
+                    return { gridTemplateColumns: Array(columns).fill('100px').join(' ') };
+                }
+                return realGetComputedStyle(el);
+            });
+
+            try {
+                const media = [];
+                for (let i = 0; i < 12; i += 1) {
+                    media.push(photoMedia({ id: i, sort_order: i }));
+                }
+                const api = buildApi(okEnvelope({ items: [reviewWith(media)], total: 1 }));
+                new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+                await flush();
+
+                // Layout lands: 6 columns → (6 * 2) - 3 = 9 elements fill the
+                // band, so 8 tiles + the "+4" tile.
+                observers[0].callback();
+                expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(8);
+                expect(grid().querySelector('[data-ugc-media-expand]').textContent).toEqual('+4');
+
+                // Wider viewport: 8 columns → 13 elements — all 12 tiles fit.
+                columns = 8;
+                observers[0].callback();
+                expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(12);
+                expect(grid().querySelector('[data-ugc-media-expand]')).toBeNull();
+            } finally {
+                styleSpy.mockRestore();
+                delete global.ResizeObserver;
+            }
+        });
+
+        it('sources the gallery from its own media=true batch, stable across list refetches', async () => {
+            const galleryMedia = [];
+            for (let i = 0; i < 10; i += 1) {
+                galleryMedia.push(photoMedia({ id: i, sort_order: i }));
+            }
+            const api = buildSequencedApi([
+                okEnvelope({ items: [reviewWith([videoMedia()])], total: 1 }),
+                okEnvelope({ items: [reviewWith(galleryMedia)], total: 1 }),
+                okEnvelope({ items: [reviewWith([])], total: 1 }),
+            ]);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            // The second call is the gallery's own §3.2.1 query.
+            expect(api.getReviews.mock.calls[1][1]).toEqual({ media: true, sort: 'date_desc', page: 1 });
+
+            // The grid is built from the gallery batch (10 photos), not the
+            // visible list page (1 video).
+            expect(grid().querySelectorAll('[data-ugc-media-tile]')).toHaveLength(8);
 
             changeSelect('sort', 'date_asc');
             await flush();
 
+            // The list refetched; the gallery batch did not.
+            expect(api.getReviews).toHaveBeenCalledTimes(3);
             const tiles = grid().querySelectorAll('[data-ugc-media-tile]');
-            expect(tiles).toHaveLength(1);
-            expect(tiles[0].dataset.ugcMediaType).toEqual('video');
-            expect(grid().querySelector('[data-ugc-media-expand]')).toBeNull();
+            expect(tiles).toHaveLength(8);
+            expect(tiles[0].dataset.ugcMediaType).toEqual('photo');
+            expect(grid().querySelector('[data-ugc-media-expand]')).not.toBeNull();
         });
     });
 

--- a/assets/js/theme/_addons/product/index.js
+++ b/assets/js/theme/_addons/product/index.js
@@ -3,10 +3,12 @@
  */
 import PageManager from '../../page-manager';
 import ProductController from './productController';
+import initTabDeepLink from './utils/tabDeepLink';
 
 export default class Product extends PageManager {
     onReady() {
         const product = new ProductController(this.context);
         product.onReady();
+        initTabDeepLink();
     }
 }

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -29,15 +29,20 @@
  * It mirrors the reviews list/sort/pagination pattern but has no filters and
  * renders each approved question with its single staff answer (§4.1 Question).
  *
- * Slice 6d (#7) adds alias-aware sorting. The module already subscribes to the
- * local StateManager; on each notify it reads the selected alias's published
- * `qty_alias_index` (SRS §3.1.4) off state.aliasData and, when it changes,
- * refetches BOTH reviews and questions with `sort_alias={qty_alias_index}` so
- * alias-matching items float to the top WITHIN the current sort, without
- * excluding non-matching items (SRS §3.2.1, §3.2.2, §3.4.1). Deselecting the
- * alias (aliasData cleared, or no integer index) drops the param. The active
- * sort and filters are preserved across the transition; only the page resets to
- * 1, since the relevance ordering shifts.
+ * Slice 6d (#7) adds alias-aware sorting; the 2026-06-05 visuals pass made it
+ * OPT-IN. The module subscribes to the local StateManager and tracks the
+ * selected alias's published `qty_alias_index` (SRS §3.1.4) off
+ * state.aliasData, but floating is user-controlled: a "My vehicle first"
+ * toggle in each toolbar (enabled only while an alias is selected). Only when
+ * the toggle is on do reviews and questions refetch with
+ * `sort_alias={qty_alias_index}`, floating alias-matching items WITHIN the
+ * current sort without excluding others (SRS §3.2.1, §3.2.2). Automatic
+ * floating was rejected as quietly misrepresenting the default order — this
+ * deviates from §3.4.1 as written (flagged to the cs-ugc PM for an SRS
+ * amendment). The active sort and filters are preserved across the
+ * transition; only the page resets to 1, since the relevance ordering
+ * shifts. The selected alias index itself still rides on submissions as
+ * `alias_id` regardless of the toggle.
  *
  * Slice 6e (#8) adds the submission modal: review and question forms posted to
  * POST /api/reviews and POST /api/questions via ugcApi (SRS §3.2.4, §3.2.5). Each
@@ -106,11 +111,19 @@ const SORT_VALUES = ['date_desc', 'date_asc', 'rating_desc', 'rating_asc'];
 // Questions support only date sorts (SRS §3.2.2) — no rating/verified/media.
 const QUESTION_SORT_VALUES = ['date_desc', 'date_asc'];
 
-// Top-level photo grid cap (issue #30): at most this many media tiles render
-// before the trailing "+N" tile that expands the grid to show the rest.
+// Top-level media grid fallback cap (issue #30): the collapsed grid normally
+// fills exactly the two-row band beside the featured tile, sized from the
+// grid's measured column count. This cap only applies when that measurement
+// is unavailable (no layout yet, or no ResizeObserver): at most this many
+// tiles render before the trailing "+N" tile that expands the grid.
 const MEDIA_GRID_MAX = 8;
 
+// Upper bound on §3.2.1 `media=true` pages the gallery fetches while topping
+// up the band — 30 media-bearing reviews covers any realistic band size.
+const GALLERY_MAX_PAGES = 3;
+
 const MESSAGES = {
+    mediaGridTitle: 'Customer Photos &amp; Videos',
     noReviews: 'No reviews yet. Be the first to review this product.',
     noMatches: 'No reviews match the selected filters.',
     loadError: 'Reviews are unavailable right now. Please try again later.',
@@ -151,6 +164,7 @@ export default class UgcProduct {
         // (SRS §3.2.1).
         this.ratingAverage = null;
         this.reviewCount = 0;
+        this.ratingBreakdown = null;
         this.summaryPainted = false;
 
         // Server-side query state (SRS §3.2.1 params). `rating` is the star
@@ -179,9 +193,16 @@ export default class UgcProduct {
         this.questionCount = 0;
         this.questionsLoaded = false;
 
-        // The integer alias index currently driving sort_alias (SRS §3.1.4 /
-        // §3.4.1), or null when no alias is selected. Tracked so an alias-driven
-        // refetch only fires when the selection actually changes.
+        // The selected alias's integer index (SRS §3.1.4), or null when no
+        // alias is selected. Rides on submissions as alias_id regardless of
+        // the float toggle.
+        this.aliasIndex = null;
+
+        // "My vehicle first" toggle state, and the effective sort_alias param
+        // derived from it: aliasIndex while the toggle is on AND an alias is
+        // selected, else null. Floating is opt-in — automatic floating reads
+        // as misrepresenting the default order.
+        this.vehicleFirst = false;
         this.sortAlias = null;
         this.reviewsLoaded = false;
 
@@ -212,14 +233,31 @@ export default class UgcProduct {
         this.questionsToolbarElement = document.querySelector('[data-questions-toolbar]');
         this.questionsPaginationElement = document.querySelector('[data-questions-pagination]');
 
-        // Review media display (issue #30, SRS §3.4.1): the top-level thumbnail
-        // grid container and the shared lightbox. gridMedia is the flattened
-        // media of the latest fetched reviews page, rebuilt on every render
-        // pass; gridExpanded tracks the "+N" tile state and resets per pass.
+        // Review media display (issue #30, SRS §3.4.1): the overview panel
+        // container and the shared lightbox. The gallery is its own data
+        // batch — the most recent media-bearing reviews (§3.2.1 media=true,
+        // date_desc), fetched once after the first list render and topped up
+        // page-by-page while the measured band has room. It is stable across
+        // the visible list's sort/filter/pagination. The band never expands
+        // in place — its "+N" tile opens the gallery modal.
         this.mediaGridElement = document.querySelector('[data-ugc-media-grid]');
         this.lightboxElement = document.querySelector('[data-ugc-lightbox]');
+        this.galleryModalElement = document.querySelector('[data-ugc-gallery]');
         this.gridMedia = [];
-        this.gridExpanded = false;
+        this.galleryRequested = false;
+        this.galleryLoading = false;
+        this.galleryExhausted = false;
+        this.galleryPagesFetched = 0;
+
+        // The collapsed grid fills exactly the two-row band beside the 2×2
+        // featured tile, so its capacity depends on the laid-out column count.
+        // A ResizeObserver re-measures when the grid first gains layout (the
+        // Reviews tab is hidden on load) and on viewport resizes.
+        this.gridCapacity = null;
+        if (this.mediaGridElement && typeof ResizeObserver !== 'undefined') {
+            this.gridResizeObserver = new ResizeObserver(() => this._onGridResize());
+            this.gridResizeObserver.observe(this.mediaGridElement);
+        }
 
         // Confirmed media held in upload order (SRS §3.4.4): each entry is the
         // canonical { url, type } returned by /api/media/confirm. Sent verbatim as
@@ -243,6 +281,7 @@ export default class UgcProduct {
         this.onQuestionOpenClick = this.onQuestionOpenClick.bind(this);
         this.onMediaTileClick = this.onMediaTileClick.bind(this);
         this.onLightboxClick = this.onLightboxClick.bind(this);
+        this.onGalleryModalClick = this.onGalleryModalClick.bind(this);
 
         const hasReviewsDom = this.ratingElement || this.listElement;
 
@@ -291,6 +330,10 @@ export default class UgcProduct {
 
         if (this.lightboxElement) {
             this.lightboxElement.addEventListener('click', this.onLightboxClick);
+        }
+
+        if (this.galleryModalElement) {
+            this.galleryModalElement.addEventListener('click', this.onGalleryModalClick);
         }
     }
 
@@ -692,8 +735,8 @@ export default class UgcProduct {
             website: fields.website,
         };
 
-        if (this.sortAlias !== null) {
-            payload.alias_id = this.sortAlias;
+        if (this.aliasIndex !== null) {
+            payload.alias_id = this.aliasIndex;
         }
 
         if (fields.vehicle_label) {
@@ -726,8 +769,8 @@ export default class UgcProduct {
             website: fields.website,
         };
 
-        if (this.sortAlias !== null) {
-            payload.alias_id = this.sortAlias;
+        if (this.aliasIndex !== null) {
+            payload.alias_id = this.aliasIndex;
         }
 
         if (fields.vehicle_label) {
@@ -941,6 +984,11 @@ export default class UgcProduct {
         const count = data.archetype_review_count;
         this.ratingAverage = average === undefined ? null : average;
         this.reviewCount = count === null || count === undefined ? 0 : count;
+        // Per-score counts (§3.2.1 archetype_rating_breakdown): filter-constant
+        // like the two aggregates above, zero-filled with all five keys when
+        // served. Null until the UGC API ships it — the histogram simply
+        // doesn't render then.
+        this.ratingBreakdown = data.archetype_rating_breakdown || null;
 
         this.renderSummary();
         this.summaryPainted = true;
@@ -988,8 +1036,14 @@ export default class UgcProduct {
 
         const items = Array.isArray(data.items) ? data.items : [];
         this.renderList(items);
-        this.renderMediaGrid(items);
         this.renderPagination();
+
+        // The gallery is its own data batch, independent of this render pass —
+        // kick off its one-time load after the first successful list render.
+        if (this.mediaGridElement && !this.galleryRequested) {
+            this.galleryRequested = true;
+            this._loadGalleryMedia();
+        }
     }
 
     /**
@@ -1034,15 +1088,43 @@ export default class UgcProduct {
      */
     applyAliasSort(state) {
         const nextAlias = this._resolveAliasIndex(state);
-        if (nextAlias === this.sortAlias) {
+        if (nextAlias === this.aliasIndex) {
             return;
         }
 
-        this.sortAlias = nextAlias;
+        this.aliasIndex = nextAlias;
+        this._syncVehicleToggles();
+        this._applySortAlias();
+    }
+
+    /**
+     * The "My vehicle first" toggle changed (either toolbar). Both lists
+     * share the one preference.
+     * @param {boolean} checked
+     */
+    _setVehicleFirst(checked) {
+        this.vehicleFirst = checked;
+        this._syncVehicleToggles();
+        this._applySortAlias();
+    }
+
+    /**
+     * Re-derive the effective sort_alias (toggle on AND alias selected) and,
+     * when it changes, refetch both lists so alias-matching items float to
+     * the top within the current sort, preserving the active sort and filters
+     * and resetting only the page (the relevance order shifts).
+     */
+    _applySortAlias() {
+        const effective = this.vehicleFirst && this.aliasIndex !== null ? this.aliasIndex : null;
+        if (effective === this.sortAlias) {
+            return;
+        }
+
+        this.sortAlias = effective;
 
         // Only refetch a list that has completed its initial load, so the
-        // alias-driven refetch layers on top of an established list rather than
-        // racing the in-flight init fetch (which reads sort_alias live anyway).
+        // refetch layers on top of an established list rather than racing the
+        // in-flight init fetch (which reads sort_alias live anyway).
         if (this.reviewsLoaded) {
             this.query.page = 1;
             this.fetchReviews();
@@ -1051,6 +1133,22 @@ export default class UgcProduct {
         if (this.questionsLoaded) {
             this.questionQuery.page = 1;
             this.fetchQuestions();
+        }
+    }
+
+    /**
+     * Mirror the shared toggle state onto both toolbars' checkboxes: checked
+     * follows the preference, disabled while no alias is selected (the
+     * control is meaningless without a vehicle).
+     */
+    _syncVehicleToggles() {
+        const toggles = document.querySelectorAll(
+            '[data-reviews-control="vehicle_first"], [data-questions-control="vehicle_first"]',
+        );
+
+        for (let i = 0; i < toggles.length; i += 1) {
+            toggles[i].checked = this.vehicleFirst;
+            toggles[i].disabled = this.aliasIndex === null;
         }
     }
 
@@ -1094,6 +1192,11 @@ export default class UgcProduct {
             this.query.verified = target.checked ? true : null;
         } else if (reviewsControl === 'media') {
             this.query.media = target.checked ? true : null;
+        } else if (reviewsControl === 'vehicle_first') {
+            // Shared toggle — refetches both lists itself when the effective
+            // sort_alias changes.
+            this._setVehicleFirst(target.checked);
+            return;
         } else {
             return;
         }
@@ -1180,6 +1283,14 @@ export default class UgcProduct {
         }
 
         const { questionsControl } = target.dataset;
+
+        if (questionsControl === 'vehicle_first') {
+            // Shared toggle — refetches both lists itself when the effective
+            // sort_alias changes.
+            this._setVehicleFirst(target.checked);
+            return;
+        }
+
         if (questionsControl !== 'sort') {
             return;
         }
@@ -1371,18 +1482,76 @@ export default class UgcProduct {
      * "+N" expansion collapses back on each rebuild.
      * @param {Object[]} items - The current page of review objects (§3.2.1).
      */
-    renderMediaGrid(items) {
-        this.gridExpanded = false;
-        this.gridMedia = this._collectGridMedia(items);
+    /**
+     * Fetch the next page of the gallery's own data batch (§3.2.1
+     * `media=true`, newest first): the most recent media-bearing reviews,
+     * independent of the visible list's sort/filter/page. Appends to
+     * gridMedia and resolves true when a page landed; a failed fetch marks
+     * the batch exhausted and resolves false.
+     * @returns {Promise<boolean>}
+     */
+    async _fetchGalleryPage() {
+        if (this.galleryLoading || this.galleryExhausted) {
+            return false;
+        }
+
+        this.galleryLoading = true;
+        const result = await this.api.getReviews(this.archetypeId, {
+            media: true,
+            sort: 'date_desc',
+            page: this.galleryPagesFetched + 1,
+        });
+        this.galleryLoading = false;
+
+        if (!result.ok) {
+            this.galleryExhausted = true;
+            return false;
+        }
+
+        const data = result.data || {};
+        const items = Array.isArray(data.items) ? data.items : [];
+        this.galleryPagesFetched += 1;
+
+        const total = Number.isFinite(data.total) ? data.total : null;
+        const perPage = Number.isFinite(data.per_page) ? data.per_page : items.length;
+
+        if (!items.length || (total !== null && this.galleryPagesFetched * perPage >= total)) {
+            this.galleryExhausted = true;
+        }
+
+        this.gridMedia = this.gridMedia.concat(this._collectGridMedia(items));
+        return true;
+    }
+
+    /**
+     * Top the band up one page at a time (bounded by GALLERY_MAX_PAGES)
+     * while the measured band has unfilled cells, repainting after every
+     * landed page. A failed fetch stops quietly — the panel shows whatever
+     * it already has.
+     */
+    async _loadGalleryMedia() {
+        const capacity = this.gridCapacity || MEDIA_GRID_MAX + 1;
+
+        if (this.galleryPagesFetched >= GALLERY_MAX_PAGES || this.gridMedia.length >= capacity) {
+            return;
+        }
+
+        const fetched = await this._fetchGalleryPage();
         this._paintMediaGrid();
+
+        if (fetched) {
+            await this._loadGalleryMedia();
+        }
     }
 
     /**
      * Flatten the reviews' media arrays into grid entries, preserving review
      * order and each array's server-supplied sort_order ordering (index 0
-     * first; SRS §3.2.1). Items without a usable `url` are dropped defensively.
+     * first; SRS §3.2.1). Items without a usable `url` are dropped
+     * defensively. Each entry keeps its owning review so the lightbox can
+     * show the full review beside the media.
      * @param {Object[]} items
-     * @returns {Object[]} Entries of { media, author }.
+     * @returns {Object[]} Entries of { media, review }.
      */
     _collectGridMedia(items) {
         const collected = [];
@@ -1391,7 +1560,7 @@ export default class UgcProduct {
             const media = Array.isArray(review.media) ? review.media : [];
             media.forEach((item) => {
                 if (item && item.url) {
-                    collected.push({ media: item, author: review.author });
+                    collected.push({ media: item, review });
                 }
             });
         });
@@ -1400,37 +1569,142 @@ export default class UgcProduct {
     }
 
     /**
-     * Paint the grid from gridMedia / gridExpanded. Empty media keeps the
-     * container's reserved space but hides it via visibility (CLS rule — the
-     * grid populates async, so it never collapses with display:none). When more
-     * than MEDIA_GRID_MAX items exist and the grid is collapsed, a trailing
-     * "+N" tile expands it in place.
+     * Paint the reviews-overview panel: the archetype rating summary header
+     * plus the media collage from gridMedia. The panel renders
+     * whenever the archetype has reviews — with no media it carries the
+     * summary alone. With neither, the container keeps its reserved space but
+     * hides via visibility (CLS rule — it populates async, so it never
+     * collapses with display:none). When more media exists than the band
+     * holds — locally or still on the server — a trailing "+N" tile opens
+     * the browsable gallery modal.
      */
     _paintMediaGrid() {
         if (!this.mediaGridElement) {
             return;
         }
 
+        const summary = this._buildPanelSummary();
         const total = this.gridMedia.length;
 
-        if (!total) {
+        if (!total && !summary) {
             this.mediaGridElement.innerHTML = '';
             this.mediaGridElement.style.visibility = 'hidden';
             return;
         }
 
-        const overflow = !this.gridExpanded && total > MEDIA_GRID_MAX;
-        const visible = overflow ? this.gridMedia.slice(0, MEDIA_GRID_MAX) : this.gridMedia;
-        const tiles = visible.map(entry => this._buildMediaTile(entry.media, entry.author));
+        let gallery = '';
 
-        if (overflow) {
-            const hidden = total - MEDIA_GRID_MAX;
-            const label = hidden === 1 ? 'Show 1 more media item' : `Show ${hidden} more media items`;
-            tiles.push(`<button type="button" class="cs-media-tile cs-media-tile--more" data-ugc-media-expand aria-label="${label}">+${hidden}</button>`);
+        if (total) {
+            // Capacity counts grid elements (tiles plus any "+N") that fill the
+            // two-row band exactly; when unmeasured, fall back to the fixed cap.
+            // The band never grows in place — "+N" opens the gallery modal,
+            // and it also shows when the server holds more media than the
+            // batch has fetched so far.
+            const capacity = this.gridCapacity || MEDIA_GRID_MAX + 1;
+            const overflow = total > capacity || !this.galleryExhausted;
+            const visible = overflow ? this.gridMedia.slice(0, capacity - 1) : this.gridMedia;
+            const tiles = visible.map((entry, index) => this._buildMediaTile(entry.media, entry.review.author, index));
+
+            if (overflow) {
+                const hidden = total - visible.length;
+                const text = hidden > 0 ? `+${hidden}` : '&hellip;';
+                tiles.push(`<button type="button" class="cs-media-tile cs-media-tile--more" data-ugc-media-expand aria-label="View all customer photos and videos">${text}</button>`);
+            }
+
+            gallery = `<div class="cs-ugc-media-gallery" data-ugc-media-gallery><h3 class="cs-ugc-media-grid-title">${MESSAGES.mediaGridTitle} (${total})</h3>${tiles.join('')}</div>`;
         }
 
-        this.mediaGridElement.innerHTML = tiles.join('');
+        this.mediaGridElement.innerHTML = summary + gallery;
         this.mediaGridElement.style.visibility = 'visible';
+    }
+
+    /**
+     * Re-measure the collapsed grid's capacity after layout changes (tab
+     * activation, viewport resize) and repaint only when it actually changed.
+     * An expanded grid keeps showing everything until the next render pass.
+     */
+    _onGridResize() {
+        const capacity = this._measureGridCapacity();
+
+        if (capacity !== this.gridCapacity) {
+            this.gridCapacity = capacity;
+            this._paintMediaGrid();
+
+            // A wider band may want more tiles than the batch holds.
+            if (this.galleryRequested) {
+                this._loadGalleryMedia();
+            }
+        }
+    }
+
+    /**
+     * Derive how many grid elements fill the two-row band from the browser's
+     * resolved column tracks (authoritative — no duplication of the SCSS
+     * auto-fill math). The 2×2 featured tile occupies four cells, so a
+     * cols-wide band holds (cols * 2) - 3 elements. Returns null when the grid
+     * has no resolved layout yet (e.g. inside the inactive Reviews tab).
+     * @returns {?number}
+     */
+    _measureGridCapacity() {
+        const gallery = this.mediaGridElement.querySelector('[data-ugc-media-gallery]');
+
+        if (!gallery) {
+            return null;
+        }
+
+        const style = window.getComputedStyle(gallery);
+        const tracks = (style.gridTemplateColumns || '').split(' ').filter(track => track.endsWith('px'));
+        const cols = tracks.length;
+
+        if (cols < 3) {
+            return null;
+        }
+
+        return (cols * 2) - 3;
+    }
+
+    /**
+     * Archetype-wide rating header for the overview panel: average stars, the
+     * numeric average, and the review count (the cached, filter-constant
+     * envelope aggregates). Empty string before the first envelope lands or
+     * when the archetype has no approved reviews. A breakdown by score joins
+     * here once the §3.2.1 envelope serves an aggregate for it.
+     * @returns {string}
+     */
+    _buildPanelSummary() {
+        if (this.ratingAverage === null || !this.reviewCount) {
+            return '';
+        }
+
+        const average = Math.round(this.ratingAverage * 10) / 10;
+        const rating = `<div class="cs-ugc-summary-rating">${this._buildStars(this.ratingAverage)}<span class="cs-ugc-summary-average">${average}</span><span class="cs-ugc-summary-count">${this._countLabel(this.reviewCount)}</span></div>`;
+        return `<div class="cs-ugc-media-grid-summary">${rating}${this._buildBreakdown()}</div>`;
+    }
+
+    /**
+     * Per-score histogram from the cached §3.2.1 archetype_rating_breakdown,
+     * rendered 5★ down to 1★ with bars proportional to the review count.
+     * Empty string until the UGC API serves the field. The spec guarantees
+     * all five keys zero-filled and sum == archetype_review_count, so bar
+     * math needs no per-key guards.
+     * @returns {string}
+     */
+    _buildBreakdown() {
+        if (!this.ratingBreakdown || !this.reviewCount) {
+            return '';
+        }
+
+        const rows = [];
+
+        for (let score = MAX_STARS; score >= 1; score -= 1) {
+            const count = this.ratingBreakdown[String(score)];
+            const percent = Math.round((count / this.reviewCount) * 100);
+            const noun = count === 1 ? 'review' : 'reviews';
+            const starNoun = score === 1 ? 'star' : 'stars';
+            rows.push(`<div class="cs-ugc-breakdown-row" role="img" aria-label="${count} ${noun} at ${score} ${starNoun}"><span class="cs-ugc-breakdown-label" aria-hidden="true">${score}★</span><span class="cs-ugc-breakdown-bar" aria-hidden="true"><span class="cs-ugc-breakdown-fill" style="width: ${percent}%"></span></span><span class="cs-ugc-breakdown-count" aria-hidden="true">${count}</span></div>`);
+        }
+
+        return `<div class="cs-ugc-summary-breakdown">${rows.join('')}</div>`;
     }
 
     /**
@@ -1442,16 +1716,21 @@ export default class UgcProduct {
      * with an aria-label, since the poster image alone names nothing.
      * @param {Object} media - A §3.2.1 media item.
      * @param {string} [author] - The owning review's author, for labels.
+     * @param {number} [index] - The entry's gridMedia index. Present on band
+     *     and gallery-modal tiles, where the lightbox shows the full owning
+     *     review; absent on per-review strips (their review is already on
+     *     screen).
      * @returns {string}
      */
-    _buildMediaTile(media, author) {
+    _buildMediaTile(media, author, index) {
         const isVideo = media.type === 'video';
         const thumb = media.thumb_url || media.poster_url || media.medium_url || media.url;
         const src = isVideo ? media.url : (media.medium_url || media.url);
         const source = author ? `${author}'s review` : 'a customer review';
         const label = isVideo ? `Video from ${source}` : `Photo from ${source}`;
         const escapedLabel = this._escapeAttr(label);
-        const common = `data-ugc-media-tile data-ugc-media-type="${isVideo ? 'video' : 'photo'}" data-ugc-media-src="${this._escapeAttr(src)}" data-ugc-media-label="${escapedLabel}"`;
+        const indexAttr = index === undefined ? '' : ` data-ugc-media-index="${index}"`;
+        const common = `data-ugc-media-tile${indexAttr} data-ugc-media-type="${isVideo ? 'video' : 'photo'}" data-ugc-media-src="${this._escapeAttr(src)}" data-ugc-media-label="${escapedLabel}"`;
 
         if (isVideo) {
             const poster = media.poster_url ? ` data-ugc-media-poster="${this._escapeAttr(media.poster_url)}"` : '';
@@ -1484,14 +1763,13 @@ export default class UgcProduct {
 
     /**
      * Delegated click handler for media tiles in the grid and the per-review
-     * strips. The "+N" tile expands the grid in place; any other tile opens
+     * strips. The "+N" tile opens the gallery modal; any other tile opens
      * the lightbox from its dataset.
      * @param {MouseEvent} event
      */
     onMediaTileClick(event) {
         if (event.target.closest('[data-ugc-media-expand]')) {
-            this.gridExpanded = true;
-            this._paintMediaGrid();
+            this.openGalleryModal();
             return;
         }
 
@@ -1505,6 +1783,86 @@ export default class UgcProduct {
         if (event.target.closest('[data-ugc-lightbox-close]')) {
             this.closeLightbox();
         }
+    }
+
+    /**
+     * Delegated click handler for the all-media gallery modal: dismissal,
+     * Load more paging, and tiles opening the lightbox (which layers above
+     * the modal).
+     * @param {MouseEvent} event
+     */
+    onGalleryModalClick(event) {
+        if (event.target.closest('[data-ugc-gallery-close]')) {
+            this.closeGalleryModal();
+            return;
+        }
+
+        if (event.target.closest('[data-ugc-gallery-more]')) {
+            this._loadMoreGalleryMedia();
+            return;
+        }
+
+        const tile = event.target.closest('[data-ugc-media-tile]');
+        if (tile) {
+            this.openLightbox(tile.dataset);
+        }
+    }
+
+    /**
+     * Open the browsable gallery of every fetched media item. The panel's
+     * band stays capped — browsing all media (archetypes can carry hundreds
+     * of items) happens here instead of growing the page in place.
+     */
+    openGalleryModal() {
+        if (!this.galleryModalElement) {
+            return;
+        }
+
+        this._paintGalleryModal();
+        this.galleryModalElement.hidden = false;
+    }
+
+    closeGalleryModal() {
+        if (this.galleryModalElement) {
+            this.galleryModalElement.hidden = true;
+        }
+    }
+
+    /**
+     * Paint the modal's grid from the full fetched batch and toggle Load
+     * more on whether the server has more media-bearing reviews (§3.2.1
+     * `total` vs pages fetched).
+     */
+    _paintGalleryModal() {
+        if (!this.galleryModalElement) {
+            return;
+        }
+
+        const gridElement = this.galleryModalElement.querySelector('[data-ugc-gallery-grid]');
+        if (gridElement) {
+            gridElement.innerHTML = this.gridMedia.map((entry, index) => this._buildMediaTile(entry.media, entry.review.author, index)).join('');
+        }
+
+        const more = this.galleryModalElement.querySelector('[data-ugc-gallery-more]');
+        if (more) {
+            more.hidden = this.galleryExhausted;
+        }
+    }
+
+    /**
+     * User-driven paging from the modal's Load more button: one further
+     * §3.2.1 media=true page per click, unbounded by the band's
+     * GALLERY_MAX_PAGES top-up budget. Repaints both the modal grid and the
+     * panel band ("+N" count grows with the batch).
+     */
+    async _loadMoreGalleryMedia() {
+        const fetched = await this._fetchGalleryPage();
+
+        if (fetched) {
+            this._paintMediaGrid();
+        }
+
+        this._paintGalleryModal();
     }
 
     /**
@@ -1524,14 +1882,27 @@ export default class UgcProduct {
 
         const src = this._escapeAttr(dataset.ugcMediaSrc || '');
         const label = this._escapeAttr(dataset.ugcMediaLabel || '');
+        let media;
 
         if (dataset.ugcMediaType === 'video') {
             const poster = dataset.ugcMediaPoster ? ` poster="${this._escapeAttr(dataset.ugcMediaPoster)}"` : '';
-            content.innerHTML = `<video class="cs-ugc-lightbox-video" src="${src}"${poster} controls autoplay playsinline aria-label="${label}"></video>`;
+            media = `<video class="cs-ugc-lightbox-video" src="${src}"${poster} controls autoplay playsinline aria-label="${label}"></video>`;
         } else {
-            content.innerHTML = `<img class="cs-ugc-lightbox-img" src="${src}" alt="${label}">`;
+            media = `<img class="cs-ugc-lightbox-img" src="${src}" alt="${label}">`;
         }
 
+        // Band and gallery-modal tiles carry their gridMedia index — show the
+        // full owning review under the media. Per-review strip tiles don't
+        // (their review is already on screen).
+        let review = '';
+        const entry = dataset.ugcMediaIndex === undefined
+            ? null
+            : this.gridMedia[parseInt(dataset.ugcMediaIndex, 10)];
+        if (entry && entry.review) {
+            review = `<div class="cs-ugc-lightbox-review">${this._buildReview(entry.review, false)}</div>`;
+        }
+
+        content.innerHTML = media + review;
         this.lightboxElement.hidden = false;
     }
 
@@ -1571,8 +1942,13 @@ export default class UgcProduct {
             this.paginationElement.style.visibility = 'hidden';
         }
 
-        // No fetched reviews means no media to source — clear the grid too.
-        this.renderMediaGrid([]);
+        // The reviews list is unavailable, so hide the overview panel with it
+        // and re-arm the gallery load for the next successful render.
+        this.gridMedia = [];
+        this.galleryRequested = false;
+        this.galleryPagesFetched = 0;
+        this.galleryExhausted = false;
+        this._paintMediaGrid();
     }
 
     _buildStars(average) {
@@ -1591,7 +1967,7 @@ export default class UgcProduct {
         return count === 1 ? '1 review' : `${count} reviews`;
     }
 
-    _buildReview(review) {
+    _buildReview(review, includeMedia = true) {
         const author = this._escape(review.author) || MESSAGES.anonymous;
         const title = this._escape(review.title);
         const body = this._escape(review.body);
@@ -1603,16 +1979,21 @@ export default class UgcProduct {
         const staff = review.staff_response
             ? `<div class="cs-review-staff"><strong>CravenSpeed:</strong> ${this._escape(review.staff_response)}</div>`
             : '';
-        const media = this._buildReviewMedia(review);
+        // The lightbox renders the review beside the media itself — its strip
+        // would just be inert duplicate thumbnails there.
+        const media = includeMedia ? this._buildReviewMedia(review) : '';
 
         return `
             <article class="cs-review">
-                ${this._buildStars(review.rating || 0)}
-                ${title ? `<h3 class="cs-review-title">${title}</h3>` : ''}
+                <div class="cs-review-heading">
+                    ${date ? `<span class="cs-review-date">${date}</span>` : ''}
+                    ${this._buildStars(review.rating || 0)}
+                    <span class="cs-review-score">${review.rating || 0}</span>
+                    ${title ? `<h3 class="cs-review-title">${title}</h3>` : ''}
+                </div>
                 <p class="cs-review-meta">
                     <span class="cs-review-author">${author}</span>
                     ${verified}
-                    ${date ? `<span class="cs-review-date">${date}</span>` : ''}
                 </p>
                 ${vehicle ? `<p class="cs-review-vehicle">${vehicle}</p>` : ''}
                 <p class="cs-review-body">${body}</p>
@@ -1633,8 +2014,8 @@ export default class UgcProduct {
 
         return parsed.toLocaleDateString('en-US', {
             year: 'numeric',
-            month: 'long',
-            day: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
         });
     }
 
@@ -1662,6 +2043,10 @@ export default class UgcProduct {
     destroy() {
         if (this.unsubscribe) this.unsubscribe();
 
+        if (this.gridResizeObserver) {
+            this.gridResizeObserver.disconnect();
+        }
+
         if (this.toolbarElement) {
             this.toolbarElement.removeEventListener('change', this.onToolbarChange);
         }
@@ -1688,6 +2073,10 @@ export default class UgcProduct {
 
         if (this.lightboxElement) {
             this.lightboxElement.removeEventListener('click', this.onLightboxClick);
+        }
+
+        if (this.galleryModalElement) {
+            this.galleryModalElement.removeEventListener('click', this.onGalleryModalClick);
         }
 
         const reviewOpen = document.querySelector('[data-review-modal-open]');

--- a/assets/js/theme/_addons/product/utils/tabDeepLink.js
+++ b/assets/js/theme/_addons/product/utils/tabDeepLink.js
@@ -1,0 +1,44 @@
+/**
+ * Deep-link support for the product page tabs (#tab-reviews, #tab-shipping…).
+ *
+ * Foundation 5's own `deep_linking` option is enabled in global/foundation.js
+ * but never fires on this theme: its hash handler requires the panes to be
+ * `.content` inside `.tabs-content` (foundation.tab.js handle_location_hash_change),
+ * while the custom product tabs use `.tab-content` inside `.tabs-contents`.
+ * Clicking works (that path has no class checks), so this util resolves the
+ * location hash to the matching tab link and clicks it — same code path the
+ * user takes — then scrolls the tab strip into view.
+ */
+
+const HASH_PATTERN = /^#[\w-]+$/;
+
+function activateTabFromHash() {
+    const { hash } = window.location;
+
+    if (!hash || !HASH_PATTERN.test(hash)) {
+        return;
+    }
+
+    const link = document.querySelector(`ul.tabs a[href="${hash}"]`);
+
+    if (!link || link.closest('.tab').classList.contains('is-active')) {
+        return;
+    }
+
+    link.click();
+
+    const pane = document.querySelector(hash);
+    if (pane) {
+        pane.scrollIntoView();
+    }
+}
+
+/**
+ * Activate the tab referenced by the current location hash (direct links)
+ * and keep doing so on in-page hash changes (e.g. the rating summary's
+ * #tab-reviews anchor).
+ */
+export default function initTabDeepLink() {
+    activateTabFromHash();
+    window.addEventListener('hashchange', activateTabFromHash);
+}

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -550,6 +550,12 @@ $cs-button-height: 50px;
       margin: 0 auto;
     }
 
+    .cs-reviews,
+    .cs-questions {
+      max-width: $cs-product-max-width;
+      margin: 0 auto;
+    }
+
 
 
     .cs-product-form {
@@ -808,10 +814,14 @@ $cs-button-height: 50px;
   gap: spacing('quarter');
   font-size: 0.875rem;
 
+  // 44px min-height centers the checkbox against the selects' control row
+  // (the toolbar bottom-aligns items, so a text-height toggle would sink to
+  // the selects' baseline).
   &--toggle {
     flex-direction: row;
     align-items: center;
     gap: spacing('half');
+    min-height: 44px;
   }
 }
 
@@ -820,22 +830,8 @@ $cs-button-height: 50px;
   font-weight: 600;
 }
 
-.cs-reviews-select {
-  height: 44px;
-  font-size: 1rem;
-  padding: 0 spacing('half');
-  border: 1px solid stencilColor('color-greyLightest');
-
-  &:hover {
-    border-color: stencilColor('color-greyDark');
-  }
-
-  &:focus,
-  &:focus-visible {
-    border-color: stencilColor('color-primary');
-    outline: none;
-  }
-}
+// Visuals come from the shared .cs-form-select class (the add-to-cart option
+// dropdowns) on the same element — identical by construction.
 
 // Pagination (SRS §3.2.1 envelope counts). Reserve space rather than hiding so
 // the list does not jump when a single page collapses the control.
@@ -892,11 +888,45 @@ $cs-button-height: 50px;
 
 .cs-review {
   padding: spacing('single') 0;
-  border-bottom: 1px solid stencilColor('color-greyLightest');
+  border-bottom: 1px solid stencilColor('color-greyLighter');
 
   .cs-rating-stars {
     display: inline-flex;
   }
+}
+
+// Contrast pass: full stars keep the theme fill (brand red in the active
+// CravenSpeed variation); empties lighten so full vs empty separate cleanly.
+// Meta text steps up to greyDark below.
+.cs-reviews {
+  .icon--ratingEmpty svg {
+    fill: stencilColor('color-greyLighter');
+  }
+}
+
+// Single heading row: stars, numeric score, title, verified badge. The
+// nested title selector outranks the global `.tab-content h3` underline.
+.cs-review-heading {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: spacing('half');
+
+  .cs-review-title {
+    border-bottom: 0;
+    margin: 0;
+  }
+}
+
+// Small dark pill so the score reads as a stat, not part of the title.
+.cs-review-score {
+  font-weight: 700;
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  background: stencilColor('color-textBase');
+  color: stencilColor('color-white');
 }
 
 .cs-review-title {
@@ -909,19 +939,29 @@ $cs-button-height: 50px;
   flex-wrap: wrap;
   gap: spacing('half');
   align-items: center;
-  color: stencilColor('color-textSecondary');
+  color: stencilColor('color-greyDark');
   font-size: 0.875rem;
   margin: 0 0 spacing('half');
 }
 
+.cs-review-author {
+  color: stencilColor('color-textBase');
+  font-weight: 600;
+}
+
 .cs-review-verified {
-  color: stencilColor('color-primary');
   font-weight: 700;
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  background: rgba(30, 235, 136, 0.18); // color-success at low alpha
+  color: #067647; // dark shade of the same green; readable on the chip
 }
 
 .cs-review-date {
   font-size: 0.875rem;
-  color: stencilColor('color-textSecondary');
+  color: stencilColor('color-greyDark');
 }
 
 .cs-review-vehicle {
@@ -970,6 +1010,15 @@ $cs-button-height: 50px;
   flex-direction: column;
   gap: spacing('quarter');
   font-size: 0.875rem;
+
+  // Mirrors .cs-reviews-control--toggle: 44px min-height centers the
+  // checkbox against the select's control row.
+  &--toggle {
+    flex-direction: row;
+    align-items: center;
+    gap: spacing('half');
+    min-height: 44px;
+  }
 }
 
 .cs-questions-control-label {
@@ -977,22 +1026,8 @@ $cs-button-height: 50px;
   font-weight: 600;
 }
 
-.cs-questions-select {
-  height: 44px;
-  font-size: 1rem;
-  padding: 0 spacing('half');
-  border: 1px solid stencilColor('color-greyLightest');
-
-  &:hover {
-    border-color: stencilColor('color-greyDark');
-  }
-
-  &:focus,
-  &:focus-visible {
-    border-color: stencilColor('color-primary');
-    outline: none;
-  }
-}
+// Visuals come from the shared .cs-form-select class (the add-to-cart option
+// dropdowns) on the same element — identical by construction.
 
 .cs-questions-pagination {
   min-height: 3rem;
@@ -1272,45 +1307,216 @@ $cs-button-height: 50px;
 // lightbox.
 // =============================================================================
 
-// Populated async from fetched review media, so one tile row of space is
-// reserved and the container is revealed via visibility, never display:none
-// (CLS rule). Stays hidden — space intact — when no review carries media.
+// The reviews-overview panel (the class name predates the summary joining the
+// gallery in it). Populated async, so a floor of space is reserved and the
+// container is revealed via visibility, never display:none (CLS rule). Stays
+// hidden — space intact — when the archetype has no reviews. The summary
+// stacks above the gallery on mobile and sits beside it from medium up.
 .cs-ugc-media-grid {
   display: flex;
-  flex-wrap: wrap;
-  gap: spacing('quarter');
+  flex-direction: column;
+  gap: spacing('single');
   margin: spacing('single') 0;
+  padding: spacing('single');
+  border-radius: 0.5rem;
+  background: stencilColor('color-greyLightest');
   min-height: 4.5rem;
   visibility: hidden;
 
   @include breakpoint('medium') {
+    flex-direction: row;
+    align-items: flex-start;
     min-height: 6rem;
+  }
+
+  .cs-media-tile {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1;
+    border-color: stencilColor('color-white');
+
+    &:hover,
+    &:focus-visible {
+      border-color: stencilColor('color-primary');
+    }
+  }
+
+  .cs-media-tile--more {
+    background: stencilColor('color-white');
   }
 }
 
+// The collage: square tiles flow in an auto-fill grid and the first tile
+// features at 2×2. ugcProduct.js measures the resolved column count here to
+// fill the two-row band exactly.
+.cs-ugc-media-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(4.5rem, 1fr));
+  gap: spacing('half');
+  width: 100%;
+
+  @include breakpoint('medium') {
+    grid-template-columns: repeat(auto-fill, minmax(6rem, 1fr));
+    flex: 1;
+    min-width: 0;
+  }
+
+  .cs-media-tile:first-of-type {
+    grid-column: span 2;
+    grid-row: span 2;
+  }
+}
+
+// Archetype-wide rating summary: average rating header, then the per-score
+// histogram (§3.2.1 archetype_rating_breakdown) when the envelope serves it.
+// Full-width above the gallery on mobile; a fixed left column beside it from
+// medium up, stretched to the gallery band's height so the histogram can
+// distribute through it.
+.cs-ugc-media-grid-summary {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('half');
+
+  @include breakpoint('medium') {
+    flex: 0 0 20rem;
+    align-self: stretch;
+    justify-content: center;
+  }
+}
+
+// Outsized header row: the panel's focal stat. Sprite stars need explicit
+// dimensions here (the theme has no global .icon sizing).
+.cs-ugc-summary-rating {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: spacing('half');
+
+  @include breakpoint('medium') {
+    justify-content: center;
+  }
+
+  .icon {
+    width: 1.5rem;
+    height: 1.5rem;
+
+    @include breakpoint('medium') {
+      width: 1.75rem;
+      height: 1.75rem;
+    }
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
+}
+
+.cs-ugc-summary-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 100%;
+  max-width: 20rem;
+
+  @include breakpoint('medium') {
+    gap: 0.75rem;
+  }
+}
+
+.cs-ugc-breakdown-row {
+  display: flex;
+  align-items: center;
+  gap: spacing('half');
+  font-size: 0.875rem;
+
+  @include breakpoint('medium') {
+    font-size: 1rem;
+  }
+}
+
+.cs-ugc-breakdown-label {
+  min-width: 2rem;
+}
+
+.cs-ugc-breakdown-bar {
+  flex: 1;
+  height: 0.5rem;
+  overflow: hidden;
+  border-radius: 0.25rem;
+  background: stencilColor('color-white');
+
+  @include breakpoint('medium') {
+    height: 1rem;
+    border-radius: 0.5rem;
+  }
+}
+
+.cs-ugc-breakdown-fill {
+  display: block;
+  height: 100%;
+  background: stencilColor('color-primary');
+}
+
+.cs-ugc-breakdown-count {
+  min-width: 1.5rem;
+  text-align: right;
+  color: stencilColor('color-greyDark');
+}
+
+.cs-ugc-summary-average {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+
+  @include breakpoint('medium') {
+    font-size: 2.5rem;
+  }
+}
+
+.cs-ugc-summary-count {
+  color: stencilColor('color-greyDark');
+}
+
+// Painted by ugcProduct.js alongside the tiles; spans the full grid row so
+// the tiles flow beneath it. The global .tab-content heading underline reads
+// as a stray rule inside the panel, so it is dropped here (the descendant
+// selector outranks `.tab-content h3`).
+.cs-ugc-media-gallery .cs-ugc-media-grid-title {
+  grid-column: 1 / -1;
+  border-bottom: 0;
+  font-size: 1.125rem;
+  margin: 0;
+}
+
 // Per-review strip after the review body. Renders only when the review has
-// media, inside an already-async list, so no space reservation is needed here.
+// media, inside an already-async list, so no space reservation is needed
+// here. Tiles keep a fixed thumbnail size in this context.
 .cs-review-media {
   display: flex;
   flex-wrap: wrap;
   gap: spacing('quarter');
   margin-top: spacing('half');
+
+  .cs-media-tile {
+    width: 4.5rem;
+    height: 4.5rem;
+
+    @include breakpoint('medium') {
+      width: 6rem;
+      height: 6rem;
+    }
+  }
 }
 
 .cs-media-tile {
   position: relative;
-  width: 4.5rem;
-  height: 4.5rem;
   padding: 0;
   overflow: hidden;
   border: 1px solid stencilColor('color-greyLightest');
+  border-radius: 0.375rem;
   background: stencilColor('color-greyLightest');
   cursor: pointer;
-
-  @include breakpoint('medium') {
-    width: 6rem;
-    height: 6rem;
-  }
 
   &:hover,
   &:focus-visible {
@@ -1324,6 +1530,23 @@ $cs-button-height: 50px;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.cs-media-tile:hover .cs-media-tile-thumb,
+.cs-media-tile:focus-visible .cs-media-tile-thumb {
+  transform: scale(1.05);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cs-media-tile-thumb {
+    transition: none;
+  }
+
+  .cs-media-tile:hover .cs-media-tile-thumb,
+  .cs-media-tile:focus-visible .cs-media-tile-thumb {
+    transform: none;
+  }
 }
 
 // Play affordance overlaid on a video tile's poster thumbnail.
@@ -1361,8 +1584,69 @@ $cs-button-height: 50px;
 
 // Shared media lightbox: reuses the cs-ugc-modal shell; centers the media and
 // widens the dialog so photos/video get room on desktop.
+// Browsable all-media gallery modal, opened from the panel's "+N" tile.
+// Tiles inside reuse .cs-media-tile; clicking one opens the lightbox, which
+// layers above this modal.
+.cs-ugc-gallery-dialog {
+  width: 100%;
+  max-width: 60rem;
+}
+
+.cs-ugc-gallery-title {
+  margin: 0 0 spacing('half');
+  font-size: 1.125rem;
+}
+
+.cs-ugc-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(4.5rem, 1fr));
+  gap: spacing('half');
+  max-height: 60vh;
+  overflow-y: auto;
+
+  @include breakpoint('medium') {
+    grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+  }
+
+  .cs-media-tile {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1;
+  }
+}
+
+.cs-ugc-gallery-footer {
+  display: flex;
+  justify-content: center;
+  margin-top: spacing('half');
+
+  > [hidden] {
+    display: none;
+  }
+}
+
 .cs-ugc-lightbox {
   align-items: center;
+
+  // Above the gallery modal (.cs-ugc-modal base is 1000), so a tile clicked
+  // inside it opens the viewer on top.
+  z-index: 1010;
+}
+
+// Full owning review rendered under the media for band / gallery-modal
+// tiles. Scrolls on its own so a long review never pushes the media off
+// screen.
+.cs-ugc-lightbox-review {
+  width: 100%;
+  margin-top: spacing('half');
+  max-height: 30vh;
+  overflow-y: auto;
+  text-align: left;
+
+  .cs-review {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
 }
 
 .cs-ugc-lightbox-dialog {
@@ -1374,9 +1658,11 @@ $cs-button-height: 50px;
   }
 }
 
+// Column stack: media on top, the owning review (when present) beneath.
 .cs-ugc-lightbox-content {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   min-height: 4.5rem;
 }
 
@@ -1384,5 +1670,5 @@ $cs-button-height: 50px;
 .cs-ugc-lightbox-video {
   display: block;
   max-width: 100%;
-  max-height: 80vh;
+  max-height: 60vh;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -763,6 +763,7 @@
             "filter_rating_all": "All ratings",
             "filter_verified": "Verified purchasers",
             "filter_media": "With photos & videos",
+            "filter_vehicle_first": "My vehicle first",
             "form_write": {
                 "name": "Name",
                 "email": "Email",
@@ -793,6 +794,7 @@
         "questions": {
             "header": "Q&A",
             "sort_label": "Sort by",
+            "filter_vehicle_first": "My vehicle first",
             "sort_newest": "Newest",
             "sort_oldest": "Oldest",
             "submit": {

--- a/templates/components/products-cs/qa-cs.html
+++ b/templates/components/products-cs/qa-cs.html
@@ -2,10 +2,16 @@
     <div class="cs-questions-toolbar" data-questions-toolbar>
         <label class="cs-questions-control cs-questions-control--sort">
             <span class="cs-questions-control-label">{{lang 'products.questions.sort_label'}}</span>
-            <select class="cs-questions-select" data-questions-control="sort">
+            <select class="cs-questions-select cs-form-select" data-questions-control="sort">
                 <option value="date_desc">{{lang 'products.questions.sort_newest'}}</option>
                 <option value="date_asc">{{lang 'products.questions.sort_oldest'}}</option>
             </select>
+        </label>
+        {{!-- Opt-in alias-aware sort: disabled until a vehicle is selected;
+        ugcProduct.js enables it and mirrors it with the reviews toolbar's copy. --}}
+        <label class="cs-questions-control cs-questions-control--toggle">
+            <input type="checkbox" data-questions-control="vehicle_first" disabled>
+            <span class="cs-questions-control-label">{{lang 'products.questions.filter_vehicle_first'}}</span>
         </label>
         <button type="button" class="button button--primary cs-ugc-submit-open" data-question-modal-open>
             {{lang 'products.questions.submit.open'}}

--- a/templates/components/products-cs/reviews-cs.html
+++ b/templates/components/products-cs/reviews-cs.html
@@ -1,8 +1,14 @@
 <div class="cs-reviews" data-reviews>
+    {{!-- UGC reviews-overview panel: archetype rating summary + customer
+    media grid (SRS §3.4.1). Populated async by ugcProduct.js; space is
+    reserved via min-height + visibility:hidden in SCSS so the late paint
+    never shifts layout. --}}
+    <section class="cs-ugc-media-grid" aria-label="Reviews overview" data-ugc-media-grid></section>
+
     <div class="cs-reviews-toolbar" data-reviews-toolbar>
         <label class="cs-reviews-control cs-reviews-control--sort">
             <span class="cs-reviews-control-label">{{lang 'products.reviews.sort_label'}}</span>
-            <select class="cs-reviews-select" data-reviews-control="sort">
+            <select class="cs-reviews-select cs-form-select" data-reviews-control="sort">
                 <option value="date_desc">{{lang 'products.reviews.sort_newest'}}</option>
                 <option value="date_asc">{{lang 'products.reviews.sort_oldest'}}</option>
                 <option value="rating_desc">{{lang 'products.reviews.sort_rating_high'}}</option>
@@ -11,7 +17,7 @@
         </label>
         <label class="cs-reviews-control cs-reviews-control--rating">
             <span class="cs-reviews-control-label">{{lang 'products.reviews.filter_rating'}}</span>
-            <select class="cs-reviews-select" data-reviews-control="rating">
+            <select class="cs-reviews-select cs-form-select" data-reviews-control="rating">
                 <option value="">{{lang 'products.reviews.filter_rating_all'}}</option>
                 <option value="5">5</option>
                 <option value="4">4</option>
@@ -27,6 +33,12 @@
         <label class="cs-reviews-control cs-reviews-control--toggle">
             <input type="checkbox" data-reviews-control="media">
             <span class="cs-reviews-control-label">{{lang 'products.reviews.filter_media'}}</span>
+        </label>
+        {{!-- Opt-in alias-aware sort: disabled until a vehicle is selected;
+        ugcProduct.js enables it and mirrors it with the Q&A toolbar's copy. --}}
+        <label class="cs-reviews-control cs-reviews-control--toggle">
+            <input type="checkbox" data-reviews-control="vehicle_first" disabled>
+            <span class="cs-reviews-control-label">{{lang 'products.reviews.filter_vehicle_first'}}</span>
         </label>
         <button type="button" class="button button--primary cs-ugc-submit-open" data-review-modal-open>
             {{lang 'products.reviews.submit.open'}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -90,16 +90,25 @@
         </div>
 
 
-        {{!-- =====================================================================
-        // UGC review media (SRS §3.4.1 ordering: rating summary → photo
-        // thumbnail grid → review/question tabs). Populated async from fetched
-        // review media by ugcProduct.js; space is reserved via min-height +
-        // visibility:hidden in SCSS so the late paint never shifts layout.
-        // ===================================================================== --}}
-        <section class="cs-ugc-media-grid" aria-label="Customer photos and videos" data-ugc-media-grid></section>
+        {{!-- Browsable gallery of all customer media, opened from the
+        overview panel's "+N" tile. Pages in further media-bearing reviews on
+        demand via the Load more button. Toggled via the `hidden` attribute
+        from ugcProduct.js. --}}
+        <div class="cs-ugc-modal cs-ugc-gallery-modal" data-ugc-gallery hidden>
+            <div class="cs-ugc-modal-overlay" data-ugc-gallery-close></div>
+            <div class="cs-ugc-modal-dialog cs-ugc-gallery-dialog" role="dialog" aria-modal="true" aria-label="Customer photos and videos">
+                <button type="button" class="cs-ugc-modal-close" data-ugc-gallery-close aria-label="Close">&times;</button>
+                <h3 class="cs-ugc-gallery-title">Customer Photos &amp; Videos</h3>
+                <div class="cs-ugc-gallery-grid" data-ugc-gallery-grid></div>
+                <div class="cs-ugc-gallery-footer">
+                    <button type="button" class="button" data-ugc-gallery-more hidden>Load more</button>
+                </div>
+            </div>
+        </div>
 
-        {{!-- Shared media lightbox for the grid and per-review thumbnails.
-        Toggled via the `hidden` attribute from ugcProduct.js. --}}
+        {{!-- Shared media lightbox for the review media grid (in the Reviews
+        tab) and per-review thumbnails. Toggled via the `hidden` attribute
+        from ugcProduct.js. --}}
         <div class="cs-ugc-modal cs-ugc-lightbox" data-ugc-lightbox hidden>
             <div class="cs-ugc-modal-overlay" data-ugc-lightbox-close></div>
             <div class="cs-ugc-modal-dialog cs-ugc-lightbox-dialog" role="dialog" aria-modal="true" aria-label="Review media">


### PR DESCRIPTION
Follow-up iteration pass from the 2026-06-05 live QA session, on top of #32 + #33.

## Changes

- **Reviews overview panel**: media grid moved inside the Reviews tab; archetype rating summary header + per-score histogram (SRS Pass 23 `archetype_rating_breakdown`, renders only when served); summary column beside the gallery from `medium` up
- **Gallery**: decoupled into its own data batch (`media=true & sort=date_desc`); fixed-height two-row collage band sized from measured grid columns (ResizeObserver); "+N" opens a browsable gallery modal with Load-more paging; lightbox stacks above and shows the full owning review
- **Review cards**: restructured — date / stars / score pill / title heading, author + green verified chip, vehicle line, MM/DD/YYYY dates; contrast pass (lighter empty stars, darker meta text, clearer separators)
- **Toolbar**: selects share `cs-form-select` with the add-to-cart dropdowns; checkbox rows aligned to the 44px control height
- **Tab deep-linking fix** (`tabDeepLink.js` + spec): Foundation's `deep_linking` never fired due to the `.tab-content`/`.tabs-contents` class mismatch

## Notes

- An SRS revision around the vehicle/reviews integration is expected from cs-ugc; if it lands before merge, this PR should be re-checked against it.
- `npx grunt check` passing (ESLint, Jest, stylelint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)