### PR TITLE
M9 Slice A (#158): fitment filter chip; remove sort_alias relevance sort

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -26,6 +26,43 @@ const buildStateManager = () => {
     };
 };
 
+// Minimal GlobalStateManager stub: holds a vehicle.selected + a search registry
+// and lets a test emit a new global snapshot. `registry.models[model]
+// .generations[generation]` mirrors the search-JSON shape resolveGarageFitment
+// reads (object generation node `{ name, fitment_id }`, SRS §3.1.4 Pass 27).
+const F56_REGISTRY = {
+    models: {
+        cooper: {
+            name: 'Cooper',
+            generations: {
+                f56: { name: 'MINI Cooper F56', fitment_id: 87 },
+                r53: { name: 'MINI Cooper R53', fitment_id: 42 },
+            },
+        },
+    },
+};
+
+const F56_GARAGE = { make: 'mini', model: 'cooper', generation: 'f56' };
+
+const buildGlobalStateManager = (initial = {}) => {
+    const subscribers = new Set();
+    let state = {
+        vehicle: { selected: initial.vehicle || null },
+        search: { data: initial.registry ? { vehicle_registry: initial.registry } : null },
+    };
+    return {
+        getState: jest.fn(() => state),
+        subscribe: jest.fn((cb) => {
+            subscribers.add(cb);
+            return () => subscribers.delete(cb);
+        }),
+        _set(next) {
+            state = next;
+            subscribers.forEach(cb => cb(state));
+        },
+    };
+};
+
 const buildApi = result => ({
     getReviews: jest.fn(() => Promise.resolve(result)),
 });
@@ -49,7 +86,7 @@ const mountScaffold = () => {
             </select>
             <input type="checkbox" data-reviews-control="verified">
             <input type="checkbox" data-reviews-control="media">
-            <input type="checkbox" data-reviews-control="vehicle_first" disabled>
+            <div class="cs-fitment-chip-slot" data-reviews-fitment-chip></div>
         </div>
         <div id="product-reviews"></div>
         <div class="cs-reviews-pagination" data-reviews-pagination></div>
@@ -103,13 +140,15 @@ describe('UgcProduct (slice 6a)', () => {
 
         // verified/media are null (omitted by buildQuery) until toggled on; rating
         // is null until selected; sort defaults to date_desc (SRS §3.2.1).
+        // fitment_id is null with no garage; fitment_only stays null (off).
         expect(api.getReviews).toHaveBeenCalledWith(ARCHETYPE_ID, {
             page: 1,
             sort: 'date_desc',
             rating: null,
             verified: null,
             media: null,
-            sort_alias: null,
+            fitment_id: null,
+            fitment_only: null,
         });
     });
 
@@ -567,7 +606,7 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
                     <option value="date_desc">Newest</option>
                     <option value="date_asc">Oldest</option>
                 </select>
-                <input type="checkbox" data-questions-control="vehicle_first" disabled>
+                <div class="cs-fitment-chip-slot" data-questions-fitment-chip></div>
             </div>
             <div id="product-questions"></div>
             <div class="cs-questions-pagination" data-questions-pagination></div>
@@ -596,7 +635,8 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
         expect(api.getQuestions).toHaveBeenCalledWith(ARCHETYPE_ID, {
             page: 1,
             sort: 'date_desc',
-            sort_alias: null,
+            fitment_id: null,
+            fitment_only: null,
         });
     });
 
@@ -712,7 +752,9 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
             await flush();
 
             expect(api.getQuestions).toHaveBeenCalledTimes(2);
-            expect(qParamsOfCall(api, 2)).toEqual({ sort: expected, page: 1, sort_alias: null });
+            expect(qParamsOfCall(api, 2)).toEqual({
+                sort: expected, page: 1, fitment_id: null, fitment_only: null,
+            });
         });
 
         it('resets to page 1 when the sort changes after paging forward', async () => {
@@ -789,36 +831,53 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
         });
     });
 
-    it('floats alias-matching questions only when the vehicle-first toggle is on', async () => {
-        const stateManager = buildStateManager();
-        const api = buildQaApi(okQuestions());
-        new UgcProduct(ARCHETYPE_ID, stateManager, api);
+    it('passes the garage fitment_id on the initial questions fetch and shows the chip on count > 0', async () => {
+        const api = buildQaApi(okQuestions({ fitment_question_count: 4 }));
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
-        // Initial Q&A fetch carries no sort_alias; the toggle is disabled.
-        expect(qParamsOfCall(api, 1).sort_alias).toBeNull();
-        const toggle = document.querySelector('[data-questions-control="vehicle_first"]');
-        expect(toggle.disabled).toBe(true);
+        expect(qParamsOfCall(api, 1).fitment_id).toBe(87);
+        expect(qParamsOfCall(api, 1).fitment_only).toBeNull();
 
-        // Selecting an alias enables the toggle but does NOT refetch — the
-        // float is opt-in.
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        const chip = document.querySelector('[data-questions-fitment-chip]');
+        const toggle = chip.querySelector('[data-fitment-chip-toggle]');
+        expect(toggle).not.toBeNull();
+        expect(toggle.textContent).toContain('For your MINI Cooper F56');
+        expect(chip.style.visibility).toBe('visible');
+    });
+
+    it('hard-filters questions with fitment_only when the Q&A chip is clicked, and clears it', async () => {
+        const api = buildQaApi(okQuestions({ fitment_question_count: 4 }));
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
-        expect(api.getQuestions).toHaveBeenCalledTimes(1);
-        expect(toggle.disabled).toBe(false);
 
-        toggle.checked = true;
-        toggle.dispatchEvent(new Event('change', { bubbles: true }));
+        document.querySelector('[data-questions-fitment-chip] [data-fitment-chip-toggle]').click();
         await flush();
         expect(api.getQuestions).toHaveBeenCalledTimes(2);
-        expect(qParamsOfCall(api, 2).sort_alias).toBe(4821);
+        expect(qParamsOfCall(api, 2)).toEqual({
+            page: 1, sort: 'date_desc', fitment_id: 87, fitment_only: true,
+        });
 
-        // Deselecting the alias drops the param and disables the toggle.
-        stateManager._emit({ aliasData: null });
+        document.querySelector('[data-questions-fitment-chip] [data-fitment-chip-clear]').click();
         await flush();
         expect(api.getQuestions).toHaveBeenCalledTimes(3);
-        expect(qParamsOfCall(api, 3).sort_alias).toBeNull();
-        expect(toggle.disabled).toBe(true);
+        expect(qParamsOfCall(api, 3).fitment_only).toBeNull();
+    });
+
+    it('hides the Q&A chip when fitment_question_count is 0 (universal / no match)', async () => {
+        const api = buildQaApi(okQuestions({ fitment_question_count: 0 }));
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+        await flush();
+
+        const chip = document.querySelector('[data-questions-fitment-chip]');
+        expect(chip.innerHTML).toBe('');
+        expect(chip.style.visibility).toBe('hidden');
     });
 
     it('does not fetch questions when the Q&A DOM is absent', async () => {
@@ -844,7 +903,7 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
     });
 });
 
