### PR TITLE
M9 Slice C (#158): structured vehicle badge on cards + overview wall

### DIFF
--- a/assets/js/test-unit/theme/global/ugcOverview.spec.js
+++ b/assets/js/test-unit/theme/global/ugcOverview.spec.js
@@ -2,6 +2,7 @@ import UgcOverview, {
     FILTERS,
     applyFilter,
     buildStarIcons,
+    buildVehicleBadge,
     paginate,
     pageCount,
 } from '../../../theme/_addons/global/ugcOverview';
@@ -97,6 +98,26 @@ describe('ugcOverview pure helpers', () => {
             const reviews = [{ rating: 5 }, { rating: 5, media: null }];
             expect(applyFilter(reviews, FILTERS.WITH_PHOTOS)).toHaveLength(0);
             expect(applyFilter(reviews, FILTERS.BASIC)).toHaveLength(2);
+        });
+    });
+
+    describe('buildVehicleBadge', () => {
+        it('renders the system-generated vehicle_label inside the badge', () => {
+            const html = buildVehicleBadge('MINI Cooper F56');
+            expect(html).toContain('cs-ugc-vehicle-badge');
+            expect(html).toContain('MINI Cooper F56');
+        });
+
+        it('escapes the label (no XSS via vehicle_label)', () => {
+            const html = buildVehicleBadge('<img src=x onerror=alert(1)>');
+            expect(html).not.toContain('<img');
+            expect(html).toContain('&lt;img');
+        });
+
+        it('omits the badge entirely when there is no vehicle (null / empty / missing)', () => {
+            expect(buildVehicleBadge(null)).toBe('');
+            expect(buildVehicleBadge(undefined)).toBe('');
+            expect(buildVehicleBadge('')).toBe('');
         });
     });
 
@@ -237,5 +258,29 @@ describe('UgcOverview controller', () => {
 
         const img = document.querySelector('.cs-ugc-overview-thumb img');
         expect(img.getAttribute('src')).toBe('https://cdn/0/thumb.jpg');
+    });
+
+    it('renders the structured-vehicle badge on a wall card from vehicle_label', async () => {
+        const reviews = makeReviews(1);
+        reviews[0].vehicle_label = 'MINI Cooper F56';
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        const badge = document.querySelector('.cs-ugc-overview-card .cs-ugc-vehicle-badge');
+        expect(badge).not.toBeNull();
+        expect(badge.textContent).toBe('MINI Cooper F56');
+    });
+
+    it('omits the badge on a wall card with no vehicle (null / missing label)', async () => {
+        const reviews = makeReviews(2);
+        reviews[0].vehicle_label = null;
+        // reviews[1] has no vehicle_label key at all.
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(2);
+        expect(document.querySelector('.cs-ugc-vehicle-badge')).toBeNull();
     });
 });

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -2935,3 +2935,130 @@ describe('UgcProduct (#30 — review media display)', () => {
         });
     });
 });
