### PR TITLE
M9 #175: tolerant registry generation-node read (string-or-object shim)

### DIFF
--- a/assets/js/test-unit/theme/global/searchEngine.spec.js
+++ b/assets/js/test-unit/theme/global/searchEngine.spec.js
@@ -1,0 +1,54 @@
+import SearchEngine from '../../../theme/_addons/global/search/searchEngine';
+
+// cs-ugc #175: the registry's vehicle_registry generation nodes are migrating
+// from a bare string label to an object { name, fitment_id } (UGC-SRS §3.1.4 /
+// change-log Pass 27). These tests pin the tolerant-read shim: the live store
+// must render correct labels whether a generation node is a string OR an object,
+// with no behavior change while QTY still publishes strings.
+
+const buildRegistry = (generationNode) => ({
+    vehicle_registry: {
+        brands: {
+            mini: { name: 'MINI', models: ['cooper'] },
+        },
+        models: {
+            cooper: {
+                name: 'Cooper',
+                generations: { f56: generationNode },
+            },
+        },
+    },
+    products: [],
+});
+
+const STRING_NODE = 'F56 2014 to 2019';
+const OBJECT_NODE = { name: 'F56 2014 to 2019', fitment_id: 87 };
+
+describe('SearchEngine registry generation-node tolerance (cs-ugc #175 / SRS Pass 27)', () => {
+    describe('getVehicleName()', () => {
+        it('resolves the generation label from a bare-string node (current live shape)', () => {
+            const engine = new SearchEngine(buildRegistry(STRING_NODE));
+            expect(engine.getVehicleName('mini', 'cooper', 'f56')).toBe('MINI Cooper F56 2014 to 2019');
+        });
+
+        it('resolves the generation label from a { name, fitment_id } object node (post-flip shape)', () => {
+            const engine = new SearchEngine(buildRegistry(OBJECT_NODE));
+            expect(engine.getVehicleName('mini', 'cooper', 'f56')).toBe('MINI Cooper F56 2014 to 2019');
+        });
+    });
+
+    describe('vehicle search index', () => {
+        it('indexes the generation label token from a bare-string node', () => {
+            const engine = new SearchEngine(buildRegistry(STRING_NODE));
+            expect(engine.vehicleIndex.f56).toBeDefined();
+            expect(Array.from(engine.vehicleIndex.f56)).toContain('f56');
+        });
+
+        it('indexes the generation label from an object node without throwing (pre-shim this crashed on .toLowerCase)', () => {
+            let engine;
+            expect(() => { engine = new SearchEngine(buildRegistry(OBJECT_NODE)); }).not.toThrow();
+            expect(engine.vehicleIndex.f56).toBeDefined();
+            expect(Array.from(engine.vehicleIndex.f56)).toContain('f56');
+        });
+    });
+});

--- a/assets/js/theme/_addons/global/search/searchEngine.js
+++ b/assets/js/theme/_addons/global/search/searchEngine.js
@@ -1,3 +1,8 @@
+// cs-ugc #175 shim: registry generation nodes are migrating from a bare string
+// label to { name, fitment_id } (UGC-SRS §3.1.4 / change-log Pass 27). Tolerate
+// either shape until the object-only cutover overwrites these reads; retires then.
+const generationLabel = (node) => (node && typeof node === 'object' ? node.name : node);
+
 export default class SearchEngine {
     constructor(data) {
         this.data = data || {};
@@ -107,7 +112,7 @@ export default class SearchEngine {
         if (modelSlug && registry.models && registry.models[modelSlug]) {
             modelName = registry.models[modelSlug].name || modelSlug;
             if (genSlug && registry.models[modelSlug].generations && registry.models[modelSlug].generations[genSlug]) {
-                genName = registry.models[modelSlug].generations[genSlug];
+                genName = generationLabel(registry.models[modelSlug].generations[genSlug]);
             }
         }
 
@@ -235,8 +240,8 @@ export default class SearchEngine {
                 if (modelData.name) addIds(modelData.name, ids);
 
                 if (modelData.generations) {
-                    Object.entries(modelData.generations).forEach(([genId, genName]) => {
-                        addIds(genName, [genId]);
+                    Object.entries(modelData.generations).forEach(([genId, genNode]) => {
+                        addIds(generationLabel(genNode), [genId]);
                     });
                 }
             });

--- a/assets/js/theme/_addons/home/vehicleSelector.js
+++ b/assets/js/theme/_addons/home/vehicleSelector.js
@@ -1,6 +1,11 @@
 import StateManager from '../global/stateManager';
 import VehiclePersistence from '../global/vehiclePersistence';
 
+// cs-ugc #175 shim: registry generation nodes are migrating from a bare string
+// label to { name, fitment_id } (UGC-SRS §3.1.4 / change-log Pass 27). Tolerate
+// either shape until the object-only cutover overwrites these reads; retires then.
+const generationLabel = (node) => (node && typeof node === 'object' ? node.name : node);
+
 export default class VehicleSelector {
     constructor(context) {
         this.context = context;
@@ -111,7 +116,7 @@ export default class VehicleSelector {
             const modelSlug = this.modelSelect.value;
             if (modelSlug && this.registry.models[modelSlug]) {
                 const generations = this.registry.models[modelSlug].generations || {};
-                const gens = Object.entries(generations).map(([id, name]) => ({ id, name }))
+                const gens = Object.entries(generations).map(([id, node]) => ({ id, name: generationLabel(node) }))
                     .sort((a, b) => b.name.localeCompare(a.name)); // Sort descending by name
                 gens.forEach(g => this.addOption(this.yearSelect, g.id, g.name));
 


### PR DESCRIPTION
Closes #175.

**Target: live theme `master`** (the issue/SRS say "main" — this repo has no `main`; live default is `master`). Ships first, does nothing visible, exists only so the live store survives QTY's `vehicle_registry` string→object flip (#157).

## What & why
QTY is moving each `vehicle_registry` generation node in `cravenspeed-global-search.json` from a bare string label to `{ name, fitment_id }` (UGC-SRS §3.1.4 / change-log Pass 27). The live store reads it as a string — and `searchEngine`'s index build calls `.toLowerCase()` on it, so an object would **crash**, not merely render `[object Object]`. This makes the reads tolerant of either shape.

Single helper, three read sites:
```js
const generationLabel = (node) => (node && typeof node === 'object' ? node.name : node);
```
- `searchEngine.js` — `getVehicleName()` display name (`:111`) + vehicle index build (`:240`, the crash site)
- `vehicleSelector.js` — garage year dropdown (`:120`)

Display-only: `fitment_id` is ignored here. The `make_model_index` reads in `urlResolver.js`/`stateManager.js` are a **different structure** (archetype tree, not the registry, not flipping) and are intentionally untouched.

## Acceptance criteria
- [x] Garage dropdown + vehicle search render correct labels whether a generation node is a string **or** `{ name, fitment_id }` — `searchEngine.spec.js`
- [x] No behavior change while QTY still publishes strings (helper returns strings unchanged)
- [x] Based on live `master` (gate for QTY registry flip #157)

## Tests
New `assets/js/test-unit/theme/global/searchEngine.spec.js`: both shapes for `getVehicleName` + the index build (incl. "object node no longer throws"). Full suite green: **120/120**.

## Lifecycle
Throwaway scaffolding — retires when the object-only `cs-ugc-frontend` cutover overwrites these reads. No "remove shim" task; the cutover removes it. Ordering gate: this shim live → QTY flip → cs-ugc cutover (cs-ugc #163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)