-describe('UgcProduct (slice 6d — alias-aware sort)', () => {
+describe('UgcProduct (slice A — fitment filter chip, reviews)', () => {
     beforeEach(() => {
         mountScaffold();
     });
@@ -855,65 +914,118 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
 
     const paramsOfCall = (api, n) => api.getReviews.mock.calls[n - 1][1];
 
-    // A reviews-only api that returns a fresh ok envelope on every call, so each
-    // alias-driven refetch can be asserted against its params.
-    const buildReviewsApi = () => ({
-        getReviews: jest.fn(() => Promise.resolve(okEnvelope())),
+    const reviewsChip = () => document.querySelector('[data-reviews-fitment-chip]');
+
+    // A reviews-only api that returns a fresh envelope (default fitment count of
+    // 4) on every call, so each refetch can be asserted against its params.
+    const buildReviewsApi = (count = 4) => ({
+        getReviews: jest.fn(() => Promise.resolve(okEnvelope({ fitment_review_count: count }))),
     });
 
-    it('omits sort_alias on the initial fetch (no alias selected)', async () => {
+    it('passes the garage fitment_id on the initial reviews fetch', async () => {
         const api = buildReviewsApi();
-        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
-        expect(paramsOfCall(api, 1).sort_alias).toBeNull();
+        expect(paramsOfCall(api, 1).fitment_id).toBe(87);
+        expect(paramsOfCall(api, 1).fitment_only).toBeNull();
     });
 
-    it('refetches reviews with sort_alias when the toggle is on and an alias is selected', async () => {
-        const stateManager = buildStateManager();
+    it('omits fitment_id when there is no garage vehicle', async () => {
         const api = buildReviewsApi();
-        new UgcProduct(ARCHETYPE_ID, stateManager, api);
+        const global = buildGlobalStateManager({ registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
-        // Alias selection alone never refetches — floating is opt-in.
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
-        await flush();
-        expect(api.getReviews).toHaveBeenCalledTimes(1);
+        expect(paramsOfCall(api, 1).fitment_id).toBeNull();
+        expect(reviewsChip().style.visibility).toBe('hidden');
+    });
 
-        toggleCheckbox('vehicle_first', true);
+    it('omits fitment_id for an un-filterable (null fitment_id) generation', async () => {
+        const api = buildReviewsApi(0);
+        const registry = {
+            models: {
+                cooper: { name: 'Cooper', generations: { f56: { name: 'MINI Cooper F56', fitment_id: null } } },
+            },
+        };
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+        await flush();
+
+        expect(paramsOfCall(api, 1).fitment_id).toBeNull();
+        expect(reviewsChip().style.visibility).toBe('hidden');
+    });
+
+    it('shows the "For your <vehicle>" chip only when fitment_review_count > 0', async () => {
+        const api = buildReviewsApi(7);
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+        await flush();
+
+        const chip = reviewsChip();
+        const toggle = chip.querySelector('[data-fitment-chip-toggle]');
+        expect(toggle).not.toBeNull();
+        expect(toggle.textContent).toContain('For your MINI Cooper F56');
+        expect(chip.querySelector('.cs-fitment-chip-count').textContent).toBe('7');
+        expect(chip.style.visibility).toBe('visible');
+    });
+
+    it('hides the chip when fitment_review_count is 0 (universal / no match)', async () => {
+        const api = buildReviewsApi(0);
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+        await flush();
+
+        const chip = reviewsChip();
+        expect(chip.innerHTML).toBe('');
+        expect(chip.style.visibility).toBe('hidden');
+    });
+
+    it('hard-filters with fitment_only=true on chip click and resets to page 1', async () => {
+        const api = buildReviewsApi(5);
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+        await flush();
+
+        reviewsChip().querySelector('[data-fitment-chip-toggle]').click();
         await flush();
 
         expect(api.getReviews).toHaveBeenCalledTimes(2);
-        expect(paramsOfCall(api, 2).sort_alias).toBe(4821);
+        expect(paramsOfCall(api, 2)).toEqual({
+            page: 1,
+            sort: 'date_desc',
+            rating: null,
+            verified: null,
+            media: null,
+            fitment_id: 87,
+            fitment_only: true,
+        });
+        expect(reviewsChip().querySelector('[data-fitment-chip-toggle]').classList).toContain('is-active');
     });
 
-    it('drops sort_alias when the alias is deselected', async () => {
-        const stateManager = buildStateManager();
-        const api = buildReviewsApi();
-        new UgcProduct(ARCHETYPE_ID, stateManager, api);
+    it('clears the hard filter (drops fitment_only) when the clear control is clicked', async () => {
+        const api = buildReviewsApi(5);
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        reviewsChip().querySelector('[data-fitment-chip-toggle]').click();
         await flush();
-        toggleCheckbox('vehicle_first', true);
-        await flush();
-        expect(paramsOfCall(api, 2).sort_alias).toBe(4821);
+        expect(paramsOfCall(api, 2).fitment_only).toBe(true);
 
-        stateManager._emit({ aliasData: null });
+        reviewsChip().querySelector('[data-fitment-chip-clear]').click();
         await flush();
-
         expect(api.getReviews).toHaveBeenCalledTimes(3);
-        expect(paramsOfCall(api, 3).sort_alias).toBeNull();
+        expect(paramsOfCall(api, 3).fitment_only).toBeNull();
     });
 
-    it('preserves the active sort and filters across an alias-driven refetch', async () => {
-        const stateManager = buildStateManager();
-        const api = buildReviewsApi();
-        new UgcProduct(ARCHETYPE_ID, stateManager, api);
+    it('composes fitment_only with the active sort and filters', async () => {
+        const api = buildReviewsApi(5);
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
-        // Establish a non-default sort and two active filters before the alias
-        // is selected — they must survive the alias refetch unchanged.
         changeSelect('sort', 'rating_desc');
         await flush();
         changeSelect('rating', '4');
@@ -921,9 +1033,7 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
         toggleCheckbox('verified', true);
         await flush();
 
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
-        await flush();
-        toggleCheckbox('vehicle_first', true);
+        reviewsChip().querySelector('[data-fitment-chip-toggle]').click();
         await flush();
 
         const last = paramsOfCall(api, api.getReviews.mock.calls.length);
@@ -933,62 +1043,74 @@ describe('UgcProduct (slice 6d — alias-aware sort)', () => {
             rating: 4,
             verified: true,
             media: null,
-            sort_alias: 4821,
+            fitment_id: 87,
+            fitment_only: true,
         });
     });
 
-    it('resets to page 1 when the alias selection changes', async () => {
-        const stateManager = buildStateManager();
-        const api = {
-            getReviews: jest.fn(() => Promise.resolve(okEnvelope({ total: 25, page: 1, per_page: 10 }))),
-        };
-        new UgcProduct(ARCHETYPE_ID, stateManager, api);
+    it('re-resolves and refetches when a late-arriving registry resolves the garage vehicle', async () => {
+        const api = buildReviewsApi(3);
+        // Garage selected, but the registry has not loaded yet → no fitment_id.
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
-        toggleCheckbox('vehicle_first', true);
-        await flush();
-        expect(paramsOfCall(api, 2).sort_alias).toBe(4821);
+        expect(paramsOfCall(api, 1).fitment_id).toBeNull();
 
-        document.querySelector('[data-reviews-page="3"]').click();
+        // Search data arrives: registry now resolves the garage to fitment 87.
+        global._set({
+            vehicle: { selected: F56_GARAGE },
+            search: { data: { vehicle_registry: F56_REGISTRY } },
+        });
         await flush();
-        expect(paramsOfCall(api, 3).page).toBe(3);
 
-        // Switching to a different alias re-floats and resets the page.
-        stateManager._emit({ aliasData: { qty_alias_index: 7777 } });
-        await flush();
-        expect(paramsOfCall(api, 4).page).toBe(1);
-        expect(paramsOfCall(api, 4).sort_alias).toBe(7777);
+        expect(api.getReviews).toHaveBeenCalledTimes(2);
+        expect(paramsOfCall(api, 2).fitment_id).toBe(87);
+        expect(paramsOfCall(api, 2).page).toBe(1);
+        expect(reviewsChip().style.visibility).toBe('visible');
     });
 
-    it('does not refetch when an unrelated state notification leaves the alias unchanged', async () => {
-        const stateManager = buildStateManager();
-        const api = buildReviewsApi();
-        new UgcProduct(ARCHETYPE_ID, stateManager, api);
+    it('refetches with the new fitment_id and resets the hard filter on a garage swap', async () => {
+        const api = buildReviewsApi(3);
+        const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
-        toggleCheckbox('vehicle_first', true);
+        // Turn the hard filter on for the F56.
+        reviewsChip().querySelector('[data-fitment-chip-toggle]').click();
         await flush();
-        expect(api.getReviews).toHaveBeenCalledTimes(2);
+        expect(paramsOfCall(api, 2).fitment_only).toBe(true);
 
-        // Same alias re-emitted (e.g. inventory/blem change) — no extra fetch.
-        stateManager._emit({ aliasData: { qty_alias_index: 4821 }, blemSelected: true });
+        // Swap the garage to the R53 (fitment 42) — the filter resets to off.
+        global._set({
+            vehicle: { selected: { make: 'mini', model: 'cooper', generation: 'r53' } },
+            search: { data: { vehicle_registry: F56_REGISTRY } },
+        });
         await flush();
-        expect(api.getReviews).toHaveBeenCalledTimes(2);
+
+        expect(paramsOfCall(api, 3).fitment_id).toBe(42);
+        expect(paramsOfCall(api, 3).fitment_only).toBeNull();
+        expect(paramsOfCall(api, 3).page).toBe(1);
     });
 
-    it('treats a missing or non-numeric qty_alias_index as no alias sort', async () => {
+    it('still tracks qty_alias_index as alias_id provenance without refetching', async () => {
         const stateManager = buildStateManager();
         const api = buildReviewsApi();
-        new UgcProduct(ARCHETYPE_ID, stateManager, api);
+        const ugc = new UgcProduct(ARCHETYPE_ID, stateManager, api);
         await flush();
+        expect(api.getReviews).toHaveBeenCalledTimes(1);
 
-        // A "self" simple-product alias whose JSON carries no published index
-        // must not trigger an alias refetch and must not send sort_alias.
+        // A local alias selection updates provenance but never triggers a fetch
+        // (the removed sort_alias relevance sort is gone).
+        stateManager._emit({ aliasData: { qty_alias_index: 4821 } });
+        await flush();
+        expect(api.getReviews).toHaveBeenCalledTimes(1);
+        expect(ugc.aliasIndex).toBe(4821);
+
         stateManager._emit({ aliasData: { bc_id: 99 } });
         await flush();
         expect(api.getReviews).toHaveBeenCalledTimes(1);
+        expect(ugc.aliasIndex).toBeNull();
     });
 });
 

--- a/assets/js/theme/_addons/product/productController.js
+++ b/assets/js/theme/_addons/product/productController.js
@@ -74,7 +74,13 @@ export default class ProductController {
             this.badges = new Badges(this.stateManager);
             this.blemProducts = new BlemProducts(this.stateManager);
             this.schemaManager = new SchemaManager(this.stateManager);
-            this.ugcProduct = new UgcProduct(archetypeData.qty_archetype_id, this.stateManager, ugcApi);
+            this.ugcProduct = new UgcProduct(
+                archetypeData.qty_archetype_id,
+                this.stateManager,
+                ugcApi,
+                undefined,
+                GlobalStateManager,
+            );
 
             this.unsubscribeLocal = this.stateManager.subscribe(this.handleLocalStateChange.bind(this));
 

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -29,20 +29,30 @@
  * It mirrors the reviews list/sort/pagination pattern but has no filters and
  * renders each approved question with its single staff answer (§4.1 Question).
  *
- * Slice 6d (#7) adds alias-aware sorting; the 2026-06-05 visuals pass made it
- * OPT-IN. The module subscribes to the local StateManager and tracks the
- * selected alias's published `qty_alias_index` (SRS §3.1.4) off
- * state.aliasData, but floating is user-controlled: a "My vehicle first"
- * toggle in each toolbar (enabled only while an alias is selected). Only when
- * the toggle is on do reviews and questions refetch with
- * `sort_alias={qty_alias_index}`, floating alias-matching items WITHIN the
- * current sort without excluding others (SRS §3.2.1, §3.2.2). Automatic
- * floating was rejected as quietly misrepresenting the default order — this
- * deviates from §3.4.1 as written (flagged to the cs-ugc PM for an SRS
- * amendment). The active sort and filters are preserved across the
- * transition; only the page resets to 1, since the relevance ordering
- * shifts. The selected alias index itself still rides on submissions as
- * `alias_id` regardless of the toggle.
+ * Slice 6d (#7) tracked the selected alias's published `qty_alias_index`
+ * (SRS §3.1.4) off state.aliasData and rode it as `alias_id` on submissions.
+ * That still holds — `alias_id` is retained as nullable provenance (SRS §3.1.4,
+ * change-log Pass 25). What was REMOVED in M9 Slice A (#158) is the old
+ * "my vehicle first" relevance sort: the `sort_alias` param and its opt-in
+ * toggle are gone, superseded by the fitment filter below at the correct grain
+ * (a fitment spans many aliases; the alias-keyed sort floated only the
+ * currently-viewed variant — SRS change-log Pass 25/27).
+ *
+ * Slice A (#158) makes the lists fitment-aware (SRS §3.4.1, §3.2.1, §3.2.2).
+ * The module resolves the visitor's persisted garage vehicle (make/model/
+ * generation slugs) to a QTY `fitment_id` from the search JSON's
+ * `vehicle_registry` (via the shared vehicleFitment resolver), reading both the
+ * garage selection and the registry off the injected GlobalStateManager. That
+ * `fitment_id` rides on EVERY getReviews / getQuestions call (omitted when
+ * un-resolvable or on a universal product — buildQuery drops null), so the
+ * envelopes return `fitment_review_count` / `fitment_question_count`. When that
+ * count is > 0 the module renders a "For your <vehicle>" filter chip naming the
+ * vehicle; clicking it refetches with `fitment_only=true` (composing with the
+ * active sort/rating/verified/media, resetting to page 1) and shows a selected
+ * state, and clearing it drops the flag. The honest default view stays
+ * newest-first — the chip is off by default. No chip when the count is 0 or on
+ * universal-product pages. A late-arriving registry or a garage change re-runs
+ * the resolution and refetches so the chip stays correct.
  *
  * Slice 6e (#8) adds the submission modal: review and question forms posted to
  * POST /api/reviews and POST /api/questions via ugcApi (SRS §3.2.4, §3.2.5). Each
@@ -85,6 +95,8 @@
  * alias-aware refetches stay consistent. Only the §3.2.1 public payload fields
  * are consumed — never `status` or other internal fields.
  */
+
+import { resolveGarageFitment } from '../../global/vehicleFitment';
 
 const MAX_STARS = 5;
 
@@ -140,7 +152,12 @@ const MESSAGES = {
     mediaVideoCount: 'You can attach up to 1 video.',
     mediaUploadError: 'A file failed to upload. Please remove it and try again.',
     mediaProcessing: 'Processing media… this can take up to 30 seconds for video.',
+    fitmentChipClear: 'Clear filter',
 };
+
+// "For your <vehicle>" fitment filter chip label (SRS §3.4.1). The vehicle name
+// is the resolver's label.
+const fitmentChipLabel = vehicle => `For your ${vehicle}`;
 
 export default class UgcProduct {
     /**
@@ -151,13 +168,21 @@ export default class UgcProduct {
      * @param {Function} [mediaPut] - fetch impl for the raw PUT to the DO Spaces
      *   presigned URL. Bypasses ugcApi's base entirely (the URL is absolute and
      *   external); injectable so tests never hit the network.
+     * @param {Object} [globalStateManager] - The site-wide GlobalStateManager
+     *   (getState/subscribe). Source of the persisted garage vehicle
+     *   (`vehicle.selected`) and the search-JSON `vehicle_registry`
+     *   (`search.data.vehicle_registry`) used to resolve the garage `fitment_id`
+     *   for the fitment filter (SRS §3.4.1). Omitted in tests with no garage —
+     *   the lists simply carry no `fitment_id` and no chip renders.
      */
-    constructor(archetypeId, stateManager, api, mediaPut) {
+    constructor(archetypeId, stateManager, api, mediaPut, globalStateManager) {
         this.archetypeId = archetypeId;
         this.stateManager = stateManager;
         this.api = api;
         this.mediaPut = mediaPut || ((...args) => fetch(...args));
+        this.globalStateManager = globalStateManager || null;
         this.unsubscribe = null;
+        this.unsubscribeGlobal = null;
 
         // Cached unfiltered aggregates from the reviews envelope. Constant under
         // filters, so the rating summary is painted once and never refetched
@@ -194,16 +219,22 @@ export default class UgcProduct {
         this.questionsLoaded = false;
 
         // The selected alias's integer index (SRS §3.1.4), or null when no
-        // alias is selected. Rides on submissions as alias_id regardless of
-        // the float toggle.
+        // alias is selected. Provenance only — rides on submissions as
+        // `alias_id` (the former sort_alias relevance sort was removed in M9).
         this.aliasIndex = null;
 
-        // "My vehicle first" toggle state, and the effective sort_alias param
-        // derived from it: aliasIndex while the toggle is on AND an alias is
-        // selected, else null. Floating is opt-in — automatic floating reads
-        // as misrepresenting the default order.
-        this.vehicleFirst = false;
-        this.sortAlias = null;
+        // Garage fitment (SRS §3.4.1, §3.2.1/§3.2.2). `fitmentId` is the QTY
+        // `fitment_id` resolved from the persisted garage vehicle against the
+        // search-JSON registry; it rides on every reviews/questions fetch.
+        // `fitmentLabel` names the vehicle on the chip. `fitmentOnly` is the
+        // chip's hard-filter flag — off by default, so the honest view is
+        // newest-first. The two `fitment*Count` values come from the envelopes
+        // and drive each chip's show-at->0 rule.
+        this.fitmentId = null;
+        this.fitmentLabel = null;
+        this.fitmentOnly = false;
+        this.fitmentReviewCount = 0;
+        this.fitmentQuestionCount = 0;
         this.reviewsLoaded = false;
 
         // The vehicle label of the currently selected alias, kept in sync from
@@ -232,6 +263,12 @@ export default class UgcProduct {
         this.questionsElement = document.querySelector('#product-questions');
         this.questionsToolbarElement = document.querySelector('[data-questions-toolbar]');
         this.questionsPaginationElement = document.querySelector('[data-questions-pagination]');
+
+        // "For your <vehicle>" fitment chip containers (SRS §3.4.1), one per
+        // list. Space is reserved in SCSS (visibility, not display) so the
+        // async chip paint never shifts the toolbar.
+        this.reviewsFitmentChipElement = document.querySelector('[data-reviews-fitment-chip]');
+        this.questionsFitmentChipElement = document.querySelector('[data-questions-fitment-chip]');
 
         // Review media display (issue #30, SRS §3.4.1): the overview panel
         // container and the shared lightbox. The gallery is its own data
@@ -282,11 +319,19 @@ export default class UgcProduct {
         this.onMediaTileClick = this.onMediaTileClick.bind(this);
         this.onLightboxClick = this.onLightboxClick.bind(this);
         this.onGalleryModalClick = this.onGalleryModalClick.bind(this);
+        this.onFitmentChipClick = this.onFitmentChipClick.bind(this);
 
         const hasReviewsDom = this.ratingElement || this.listElement;
 
         if (this.archetypeId && (hasReviewsDom || this.questionsElement)) {
             this.unsubscribe = this.stateManager.subscribe(this.update.bind(this));
+
+            // Resolve the garage fitment_id BEFORE the first fetch so it rides
+            // on the initial reviews/questions calls (SRS §3.4.1), and subscribe
+            // so a late-arriving registry or a garage change re-resolves and
+            // refetches.
+            this.subscribeGlobalFitment();
+
             this.bindControls();
             this.bindModals();
             this.captureVerifiedPurchaserToken();
@@ -316,6 +361,16 @@ export default class UgcProduct {
 
         if (this.questionsPaginationElement) {
             this.questionsPaginationElement.addEventListener('click', this.onQuestionsPaginationClick);
+        }
+
+        // Fitment chip clicks are delegated on the chip containers so the chip
+        // survives every re-render without rebinding (SRS §3.4.1).
+        if (this.reviewsFitmentChipElement) {
+            this.reviewsFitmentChipElement.addEventListener('click', this.onFitmentChipClick);
+        }
+
+        if (this.questionsFitmentChipElement) {
+            this.questionsFitmentChipElement.addEventListener('click', this.onFitmentChipClick);
         }
 
         // Media tile clicks are delegated so per-review strips and the grid
@@ -1025,7 +1080,8 @@ export default class UgcProduct {
             rating: this.query.rating,
             verified: this.query.verified,
             media: this.query.media,
-            sort_alias: this.sortAlias,
+            fitment_id: this.fitmentId,
+            fitment_only: this.fitmentOnly ? true : null,
         };
     }
 
@@ -1033,6 +1089,13 @@ export default class UgcProduct {
         this.total = Number.isFinite(data.total) ? data.total : 0;
         this.perPage = Number.isFinite(data.per_page) ? data.per_page : 0;
         this.query.page = Number.isFinite(data.page) ? data.page : this.query.page;
+
+        // Pre-filter match count for the garage fitment (SRS §3.2.1) — drives
+        // the reviews "For your <vehicle>" chip's show-at->0 rule.
+        this.fitmentReviewCount = Number.isFinite(data.fitment_review_count)
+            ? data.fitment_review_count
+            : 0;
+        this.renderFitmentChip('reviews');
 
         const items = Array.isArray(data.items) ? data.items : [];
         this.renderList(items);
@@ -1047,8 +1110,12 @@ export default class UgcProduct {
     }
 
     /**
-     * StateManager subscriber. Re-paints the cached summary so the block stays
-     * consistent across re-renders, then applies any alias-driven sort change.
+     * Local StateManager subscriber. Re-paints the cached summary so the block
+     * stays consistent across re-renders, refreshes the optional submission
+     * `vehicle_label`, and tracks the selected alias's `qty_alias_index` so it
+     * rides on submissions as `alias_id` (provenance; SRS §3.1.4). No fetch is
+     * triggered here — the fitment filter is driven by the GLOBAL garage state,
+     * not the locally-selected alias.
      * @param {Object} [state] - The local StateManager snapshot.
      */
     update(state) {
@@ -1057,7 +1124,7 @@ export default class UgcProduct {
         }
 
         this.vehicleLabel = this._resolveVehicleLabel(state);
-        this.applyAliasSort(state);
+        this.aliasIndex = this._resolveAliasIndex(state);
     }
 
     /**
@@ -1077,54 +1144,63 @@ export default class UgcProduct {
     }
 
     /**
-     * Reconcile the active `sort_alias` with the alias currently selected on the
-     * local StateManager (SRS §3.4.1). On a change — select, deselect, or switch
-     * between aliases — refetch BOTH the reviews and questions lists so
-     * alias-matching items float to the top within the current sort, preserving
-     * the active sort and filters and resetting only the page (the relevance
-     * order shifts). No-ops when the selection is unchanged, so unrelated state
-     * notifications never trigger a refetch.
-     * @param {Object} [state] - The local StateManager snapshot.
+     * Subscribe to the global garage state and resolve the garage vehicle to its
+     * QTY `fitment_id` (SRS §3.4.1). Reads the persisted garage selection
+     * (`vehicle.selected`) and the search-JSON `vehicle_registry`
+     * (`search.data.vehicle_registry`) off the GlobalStateManager and resolves
+     * via the shared vehicleFitment resolver. Runs once synchronously to seed
+     * the initial fetches, then on every global state change so a late-arriving
+     * registry or a garage swap re-resolves. Absent GlobalStateManager (tests
+     * with no garage) leaves `fitmentId` null — the lists carry no `fitment_id`
+     * and no chip renders.
      */
-    applyAliasSort(state) {
-        const nextAlias = this._resolveAliasIndex(state);
-        if (nextAlias === this.aliasIndex) {
+    subscribeGlobalFitment() {
+        if (!this.globalStateManager) {
             return;
         }
 
-        this.aliasIndex = nextAlias;
-        this._syncVehicleToggles();
-        this._applySortAlias();
+        this.resolveFitmentFromGlobal(this.globalStateManager.getState());
+        this.unsubscribeGlobal = this.globalStateManager.subscribe(
+            globalState => this.onGlobalFitmentChange(globalState),
+        );
     }
 
     /**
-     * The "My vehicle first" toggle changed (either toolbar). Both lists
-     * share the one preference.
-     * @param {boolean} checked
+     * Resolve and store the garage fitment from a global state snapshot, WITHOUT
+     * refetching. Used to seed state before the initial fetch.
+     * @param {Object} [globalState]
      */
-    _setVehicleFirst(checked) {
-        this.vehicleFirst = checked;
-        this._syncVehicleToggles();
-        this._applySortAlias();
+    resolveFitmentFromGlobal(globalState) {
+        const vehicle = globalState && globalState.vehicle ? globalState.vehicle.selected : null;
+        const registry = globalState && globalState.search && globalState.search.data
+            ? globalState.search.data.vehicle_registry
+            : null;
+
+        const resolved = resolveGarageFitment(registry, vehicle);
+        this.fitmentId = resolved ? resolved.fitment_id : null;
+        this.fitmentLabel = resolved ? resolved.label : null;
     }
 
     /**
-     * Re-derive the effective sort_alias (toggle on AND alias selected) and,
-     * when it changes, refetch both lists so alias-matching items float to
-     * the top within the current sort, preserving the active sort and filters
-     * and resetting only the page (the relevance order shifts).
+     * Global state changed. Re-resolve the garage fitment; if the resolved
+     * `fitment_id` changed (garage swap, or the registry arriving and resolving
+     * a previously-unresolvable selection), drop any active hard-filter and
+     * refetch both loaded lists from page 1 so the envelopes return fresh
+     * `fitment_*_count` values and the chip re-renders (SRS §3.4.1).
+     * @param {Object} [globalState]
      */
-    _applySortAlias() {
-        const effective = this.vehicleFirst && this.aliasIndex !== null ? this.aliasIndex : null;
-        if (effective === this.sortAlias) {
+    onGlobalFitmentChange(globalState) {
+        const previousId = this.fitmentId;
+        this.resolveFitmentFromGlobal(globalState);
+
+        if (this.fitmentId === previousId) {
             return;
         }
 
-        this.sortAlias = effective;
+        // The new vehicle's chip starts unselected — the honest default is the
+        // unfiltered newest-first view (SRS §3.4.1).
+        this.fitmentOnly = false;
 
-        // Only refetch a list that has completed its initial load, so the
-        // refetch layers on top of an established list rather than racing the
-        // in-flight init fetch (which reads sort_alias live anyway).
         if (this.reviewsLoaded) {
             this.query.page = 1;
             this.fetchReviews();
@@ -1137,26 +1213,85 @@ export default class UgcProduct {
     }
 
     /**
-     * Mirror the shared toggle state onto both toolbars' checkboxes: checked
-     * follows the preference, disabled while no alias is selected (the
-     * control is meaningless without a vehicle).
+     * Toggle the "For your <vehicle>" hard filter (SRS §3.4.1). A click on an
+     * inactive chip turns `fitment_only` on; a click on the clear control turns
+     * it off. Either way both loaded lists refetch from page 1, composing with
+     * the active sort/rating/verified/media. No-op when the chip isn't actually
+     * shown (no resolved fitment).
+     * @param {Event} event
      */
-    _syncVehicleToggles() {
-        const toggles = document.querySelectorAll(
-            '[data-reviews-control="vehicle_first"], [data-questions-control="vehicle_first"]',
-        );
-
-        for (let i = 0; i < toggles.length; i += 1) {
-            toggles[i].checked = this.vehicleFirst;
-            toggles[i].disabled = this.aliasIndex === null;
+    onFitmentChipClick(event) {
+        const trigger = event.target.closest('[data-fitment-chip-toggle], [data-fitment-chip-clear]');
+        if (!trigger || this.fitmentId === null) {
+            return;
         }
+
+        event.preventDefault();
+
+        const isClear = trigger.dataset.fitmentChipClear !== undefined;
+        const nextOnly = !isClear;
+        if (nextOnly === this.fitmentOnly) {
+            return;
+        }
+
+        this.fitmentOnly = nextOnly;
+        this.renderFitmentChip('reviews');
+        this.renderFitmentChip('questions');
+
+        if (this.reviewsLoaded) {
+            this.query.page = 1;
+            this.fetchReviews();
+        }
+
+        if (this.questionsLoaded) {
+            this.questionQuery.page = 1;
+            this.fetchQuestions();
+        }
+    }
+
+    /**
+     * Render (or hide) a list's fitment chip (SRS §3.4.1). Shows the
+     * "For your <vehicle>" chip only when the matching pre-filter count is > 0
+     * (which is also 0 on universal products / unresolved fitment). When the
+     * hard filter is active the chip carries a selected state plus a clear
+     * control. Space is reserved in SCSS, so toggling visibility never shifts
+     * the toolbar.
+     * @param {string} kind - 'reviews' | 'questions'.
+     */
+    renderFitmentChip(kind) {
+        const container = kind === 'questions'
+            ? this.questionsFitmentChipElement
+            : this.reviewsFitmentChipElement;
+        if (!container) {
+            return;
+        }
+
+        const count = kind === 'questions' ? this.fitmentQuestionCount : this.fitmentReviewCount;
+
+        if (!this.fitmentLabel || count <= 0) {
+            container.innerHTML = '';
+            container.style.visibility = 'hidden';
+            return;
+        }
+
+        const label = this._escape(fitmentChipLabel(this.fitmentLabel));
+        const active = this.fitmentOnly;
+        const activeClass = active ? ' is-active' : '';
+        const pressed = active ? 'true' : 'false';
+        const clear = active
+            ? `<button type="button" class="cs-fitment-chip-clear" data-fitment-chip-clear aria-label="${this._escapeAttr(MESSAGES.fitmentChipClear)}">&times;</button>`
+            : '';
+
+        container.innerHTML = `<button type="button" class="cs-fitment-chip${activeClass}" data-fitment-chip-toggle aria-pressed="${pressed}"><span class="cs-fitment-chip-label">${label}</span><span class="cs-fitment-chip-count">${count}</span></button>${clear}`;
+        container.style.visibility = 'visible';
     }
 
     /**
      * Pull the published alias index (SRS §3.1.4 `qty_alias_index`) off the
      * selected alias and normalize it to an integer, or null when no alias is
-     * selected / the field is absent or non-numeric. The value is passed
-     * verbatim as the API `sort_alias` param.
+     * selected / the field is absent or non-numeric. Retained as nullable
+     * provenance — it rides on submissions as `alias_id` (the former
+     * `sort_alias` relevance sort was removed in M9).
      * @param {Object} [state] - The local StateManager snapshot.
      * @returns {number|null}
      */
@@ -1192,11 +1327,6 @@ export default class UgcProduct {
             this.query.verified = target.checked ? true : null;
         } else if (reviewsControl === 'media') {
             this.query.media = target.checked ? true : null;
-        } else if (reviewsControl === 'vehicle_first') {
-            // Shared toggle — refetches both lists itself when the effective
-            // sort_alias changes.
-            this._setVehicleFirst(target.checked);
-            return;
         } else {
             return;
         }
@@ -1262,7 +1392,8 @@ export default class UgcProduct {
         return {
             page: this.questionQuery.page,
             sort: this.questionQuery.sort,
-            sort_alias: this.sortAlias,
+            fitment_id: this.fitmentId,
+            fitment_only: this.fitmentOnly ? true : null,
         };
     }
 
@@ -1271,6 +1402,13 @@ export default class UgcProduct {
         this.questionPerPage = Number.isFinite(data.per_page) ? data.per_page : 0;
         this.questionCount = this.questionTotal;
         this.questionQuery.page = Number.isFinite(data.page) ? data.page : this.questionQuery.page;
+
+        // Pre-filter match count for the garage fitment (SRS §3.2.2) — drives
+        // the Q&A "For your <vehicle>" chip's show-at->0 rule.
+        this.fitmentQuestionCount = Number.isFinite(data.fitment_question_count)
+            ? data.fitment_question_count
+            : 0;
+        this.renderFitmentChip('questions');
 
         this.renderQuestionsList(Array.isArray(data.items) ? data.items : []);
         this.renderQuestionsPagination();
@@ -1283,13 +1421,6 @@ export default class UgcProduct {
         }
 
         const { questionsControl } = target.dataset;
-
-        if (questionsControl === 'vehicle_first') {
-            // Shared toggle — refetches both lists itself when the effective
-            // sort_alias changes.
-            this._setVehicleFirst(target.checked);
-            return;
-        }
 
         if (questionsControl !== 'sort') {
             return;
@@ -2051,6 +2182,7 @@ export default class UgcProduct {
 
     destroy() {
         if (this.unsubscribe) this.unsubscribe();
+        if (this.unsubscribeGlobal) this.unsubscribeGlobal();
 
         if (this.gridResizeObserver) {
             this.gridResizeObserver.disconnect();
@@ -2070,6 +2202,14 @@ export default class UgcProduct {
 
         if (this.questionsPaginationElement) {
             this.questionsPaginationElement.removeEventListener('click', this.onQuestionsPaginationClick);
+        }
+
+        if (this.reviewsFitmentChipElement) {
+            this.reviewsFitmentChipElement.removeEventListener('click', this.onFitmentChipClick);
+        }
+
+        if (this.questionsFitmentChipElement) {
+            this.questionsFitmentChipElement.removeEventListener('click', this.onFitmentChipClick);
         }
 
         if (this.listElement) {

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -830,6 +830,66 @@ $cs-button-height: 50px;
   font-weight: 600;
 }
 
+// "For your <vehicle>" fitment filter chip (SRS §3.4.1). The slot reserves the
+// chip's row height even when empty so the async paint never shifts the
+// toolbar (CLS); ugcProduct.js flips visibility, never display. Shared by the
+// reviews and Q&A toolbars.
+.cs-fitment-chip-slot {
+  display: flex;
+  align-items: center;
+  gap: spacing('quarter');
+  min-height: 44px;
+  visibility: hidden;
+}
+
+.cs-fitment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: spacing('half');
+  min-height: 36px;
+  padding: 0 spacing('half');
+  border: 1px solid stencilColor('color-textSecondary');
+  border-radius: 999px;
+  background: transparent;
+  color: stencilColor('color-textBase');
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &.is-active {
+    border-color: stencilColor('color-primary');
+    background: stencilColor('color-primary');
+    color: stencilColor('color-textInverse');
+  }
+}
+
+.cs-fitment-chip-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.375rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.08);
+  font-size: 0.75rem;
+}
+
+.cs-fitment-chip-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: stencilColor('color-textSecondary');
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
 // Visuals come from the shared .cs-form-select class (the add-to-cart option
 // dropdowns) on the same element — identical by construction.
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -763,7 +763,6 @@
             "filter_rating_all": "All ratings",
             "filter_verified": "Verified purchasers",
             "filter_media": "With photos & videos",
-            "filter_vehicle_first": "My vehicle first",
             "form_write": {
                 "name": "Name",
                 "email": "Email",
@@ -794,7 +793,6 @@
         "questions": {
             "header": "Q&A",
             "sort_label": "Sort by",
-            "filter_vehicle_first": "My vehicle first",
             "sort_newest": "Newest",
             "sort_oldest": "Oldest",
             "submit": {

--- a/templates/components/products-cs/qa-cs.html
+++ b/templates/components/products-cs/qa-cs.html
@@ -7,12 +7,11 @@
                 <option value="date_asc">{{lang 'products.questions.sort_oldest'}}</option>
             </select>
         </label>
-        {{!-- Opt-in alias-aware sort: disabled until a vehicle is selected;
-        ugcProduct.js enables it and mirrors it with the reviews toolbar's copy. --}}
-        <label class="cs-questions-control cs-questions-control--toggle">
-            <input type="checkbox" data-questions-control="vehicle_first" disabled>
-            <span class="cs-questions-control-label">{{lang 'products.questions.filter_vehicle_first'}}</span>
-        </label>
+        {{!-- "For your <vehicle>" fitment filter chip (SRS §3.4.1). Populated
+        async by ugcProduct.js only when the envelope's fitment_question_count > 0;
+        space is reserved via min-height + visibility:hidden in SCSS so the late
+        paint never shifts the toolbar. --}}
+        <div class="cs-fitment-chip-slot" data-questions-fitment-chip></div>
         <button type="button" class="button button--primary cs-ugc-submit-open" data-question-modal-open>
             {{lang 'products.questions.submit.open'}}
         </button>

--- a/templates/components/products-cs/reviews-cs.html
+++ b/templates/components/products-cs/reviews-cs.html
@@ -34,12 +34,11 @@
             <input type="checkbox" data-reviews-control="media">
             <span class="cs-reviews-control-label">{{lang 'products.reviews.filter_media'}}</span>
         </label>
-        {{!-- Opt-in alias-aware sort: disabled until a vehicle is selected;
-        ugcProduct.js enables it and mirrors it with the Q&A toolbar's copy. --}}
-        <label class="cs-reviews-control cs-reviews-control--toggle">
-            <input type="checkbox" data-reviews-control="vehicle_first" disabled>
-            <span class="cs-reviews-control-label">{{lang 'products.reviews.filter_vehicle_first'}}</span>
-        </label>
+        {{!-- "For your <vehicle>" fitment filter chip (SRS §3.4.1). Populated
+        async by ugcProduct.js only when the envelope's fitment_review_count > 0;
+        space is reserved via min-height + visibility:hidden in SCSS so the late
+        paint never shifts the toolbar. --}}
+        <div class="cs-fitment-chip-slot" data-reviews-fitment-chip></div>
         <button type="button" class="button button--primary cs-ugc-submit-open" data-review-modal-open>
             {{lang 'products.reviews.submit.open'}}
         </button>


### PR DESCRIPTION
## M9 Slice A (#158) — fitment filter chip + `sort_alias` removal

Second slice of the M9 fitment-aware UGC work (Foundation = #37, merged). Built object-only against the frozen contract; verified with Jest stubs (live end-to-end is M11/#163).

### What it delivers (SRS §3.4.1, §3.2.1 / §3.2.2)
- **"For your &lt;vehicle&gt;" chip** on both the reviews list and the Q&A list, driven by the envelope's pre-filter `fitment_review_count` / `fitment_question_count`. Renders only when the garage vehicle resolves to a label **and** the count > 0 — so no chip on universal products / unresolved fitment. CLS-safe (space reserved via `visibility:hidden`).
- Clicking the chip **hard-filters** with `fitment_only=true` (composes with sort/rating/verified/media, resets to page 1); an active chip exposes a clear (`×`) that drops the flag. Default view stays newest-first.
- The garage `fitment_id` rides on **every** `getReviews` / `getQuestions` call, resolved from `GlobalStateManager` (new `UgcProduct` injection from `productController`) via the Foundation `resolveGarageFitment(registry, garage)`. A garage swap or late-arriving registry re-resolves, resets `fitment_only`, and refetches both loaded lists.

### Removed (per the issue rip-out list)
`vehicleFirst` / `sortAlias` state, `_setVehicleFirst`, `_applySortAlias`, `_syncVehicleToggles`, `applyAliasSort`'s sort-float, the `sort_alias` param in both param builders, the `vehicle_first` toolbar branches, the toggle markup in both templates, and the two `filter_vehicle_first` lang strings. **Kept:** `aliasIndex` / `qty_alias_index` still rides on submissions as `alias_id` (provenance, §3.1.4) — it just no longer triggers a refetch.

### Verification
`npx grunt check` green — ESLint clean, **310/310 Jest tests** (20 suites), stylelint 197 files clean.

### Known minor edge (non-blocking)
If the search registry lands during the ~ms window while the *initial* list fetch is still in flight, the chip first appears on the next garage interaction rather than immediately. Mitigated because the registry is normally already in global state (localStorage-cached, 24h TTL) and read synchronously by the pre-fetch seed. No SRS contradiction.

Refs #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