+
+// Slice C (#158, SRS §3.4 / §3.2.1 / §3.2.2): the structured-vehicle badge on
+// review and question cards — the item's system-generated `vehicle_label`,
+// rendered directly from the envelope (no client-side fitment resolution),
+// absent entirely when the item has no vehicle.
+describe('UgcProduct (slice C — structured-vehicle badge on cards)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    describe('review cards', () => {
+        beforeEach(() => {
+            mountScaffold();
+        });
+
+        it('renders the badge from vehicle_label with the shared badge class', async () => {
+            const api = buildApi(okEnvelope({
+                total: 1,
+                items: [{
+                    id: 1, author: 'Jane D.', rating: 5, title: 't', body: 'b',
+                    vehicle_label: 'MINI Cooper F56', date: '2026-01-15T00:00:00Z',
+                }],
+            }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const badge = document.querySelector('#product-reviews .cs-review-vehicle');
+            expect(badge).not.toBeNull();
+            expect(badge.classList.contains('cs-ugc-vehicle-badge')).toBe(true);
+            expect(badge.textContent).toBe('MINI Cooper F56');
+        });
+
+        it('omits the badge when the review has no vehicle (null / missing label)', async () => {
+            const api = buildApi(okEnvelope({
+                total: 2,
+                items: [
+                    {
+                        id: 1, author: 'A', rating: 5, title: 't', body: 'b',
+                        vehicle_label: null, date: '2026-01-15T00:00:00Z',
+                    },
+                    {
+                        id: 2, author: 'B', rating: 4, title: 't', body: 'b',
+                        date: '2026-02-01T00:00:00Z',
+                    },
+                ],
+            }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(document.querySelectorAll('#product-reviews .cs-review')).toHaveLength(2);
+            expect(document.querySelector('#product-reviews .cs-review-vehicle')).toBeNull();
+        });
+
+        it('escapes the vehicle_label (no XSS via the badge)', async () => {
+            const api = buildApi(okEnvelope({
+                total: 1,
+                items: [{
+                    id: 1, author: 'A', rating: 5, title: 't', body: 'b',
+                    vehicle_label: '<img src=x onerror=alert(1)>', date: '2026-01-15T00:00:00Z',
+                }],
+            }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const badge = document.querySelector('#product-reviews .cs-review-vehicle');
+            expect(badge).not.toBeNull();
+            expect(badge.querySelector('img')).toBeNull();
+            expect(badge.textContent).toBe('<img src=x onerror=alert(1)>');
+        });
+    });
+
+    describe('question cards', () => {
+        const buildQaApi = result => ({
+            getReviews: jest.fn(() => Promise.resolve({ ok: true, status: 200, data: buildEnvelope() })),
+            getQuestions: jest.fn(() => Promise.resolve(result)),
+        });
+
+        const okQuestions = items => ({
+            ok: true,
+            status: 200,
+            data: {
+                items, total: items.length, page: 1, per_page: 10,
+            },
+        });
+
+        beforeEach(() => {
+            document.body.innerHTML = `
+                <div class="cs-questions-toolbar" data-questions-toolbar>
+                    <select data-questions-control="sort">
+                        <option value="date_desc">Newest</option>
+                        <option value="date_asc">Oldest</option>
+                    </select>
+                    <div class="cs-fitment-chip-slot" data-questions-fitment-chip></div>
+                </div>
+                <div id="product-questions"></div>
+                <div class="cs-questions-pagination" data-questions-pagination></div>
+            `;
+        });
+
+        it('renders the badge from vehicle_label with the shared badge class', async () => {
+            const api = buildQaApi(okQuestions([{
+                id: 1, author: 'Jane D.', body: 'Does this fit?',
+                vehicle_label: 'MINI Cooper F56', staff_answer: 'Yes.',
+                date: '2026-05-01T12:00:00Z',
+            }]));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const badge = document.querySelector('#product-questions .cs-question-vehicle');
+            expect(badge).not.toBeNull();
+            expect(badge.classList.contains('cs-ugc-vehicle-badge')).toBe(true);
+            expect(badge.textContent).toBe('MINI Cooper F56');
+        });
+
+        it('omits the badge when the question has no vehicle', async () => {
+            const api = buildQaApi(okQuestions([{
+                id: 1, author: 'Bob', body: 'Is hardware included?',
+                staff_answer: 'Yes.', date: '2026-04-15T00:00:00Z',
+            }]));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(document.querySelectorAll('#product-questions .cs-question')).toHaveLength(1);
+            expect(document.querySelector('#product-questions .cs-question-vehicle')).toBeNull();
+        });
+    });
+});

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -78,6 +78,25 @@ export function buildStarIcons(rating) {
 }
 
 /**
+ * Build the structured-vehicle badge from a review's system-generated
+ * `vehicle_label` (cs-ugc SRS §3.4.2 / §3.2.1 — the display label the storefront
+ * resolved at submit, e.g. "MINI Cooper F56"). Display-only on the home wall in
+ * v1; garage-aware filtering of the wall is deferred to v1.1. A review with no
+ * vehicle (universal product, or the submitter opted out) carries a `null` /
+ * absent label — the badge is then omitted entirely (not an empty element), so
+ * there is nothing to reserve space for.
+ * @param {string|null|undefined} label
+ * @returns {string}
+ */
+export function buildVehicleBadge(label) {
+    if (!label) {
+        return '';
+    }
+
+    return `<p class="cs-ugc-vehicle-badge cs-ugc-overview-vehicle">${escapeHtml(label)}</p>`;
+}
+
+/**
  * Slice a filtered dataset to a single page.
  * @param {Object[]} reviews
  * @param {number} page - 1-indexed.
@@ -228,6 +247,7 @@ export default class UgcOverview {
                 <div class="cs-ugc-overview-card-body">
                     <div class="cs-ugc-overview-stars" role="img" aria-label="${rating} out of ${MAX_STARS} stars">${stars}</div>
                     ${title ? `<h3 class="cs-ugc-overview-title">${title}</h3>` : ''}
+                    ${buildVehicleBadge(review.vehicle_label)}
                     <p class="cs-ugc-overview-text">${body}</p>
                     <p class="cs-ugc-overview-meta">
                         <span class="cs-ugc-overview-author">${author}</span>

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -1785,7 +1785,7 @@ export default class UgcProduct {
                     <span class="cs-question-author">${author}</span>
                     ${date ? `<span class="cs-question-date">${date}</span>` : ''}
                 </p>
-                ${vehicle ? `<p class="cs-question-vehicle">${vehicle}</p>` : ''}
+                ${vehicle ? `<p class="cs-ugc-vehicle-badge cs-question-vehicle">${vehicle}</p>` : ''}
                 <p class="cs-question-body">${body}</p>
                 ${answer}
             </article>`;
@@ -2386,7 +2386,7 @@ export default class UgcProduct {
                     ${verified}
                     ${edited}
                 </p>
-                ${vehicle ? `<p class="cs-review-vehicle">${vehicle}</p>` : ''}
+                ${vehicle ? `<p class="cs-ugc-vehicle-badge cs-review-vehicle">${vehicle}</p>` : ''}
                 <p class="cs-review-body">${body}</p>
                 ${media}
                 ${staff}

--- a/assets/scss/custom/_cs-home.scss
+++ b/assets/scss/custom/_cs-home.scss
@@ -261,6 +261,10 @@
   font-size: stencilFontSize('smaller');
 }
 
+.cs-ugc-overview-vehicle {
+  margin: 0;
+}
+
 .cs-ugc-overview-text {
   margin: 0;
 }

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1044,7 +1044,6 @@ $cs-button-height: 50px;
 .cs-ugc-vehicle-badge {
   display: inline-flex;
   align-items: center;
-  align-self: flex-start;
   max-width: 100%;
   padding: 0.125rem spacing('half');
   border: 1px solid stencilColor('color-textSecondary');

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1037,8 +1037,24 @@ $cs-button-height: 50px;
   color: stencilColor('color-greyDark');
 }
 
+// Structured-vehicle badge (cs-ugc SRS §3.4 / Pass 27). Shared across review
+// cards, question cards, and the home overview wall — the review's
+// system-generated `vehicle_label` (e.g. 'MINI Cooper F56'), display-only.
+// Absent entirely when the item has no vehicle, so no space is reserved.
+.cs-ugc-vehicle-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 0.125rem spacing('half');
+  border: 1px solid stencilColor('color-textSecondary');
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
 .cs-review-vehicle {
-  font-style: italic;
   margin: 0 0 spacing('half');
 }
 
@@ -1166,7 +1182,6 @@ $cs-button-height: 50px;
 }
 
 .cs-question-vehicle {
-  font-style: italic;
   margin: 0 0 spacing('half');
 }
 


### PR DESCRIPTION
## M9 Slice C (#158) — structured vehicle badge (final slice)

Last of four slices decomposing cs-ugc **#158** (M9 Fitment-Aware UGC), stacked into `cs-ugc-frontend`. Built **object-only** against the frozen Pass 27 contract. Foundation (#37), Slice A (#38), Slice B (#39) all merged here.

### What this delivers (issue §3 req 4, SRS §3.4.2 / §3.2.1 / §3.2.2)
Renders the **system-generated vehicle label** (e.g. "MINI Cooper F56") as a badge on:
- **Review cards** and **question cards** (`ugcProduct.js`) — gain the shared `cs-ugc-vehicle-badge` class. These already rendered `vehicle_label` since M6; Pass 27 changed the field's *semantics* (free-text → system-generated), not its name or render path.
- **Home overview photo wall** (`ugcOverview.js`) — new exported `buildVehicleBadge(label)`, wired into the wall card body. **This was the real gap** — the wall had no badge.

### Display-only in v1
Garage-aware **filtering** of the home wall is explicitly **v1.1** and is **not** implemented here — display only.

### Source of the label
Badge text comes straight from each item's **`vehicle_label`** envelope field (SRS §3.2.1: Review object's system-generated display label; §3.2.2: question objects carry `fitment_id` + generated `vehicle_label`). No `fitment_id → label` resolution on the display path — the envelope already carries the resolved label. Escaped via the existing card escaping (`_escape` / `escapeHtml`).

### No-vehicle case
An item with no vehicle (universal product, or submitter opted out) renders **no badge element at all** — nothing reserves space.

### Verification
`npx grunt check` green — ESLint clean, **331** Jest tests (+9 new), stylelint 197 files clean. New tests cover present/absent/escaped badge on all three surfaces. Verified against Jest stubs; live e2e gated in M11 #163.

Refs #158 — this is the final slice; once the whole `cs-ugc-frontend` integration lands, #158 closes in cs-ugc per its DoD (code-complete + merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
