### PR TITLE
M6 follow-up #145: render "Edited by CravenSpeed" marker from public `edited` flag

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -187,6 +187,43 @@ describe('UgcProduct (slice 6a)', () => {
         expect(list.querySelectorAll('.cs-review-verified')).toHaveLength(1);
     });
 
+    it('renders the "Edited by CravenSpeed" marker only when edited === true (SRS §3.2.1, #145)', async () => {
+        const api = buildApi({
+            ok: true,
+            status: 200,
+            data: buildEnvelope({
+                items: [
+                    // edited === true → marker shown.
+                    {
+                        id: 1, author: 'A', rating: 5, title: 't', body: 'b',
+                        date: '2026-01-15T00:00:00Z', edited: true,
+                    },
+                    // edited === false → nothing.
+                    {
+                        id: 2, author: 'B', rating: 4, title: 't', body: 'b',
+                        date: '2026-02-01T00:00:00Z', edited: false,
+                    },
+                    // field absent (older payload) → defensive no-render, card intact.
+                    {
+                        id: 3, author: 'C', rating: 3, title: 't', body: 'b',
+                        date: '2026-03-01T00:00:00Z',
+                    },
+                ],
+            }),
+        });
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        await flush();
+
+        const list = document.querySelector('#product-reviews');
+        // Exactly one marker — only the edited === true review.
+        const markers = list.querySelectorAll('.cs-review-edited');
+        expect(markers).toHaveLength(1);
+        expect(markers[0].textContent).toEqual('Edited by CravenSpeed');
+        // The absent-field card still rendered fully (no break on missing flag).
+        expect(list.querySelectorAll('.cs-review')).toHaveLength(3);
+    });
+
     it('renders the "no reviews yet" state when archetype_rating_average is null', async () => {
         const api = buildApi({
             ok: true,

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -1976,6 +1976,14 @@ export default class UgcProduct {
         const verified = review.verified_purchaser
             ? '<span class="cs-review-verified">Verified Purchaser</span>'
             : '';
+        // Public disclosure that staff edited this review's content (SRS §3.2.1
+        // `edited` / §3.1.1, cs-ugc #145). Strict `=== true` so a missing field
+        // on an older payload is treated as false and nothing renders — the card
+        // must never break on an absent flag, and it never reveals who edited or
+        // how many times (only the derived boolean is exposed).
+        const edited = review.edited === true
+            ? '<span class="cs-review-edited">Edited by CravenSpeed</span>'
+            : '';
         const staff = review.staff_response
             ? `<div class="cs-review-staff"><strong>CravenSpeed:</strong> ${this._escape(review.staff_response)}</div>`
             : '';
@@ -1994,6 +2002,7 @@ export default class UgcProduct {
                 <p class="cs-review-meta">
                     <span class="cs-review-author">${author}</span>
                     ${verified}
+                    ${edited}
                 </p>
                 ${vehicle ? `<p class="cs-review-vehicle">${vehicle}</p>` : ''}
                 <p class="cs-review-body">${body}</p>

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -959,6 +959,19 @@ $cs-button-height: 50px;
   color: #067647; // dark shade of the same green; readable on the chip
 }
 
+// Disclosure marker, not a positive badge (cs-ugc #145, SRS §3.1.1): staff
+// edited this review's content. Deliberately muted/neutral so it reads as
+// transparency, distinct from the green "Verified Purchaser" chip above.
+.cs-review-edited {
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  background: stencilColor('color-greyLightest');
+  color: stencilColor('color-greyDarker'); // #333 on #e5e5e5 clears WCAG AA
+  font-style: italic;
+}
+
 .cs-review-date {
   font-size: 0.875rem;
   color: stencilColor('color-greyDark');


### PR DESCRIPTION
Tracking issue: **CravenSpeed/cs-ugc#145** (storefront half). cs-ugc owns the contract (SRS §3.2.1 / §3.1.1); this is the storefront execution. Targets the `cs-ugc-frontend` M6 integration branch.

## What & why

The public review object (SRS §3.2.1) now carries a boolean `edited` that discloses *that* staff altered a review's content — without exposing who edited it or how many times. This renders the **"Edited by CravenSpeed"** marker on the review card from that flag. It's the FTC-relevant public disclosure required by §3.1.1; the previous spec promised the marker but had no field to drive it (cs-ugc Pass 22 / #143 added the field; #144 emits it).

## Acceptance criteria (issue #145)

- [x] Review card shows an "Edited by CravenSpeed" marker when `edited === true`, nothing when `false`/absent — `ugcProduct.js` `_buildReview` (the `edited` const + placement in `cs-review-meta`).
- [x] Defensive: a missing `edited` field is treated as `false`; the card does not break — strict `review.edited === true` check.
- [x] Unit-tested against the §3.2.1 contract — `ugcProduct.spec.js`: one envelope exercising `true` / `false` / absent, asserting exactly one marker, its text, and that all three cards still render.

## Contract fidelity

Only the public `edited` boolean is consumed — never the admin-only `edited_count` / `last_edited_by` / `last_edited_at`. The marker also renders correctly on the lightbox's full-review path (`_buildReview(entry.review, false)`).

## Styling

`.cs-review-edited` is a muted neutral italic chip (`color-greyDarker` on `color-greyLightest`, #333 on #e5e5e5 — clears WCAG AA), deliberately distinct from the green **Verified Purchaser** badge so it reads as transparency rather than a positive badge.

## Verification

- `npx jest ugcProduct` → **112 passed** (incl. the new marker test).
- `eslint` on the changed source file: clean.

## Out of scope

Live verification — the marker visible on a review actually edited via the QTY moderation UI in production — is tracked on the **M11 live-verification checklist (cs-ugc#163)**, not this PR. Per the closeable-on-core-work convention, cs-ugc#145 closes when this merges.