### PR TITLE
M9 #158 Foundation: object-only fitment resolution

### DIFF
--- a/assets/js/test-unit/theme/global/searchEngine.spec.js
+++ b/assets/js/test-unit/theme/global/searchEngine.spec.js
@@ -1,0 +1,72 @@
+import SearchEngine from '../../../theme/_addons/global/search/searchEngine';
+
+// Object-only search-JSON registry (SRS §3.1.4 / Pass 27): each generation node
+// is the canonical { name, fitment_id }. This branch reads it object-only — the
+// tolerant string-or-object shim (#175) is retired at cutover, not carried here.
+const data = {
+    products: [
+        {
+            url: '/license-plate-mount/',
+            title: 'License Plate Mount',
+            sku: 'CS-AB828',
+            compatibility_ids: ['cooperf56'],
+            sort_order: 1,
+        },
+    ],
+    vehicle_registry: {
+        brands: {
+            mini: { name: 'MINI', models: ['cooper'] },
+        },
+        models: {
+            cooper: {
+                name: 'Cooper',
+                generations: {
+                    cooperf56: { name: 'MINI Cooper F56', fitment_id: 87 },
+                    cooperr56: { name: 'MINI Cooper R56', fitment_id: 42 },
+                },
+            },
+        },
+    },
+};
+
+describe('SearchEngine (object-only registry)', () => {
+    describe('getVehicleName', () => {
+        it('reads the generation label off the object node', () => {
+            const engine = new SearchEngine(data);
+            // make name + model name + generation node's `name` field.
+            expect(engine.getVehicleName('mini', 'cooper', 'cooperf56')).toBe('MINI Cooper MINI Cooper F56');
+        });
+
+        it('falls back to the generation slug when the object node has no name', () => {
+            const partial = {
+                products: [],
+                vehicle_registry: {
+                    brands: { mini: { name: 'MINI', models: ['cooper'] } },
+                    models: { cooper: { name: 'Cooper', generations: { cooperf56: { fitment_id: 87 } } } },
+                },
+            };
+            const engine = new SearchEngine(partial);
+            expect(engine.getVehicleName('mini', 'cooper', 'cooperf56')).toBe('MINI Cooper cooperf56');
+        });
+    });
+
+    describe('vehicle index from object nodes', () => {
+        it('indexes the generation label so a vehicle query matches', () => {
+            const engine = new SearchEngine(data);
+            const results = engine.search('F56');
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].sku).toBe('CS-AB828');
+        });
+
+        it('does not throw when a generation node is missing its name', () => {
+            const partial = {
+                products: [],
+                vehicle_registry: {
+                    brands: { mini: { name: 'MINI', models: ['cooper'] } },
+                    models: { cooper: { name: 'Cooper', generations: { cooperf56: { fitment_id: 87 } } } },
+                },
+            };
+            expect(() => new SearchEngine(partial)).not.toThrow();
+        });
+    });
+});

--- a/assets/js/test-unit/theme/global/ugcApi.spec.js
+++ b/assets/js/test-unit/theme/global/ugcApi.spec.js
@@ -39,13 +39,37 @@ describe('ugcApi', () => {
             const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, body)));
             const api = makeApi(fetchImpl);
 
-            const result = await api.getReviews(12, { page: 2, sort: 'rating_desc', sort_alias: 4821 });
+            const result = await api.getReviews(12, { page: 2, sort: 'rating_desc', fitment_id: 87 });
 
             expect(fetchImpl).toHaveBeenCalledWith(
-                `${API}/reviews/12?page=2&sort=rating_desc&sort_alias=4821`,
+                `${API}/reviews/12?page=2&sort=rating_desc&fitment_id=87`,
                 { cache: 'no-cache' },
             );
             expect(result).toEqual({ ok: true, status: 200, data: body });
+        });
+
+        it('getReviews passes the fitment filter params (fitment_id + fitment_only)', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, {})));
+            const api = makeApi(fetchImpl);
+
+            await api.getReviews(12, { fitment_id: 87, fitment_only: true });
+
+            expect(fetchImpl).toHaveBeenCalledWith(
+                `${API}/reviews/12?fitment_id=87&fitment_only=true`,
+                { cache: 'no-cache' },
+            );
+        });
+
+        it('getQuestions passes the fitment filter params (fitment_id + fitment_only)', async () => {
+            const fetchImpl = jest.fn(() => Promise.resolve(mockResponse(200, { items: [] })));
+            const api = makeApi(fetchImpl);
+
+            await api.getQuestions(12, { fitment_id: 87, fitment_only: true });
+
+            expect(fetchImpl).toHaveBeenCalledWith(
+                `${API}/questions/12?fitment_id=87&fitment_only=true`,
+                { cache: 'no-cache' },
+            );
         });
 
         it('getReviews omits null/undefined/empty params', async () => {

--- a/assets/js/test-unit/theme/global/vehicleFitment.spec.js
+++ b/assets/js/test-unit/theme/global/vehicleFitment.spec.js
@@ -1,0 +1,159 @@
+import {
+    generationLabel,
+    generationFitmentId,
+    resolveGarageFitment,
+    fitmentIdToLabel,
+    buildArchetypeFitmentList,
+} from '../../../theme/_addons/global/vehicleFitment';
+
+// Object-only search-JSON vehicle_registry (SRS §3.1.4 / Pass 27): every
+// generation node is the canonical { name, fitment_id }. Model/generation maps
+// are keyed by bare slug (the slugs the vehicle selector persists).
+const registry = {
+    brands: {
+        mini: { name: 'MINI', models: ['cooper'] },
+    },
+    models: {
+        cooper: {
+            name: 'Cooper',
+            generations: {
+                cooperf56: { name: 'MINI Cooper F56', fitment_id: 87 },
+                cooperr56: { name: 'MINI Cooper R56', fitment_id: 42 },
+                coopernoid: { name: 'MINI Cooper (unmapped)', fitment_id: null },
+            },
+        },
+    },
+};
+
+describe('vehicleFitment', () => {
+    describe('generationLabel', () => {
+        it('reads name off the object node', () => {
+            expect(generationLabel({ name: 'MINI Cooper F56', fitment_id: 87 })).toBe('MINI Cooper F56');
+        });
+
+        it('returns null for null/undefined/string/missing-name nodes', () => {
+            expect(generationLabel(null)).toBeNull();
+            expect(generationLabel(undefined)).toBeNull();
+            expect(generationLabel('MINI Cooper F56')).toBeNull();
+            expect(generationLabel({ fitment_id: 87 })).toBeNull();
+        });
+    });
+
+    describe('generationFitmentId', () => {
+        it('reads an integer fitment_id', () => {
+            expect(generationFitmentId({ name: 'x', fitment_id: 87 })).toBe(87);
+        });
+
+        it('returns null when fitment_id is null/absent/non-numeric', () => {
+            expect(generationFitmentId({ name: 'x', fitment_id: null })).toBeNull();
+            expect(generationFitmentId({ name: 'x' })).toBeNull();
+            expect(generationFitmentId({ name: 'x', fitment_id: 'nope' })).toBeNull();
+            expect(generationFitmentId(null)).toBeNull();
+        });
+    });
+
+    describe('resolveGarageFitment', () => {
+        it('resolves a complete garage selection to fitment_id + label', () => {
+            const result = resolveGarageFitment(registry, { make: 'mini', model: 'cooper', generation: 'cooperf56' });
+            expect(result).toEqual({ fitment_id: 87, label: 'MINI Cooper F56' });
+        });
+
+        it('returns null fitment_id (un-filterable) when the node has no id, label still resolves', () => {
+            const result = resolveGarageFitment(registry, { make: 'mini', model: 'cooper', generation: 'coopernoid' });
+            expect(result).toEqual({ fitment_id: null, label: 'MINI Cooper (unmapped)' });
+        });
+
+        it('returns null for an incomplete garage selection', () => {
+            expect(resolveGarageFitment(registry, { make: 'mini', model: 'cooper' })).toBeNull();
+            expect(resolveGarageFitment(registry, null)).toBeNull();
+        });
+
+        it('returns null when the model/generation slug is not in the registry', () => {
+            expect(resolveGarageFitment(registry, { make: 'mini', model: 'nope', generation: 'cooperf56' })).toBeNull();
+            expect(resolveGarageFitment(registry, { make: 'mini', model: 'cooper', generation: 'nope' })).toBeNull();
+        });
+
+        it('returns null when there is no registry', () => {
+            expect(resolveGarageFitment(null, { make: 'mini', model: 'cooper', generation: 'cooperf56' })).toBeNull();
+        });
+
+        it('falls back to the generation slug as label when the node carries no name', () => {
+            const noName = { models: { cooper: { generations: { cooperf56: { fitment_id: 87 } } } } };
+            const result = resolveGarageFitment(noName, { make: 'mini', model: 'cooper', generation: 'cooperf56' });
+            expect(result).toEqual({ fitment_id: 87, label: 'cooperf56' });
+        });
+    });
+
+    describe('fitmentIdToLabel', () => {
+        it('resolves a known fitment_id to its label', () => {
+            expect(fitmentIdToLabel(registry, 42)).toBe('MINI Cooper R56');
+        });
+
+        it('returns null for an unknown id, a null id, or a missing registry', () => {
+            expect(fitmentIdToLabel(registry, 999)).toBeNull();
+            expect(fitmentIdToLabel(registry, null)).toBeNull();
+            expect(fitmentIdToLabel(null, 42)).toBeNull();
+        });
+    });
+
+    describe('buildArchetypeFitmentList', () => {
+        // Archetype JSON make_model_index: model/generation maps keyed with a
+        // make-slug prefix; generation nodes are objects with name + fitment_id
+        // plus the option/alias subtree.
+        const archetype = {
+            make_model_index: {
+                mini: {
+                    name: 'MINI',
+                    models: {
+                        minicooper: {
+                            name: 'Cooper',
+                            generations: {
+                                minicooperf56: { name: 'F56 2014-2024', fitment_id: 87, alias: 'a.json' },
+                                minicooperr56: { name: 'R56 2007-2013', fitment_id: 42, alias: 'b.json' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        it('flattens the archetype tree into make/model/generation rows with stripped slugs', () => {
+            const list = buildArchetypeFitmentList(archetype);
+            expect(list).toHaveLength(2);
+            expect(list[0]).toEqual({
+                make: 'mini',
+                model: 'cooper',
+                generation: 'cooperf56',
+                makeLabel: 'MINI',
+                modelLabel: 'Cooper',
+                generationLabel: 'F56 2014-2024',
+                label: 'MINI Cooper F56 2014-2024',
+                fitment_id: 87,
+            });
+            expect(list[1].fitment_id).toBe(42);
+        });
+
+        it('carries a null fitment_id through for an unmapped generation', () => {
+            const a = {
+                make_model_index: {
+                    mini: {
+                        name: 'MINI',
+                        models: {
+                            minicooper: {
+                                name: 'Cooper',
+                                generations: { minicooperf56: { name: 'MINI Cooper F56', fitment_id: null } },
+                            },
+                        },
+                    },
+                },
+            };
+            expect(buildArchetypeFitmentList(a)[0].fitment_id).toBeNull();
+        });
+
+        it('returns an empty list for universal products and for missing data', () => {
+            expect(buildArchetypeFitmentList({ make_model_index: archetype.make_model_index, universal_product: true })).toEqual([]);
+            expect(buildArchetypeFitmentList({})).toEqual([]);
+            expect(buildArchetypeFitmentList(null)).toEqual([]);
+        });
+    });
+});

--- a/assets/js/theme/_addons/global/search/searchEngine.js
+++ b/assets/js/theme/_addons/global/search/searchEngine.js
@@ -1,3 +1,5 @@
+import { generationLabel } from '../vehicleFitment';
+
 export default class SearchEngine {
     constructor(data) {
         this.data = data || {};
@@ -107,7 +109,7 @@ export default class SearchEngine {
         if (modelSlug && registry.models && registry.models[modelSlug]) {
             modelName = registry.models[modelSlug].name || modelSlug;
             if (genSlug && registry.models[modelSlug].generations && registry.models[modelSlug].generations[genSlug]) {
-                genName = registry.models[modelSlug].generations[genSlug];
+                genName = generationLabel(registry.models[modelSlug].generations[genSlug]) || genSlug;
             }
         }
 
@@ -235,8 +237,8 @@ export default class SearchEngine {
                 if (modelData.name) addIds(modelData.name, ids);
 
                 if (modelData.generations) {
-                    Object.entries(modelData.generations).forEach(([genId, genName]) => {
-                        addIds(genName, [genId]);
+                    Object.entries(modelData.generations).forEach(([genId, genNode]) => {
+                        addIds(generationLabel(genNode), [genId]);
                     });
                 }
             });

--- a/assets/js/theme/_addons/global/ugcApi.js
+++ b/assets/js/theme/_addons/global/ugcApi.js
@@ -156,7 +156,11 @@ export class UgcApi {
     /**
      * Approved reviews for an archetype, pooled across its aliases (SRS §3.2.1).
      * @param {number|string} archetypeId
-     * @param {Object} [params] - page, sort, rating, verified, media, sort_alias.
+     * @param {Object} [params] - page, sort, rating, verified, media, and the
+     *   fitment filter: `fitment_id` (integer — the visitor's garage vehicle,
+     *   whose pre-filter match count returns as `fitment_review_count`) and
+     *   `fitment_only` (boolean — when true, requires `fitment_id` and hard-filters
+     *   to it). Null/empty params are dropped by buildQuery and simply omitted.
      * @returns {Promise<Object>}
      */
     getReviews(archetypeId, params = {}) {
@@ -166,7 +170,10 @@ export class UgcApi {
     /**
      * Approved questions and staff answers for an archetype (SRS §3.2.2).
      * @param {number|string} archetypeId
-     * @param {Object} [params] - page, sort, sort_alias.
+     * @param {Object} [params] - page, sort, and the fitment filter: `fitment_id`
+     *   (integer — sets the fitment whose pre-filter match count returns as
+     *   `fitment_question_count`) and `fitment_only` (boolean — when true, requires
+     *   `fitment_id` and hard-filters to it).
      * @returns {Promise<Object>}
      */
     getQuestions(archetypeId, params = {}) {

--- a/assets/js/theme/_addons/global/vehicleFitment.js
+++ b/assets/js/theme/_addons/global/vehicleFitment.js
@@ -1,0 +1,164 @@
+/**
+ * @file vehicleFitment
+ * @description Resolves a vehicle to its QTY `fitment_id` and display label from
+ * the published, object-shaped generation nodes (cs-ugc SRS §3.1.4 / change-log
+ * Pass 27). The canonical generation node is `{ name, fitment_id }`, identical in
+ * the search JSON's `vehicle_registry` and the archetype JSON's `make_model_index`.
+ *
+ * This module is OBJECT-ONLY. The tolerant string-or-object read for the live
+ * store is the throwaway #175 shim that lives on theme `master`; it does NOT
+ * belong here — this branch cuts over to the canonical object shape and retires
+ * that shim on merge.
+ *
+ * Shared by the UGC modules: the garage filter (ugcProduct.js) resolves the
+ * visitor's persisted make/model/generation to a `fitment_id`; the submission
+ * modal (Slice B) builds an archetype-constrained make/model/generation list.
+ *
+ * Graceful degradation (SRS §3.1.4): a generation with `null`/absent `fitment_id`
+ * is un-filterable — the resolver returns a `null` fitment_id, never throws.
+ */
+
+/**
+ * Read the display label off a canonical object generation node.
+ * @param {{name: string, fitment_id: (number|null)}|null|undefined} node
+ * @returns {string|null} The node's `name`, or `null` when absent.
+ */
+export function generationLabel(node) {
+    return (node && typeof node === 'object' && node.name) ? node.name : null;
+}
+
+/**
+ * Read the `fitment_id` off a canonical object generation node.
+ * @param {{name: string, fitment_id: (number|null)}|null|undefined} node
+ * @returns {number|null} The integer fitment id, or `null` when absent/unresolvable.
+ */
+export function generationFitmentId(node) {
+    if (!node || typeof node !== 'object') return null;
+    const id = node.fitment_id;
+    return (typeof id === 'number' && Number.isFinite(id)) ? id : null;
+}
+
+/**
+ * Resolve the visitor's garage selection to its fitment identity from the search
+ * JSON's `vehicle_registry`. The registry's `models` map is keyed by bare model
+ * slug and each model's `generations` map by bare generation slug — the same
+ * slugs the vehicle selector persists.
+ * @param {Object|null} registry - The `vehicle_registry` object.
+ * @param {{make: string, model: string, generation: string}|null} garage
+ * @returns {{fitment_id: (number|null), label: (string|null)}|null}
+ *   `null` when there is no garage selection or no matching registry path;
+ *   otherwise `fitment_id` is `null` for an un-filterable (no-id) generation,
+ *   and `label` falls back to the make/model/generation slug string.
+ */
+export function resolveGarageFitment(registry, garage) {
+    if (!registry || !garage || !garage.make || !garage.model || !garage.generation) {
+        return null;
+    }
+
+    const models = registry.models || {};
+    const model = models[garage.model];
+    if (!model || !model.generations) return null;
+
+    const genNode = model.generations[garage.generation];
+    if (!genNode) return null;
+
+    const label = generationLabel(genNode);
+    return {
+        fitment_id: generationFitmentId(genNode),
+        label: label || garage.generation,
+    };
+}
+
+/**
+ * Resolve a `fitment_id` to its display label by scanning the registry's
+ * generation nodes. Used to render a vehicle label when only the id is known
+ * (e.g. a verified token's fitment, or a card badge fallback).
+ * @param {Object|null} registry - The `vehicle_registry` object.
+ * @param {number|null} fitmentId
+ * @returns {string|null} The matching generation's label, or `null`.
+ */
+export function fitmentIdToLabel(registry, fitmentId) {
+    if (!registry || !registry.models || typeof fitmentId !== 'number') return null;
+
+    const modelSlugs = Object.keys(registry.models);
+    for (let i = 0; i < modelSlugs.length; i += 1) {
+        const model = registry.models[modelSlugs[i]];
+        const generations = model && model.generations;
+        if (generations) {
+            const genSlugs = Object.keys(generations);
+            for (let j = 0; j < genSlugs.length; j += 1) {
+                const node = generations[genSlugs[j]];
+                if (generationFitmentId(node) === fitmentId) {
+                    return generationLabel(node);
+                }
+            }
+        }
+    }
+    return null;
+}
+
+function stripPrefix(key, prefix) {
+    return (prefix && key.startsWith(prefix)) ? key.substring(prefix.length) : key;
+}
+
+/**
+ * Build the make/model/generation fitment list constrained to a single
+ * archetype's own fitments, from the archetype JSON's `make_model_index`. The
+ * archetype tree keys its model and generation maps with a make-slug prefix; the
+ * returned `model`/`generation` slugs are stripped of that prefix so they align
+ * with the registry / garage slugs.
+ *
+ * Slice B (the non-verified submission dropdown) consumes this. Universal
+ * products have no make/model/generation tree, so this returns an empty list.
+ * @param {Object|null} archetypeData - The loaded archetype JSON.
+ * @returns {Array<{
+ *   make: string, model: string, generation: string,
+ *   makeLabel: string, modelLabel: string, generationLabel: string,
+ *   label: string, fitment_id: (number|null)
+ * }>}
+ */
+export function buildArchetypeFitmentList(archetypeData) {
+    const list = [];
+    const index = archetypeData && archetypeData.make_model_index;
+    if (!index || archetypeData.universal_product) return list;
+
+    const makeSlugs = Object.keys(index);
+    for (let m = 0; m < makeSlugs.length; m += 1) {
+        const makeSlug = makeSlugs[m];
+        const makeNode = index[makeSlug];
+        if (makeNode && makeNode.models) {
+            const makeLabel = makeNode.name || makeSlug;
+            const modelKeys = Object.keys(makeNode.models);
+
+            for (let mo = 0; mo < modelKeys.length; mo += 1) {
+                const modelKey = modelKeys[mo];
+                const modelNode = makeNode.models[modelKey];
+                if (modelNode && modelNode.generations) {
+                    const modelSlug = stripPrefix(modelKey, makeSlug);
+                    const modelLabel = modelNode.name || modelSlug;
+                    const genKeys = Object.keys(modelNode.generations);
+
+                    for (let g = 0; g < genKeys.length; g += 1) {
+                        const genKey = genKeys[g];
+                        const genNode = modelNode.generations[genKey];
+                        const genSlug = stripPrefix(genKey, makeSlug);
+                        const genLabel = generationLabel(genNode) || genSlug;
+
+                        list.push({
+                            make: makeSlug,
+                            model: modelSlug,
+                            generation: genSlug,
+                            makeLabel,
+                            modelLabel,
+                            generationLabel: genLabel,
+                            label: `${makeLabel} ${modelLabel} ${genLabel}`,
+                            fitment_id: generationFitmentId(genNode),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    return list;
+}

--- a/assets/js/theme/_addons/home/vehicleSelector.js
+++ b/assets/js/theme/_addons/home/vehicleSelector.js
@@ -1,5 +1,6 @@
 import StateManager from '../global/stateManager';
 import VehiclePersistence from '../global/vehiclePersistence';
+import { generationLabel } from '../global/vehicleFitment';
 
 export default class VehicleSelector {
     constructor(context) {
@@ -111,7 +112,8 @@ export default class VehicleSelector {
             const modelSlug = this.modelSelect.value;
             if (modelSlug && this.registry.models[modelSlug]) {
                 const generations = this.registry.models[modelSlug].generations || {};
-                const gens = Object.entries(generations).map(([id, name]) => ({ id, name }))
+                const gens = Object.entries(generations)
+                    .map(([id, node]) => ({ id, name: generationLabel(node) || id }))
                     .sort((a, b) => b.name.localeCompare(a.name)); // Sort descending by name
                 gens.forEach(g => this.addOption(this.yearSelect, g.id, g.name));
 


### PR DESCRIPTION
**Slice 1 of 4** of cs-ugc #158 (M9 — fitment-aware UGC). This is the foundation slice: it gates the others, so it builds the resolution seam cleanly and flips the search-JSON generation-node reads to the canonical object shape. **No UI yet** — chip, submission modal, and card badge are later slices.

## Built object-only — retires the #175 shim at merge
Per SRS §3.1.4 / change-log Pass 27, the generation node is the canonical object `{ name, fitment_id }`, identical in the search JSON's `vehicle_registry` and the archetype JSON's `make_model_index`. This branch reads it **object-only**. The tolerant string-or-object read is the throwaway **#175 shim** on theme `master`; it is intentionally **not** carried here, and merging this branch to `master` retires it. (Ships only after #157 publishes the objects — built to the frozen contract, verified with Jest fixtures, not live data.)

## What this slice delivers
- **`vehicleFitment.js`** (new, `assets/js/theme/_addons/global/`) — the resolver:
  - `generationLabel(node)` / `generationFitmentId(node)` — object-only readers of the canonical node.
  - `resolveGarageFitment(registry, garage)` → `{ fitment_id, label }` — maps the persisted garage `{make, model, generation}` slugs to a fitment via the search-JSON `vehicle_registry`. `null` when no selection/no match; `fitment_id: null` (un-filterable) when the node has no id; never throws.
  - `fitmentIdToLabel(registry, fitmentId)` → label — reverse lookup (for a verified token's fitment / card-badge fallback).
  - `buildArchetypeFitmentList(archetypeData)` → ordered make/model/generation rows (slugs stripped of the archetype tree's make-prefix, plus labels + `fitment_id`). **Slice B's submission dropdown consumes this** — exposed cleanly now.
- **`searchEngine.js`** — the two `vehicle_registry` generation-node reads (`getVehicleName`, `_buildVehicleIndex`) now read `.name` via `generationLabel`, object-only.
- **`vehicleSelector.js`** — the year-dropdown generation read now reads `.name` via `generationLabel`. Garage→`fitment_id` resolution stays **registry-driven** (`resolveGarageFitment` keyed on the persisted slug), so persistence/state is unchanged and no dead field is carried on the option element.
- **`ugcApi.js`** — `getReviews` / `getQuestions` JSDoc now documents `fitment_id` (integer) + `fitment_only` (boolean); `sort_alias` removed from the docs. `buildQuery` already drops null/undefined/empty, so the new keys flow through with no signature change. **Wiring `ugcProduct` to send them is Slice A** — only the API surface is made ready here.

### Out of scope (left for later slices, as the brief requires)
- Filter chip UI + sending `fitment_id` on fetches (Slice A).
- Submission modal dropdown UI (Slice B) — but its data source (`buildArchetypeFitmentList`) is exposed.
- Card vehicle badge (Slice C).
- The "my vehicle first" toggle is **not** removed (Slice A owns it) — leaving it did not force any string-shaped read.

### Deliberately untouched
The `make_model_index` reads in `stateManager.js` / `urlResolver.js` are the **archetype traversal tree** (options/aliases/`.json` leaves), a different structure from the registry generation node — they are correctly left as-is (matches the #175 shim's reasoning).

## Resolver public API (for briefing Slices A/B/C)
```js
generationLabel(node) -> string|null
generationFitmentId(node) -> number|null
resolveGarageFitment(registry, { make, model, generation }) -> { fitment_id: number|null, label: string }|null
fitmentIdToLabel(registry, fitmentId) -> string|null
buildArchetypeFitmentList(archetypeData) ->
  Array<{ make, model, generation, makeLabel, modelLabel, generationLabel, label, fitment_id: number|null }>
```

## Tests
- New `vehicleFitment.spec.js` — full coverage of all four functions incl. null-fitment_id degradation, incomplete garage, missing registry, label fallback, archetype-tree prefix stripping, universal/empty.
- New `searchEngine.spec.js` — proves the object-only registry reads (`getVehicleName` + vehicle index) and the missing-name fallback.
- `ugcApi.spec.js` — retargeted the `sort_alias` case to `fitment_id`; added `fitment_id` + `fitment_only` pass-through cases for reviews and questions.

`npx grunt check`: **green** — ESLint clean, **304 Jest tests pass** (20 suites), stylelint clean (no SCSS touched).

Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)