### PR TITLE
M9 #181 (partial): fitment chip a11y + active styling, badge truncation, make+model chip label

### DIFF
--- a/assets/js/test-unit/theme/global/vehicleFitment.spec.js
+++ b/assets/js/test-unit/theme/global/vehicleFitment.spec.js
@@ -53,14 +53,14 @@ describe('vehicleFitment', () => {
     });
 
     describe('resolveGarageFitment', () => {
-        it('resolves a complete garage selection to fitment_id + label', () => {
+        it('resolves a complete garage selection to fitment_id + a make/model label', () => {
             const result = resolveGarageFitment(registry, { make: 'mini', model: 'cooper', generation: 'cooperf56' });
-            expect(result).toEqual({ fitment_id: 87, label: 'MINI Cooper F56' });
+            expect(result).toEqual({ fitment_id: 87, label: 'MINI Cooper' });
         });
 
         it('returns null fitment_id (un-filterable) when the node has no id, label still resolves', () => {
             const result = resolveGarageFitment(registry, { make: 'mini', model: 'cooper', generation: 'coopernoid' });
-            expect(result).toEqual({ fitment_id: null, label: 'MINI Cooper (unmapped)' });
+            expect(result).toEqual({ fitment_id: null, label: 'MINI Cooper' });
         });
 
         it('returns null for an incomplete garage selection', () => {
@@ -77,10 +77,10 @@ describe('vehicleFitment', () => {
             expect(resolveGarageFitment(null, { make: 'mini', model: 'cooper', generation: 'cooperf56' })).toBeNull();
         });
 
-        it('falls back to the generation slug as label when the node carries no name', () => {
+        it('falls back to make/model slugs for the label when brand/model names are absent', () => {
             const noName = { models: { cooper: { generations: { cooperf56: { fitment_id: 87 } } } } };
             const result = resolveGarageFitment(noName, { make: 'mini', model: 'cooper', generation: 'cooperf56' });
-            expect(result).toEqual({ fitment_id: 87, label: 'cooperf56' });
+            expect(result).toEqual({ fitment_id: 87, label: 'mini cooper' });
         });
     });
 

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -27,10 +27,15 @@ const buildStateManager = () => {
 };
 
 // Minimal GlobalStateManager stub: holds a vehicle.selected + a search registry
-// and lets a test emit a new global snapshot. `registry.models[model]
-// .generations[generation]` mirrors the search-JSON shape resolveGarageFitment
-// reads (object generation node `{ name, fitment_id }`, SRS §3.1.4 Pass 27).
+// and lets a test emit a new global snapshot. Mirrors the live search-JSON shape
+// resolveGarageFitment reads: a `brands` map keyed by make slug, a `models` map
+// keyed by model slug, and object generation nodes `{ name, fitment_id }`
+// (SRS §3.1.4 Pass 27). The chip names the garage vehicle by make + model
+// ("MINI Cooper"), composed from the brand/model display names.
 const F56_REGISTRY = {
+    brands: {
+        mini: { name: 'MINI', models: ['cooper'] },
+    },
     models: {
         cooper: {
             name: 'Cooper',
@@ -844,7 +849,7 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
         const chip = document.querySelector('[data-questions-fitment-chip]');
         const toggle = chip.querySelector('[data-fitment-chip-toggle]');
         expect(toggle).not.toBeNull();
-        expect(toggle.textContent).toContain('For your MINI Cooper F56');
+        expect(toggle.textContent).toContain('For your MINI Cooper');
         expect(chip.style.visibility).toBe('visible');
     });
 
@@ -966,7 +971,7 @@ describe('UgcProduct (slice A — fitment filter chip, reviews)', () => {
         const chip = reviewsChip();
         const toggle = chip.querySelector('[data-fitment-chip-toggle]');
         expect(toggle).not.toBeNull();
-        expect(toggle.textContent).toContain('For your MINI Cooper F56');
+        expect(toggle.textContent).toContain('For your MINI Cooper');
         expect(chip.querySelector('.cs-fitment-chip-count').textContent).toBe('7');
         expect(chip.style.visibility).toBe('visible');
     });

--- a/assets/js/theme/_addons/global/vehicleFitment.js
+++ b/assets/js/theme/_addons/global/vehicleFitment.js
@@ -42,13 +42,18 @@ export function generationFitmentId(node) {
  * Resolve the visitor's garage selection to its fitment identity from the search
  * JSON's `vehicle_registry`. The registry's `models` map is keyed by bare model
  * slug and each model's `generations` map by bare generation slug — the same
- * slugs the vehicle selector persists.
+ * slugs the vehicle selector persists; the `brands` map is keyed by make slug.
+ *
+ * The display `label` is composed "<make> <model>" (e.g. "MINI Cooper") from the
+ * brand and model display names. The generation node's own `name` is the
+ * generation-only label (e.g. "F56 2014 to 2024"), so it is intentionally NOT
+ * used here — naming the garage vehicle by make + model reads cleanly on the
+ * "For your <vehicle>" chip. Make/model names fall back to their slugs if absent.
  * @param {Object|null} registry - The `vehicle_registry` object.
  * @param {{make: string, model: string, generation: string}|null} garage
- * @returns {{fitment_id: (number|null), label: (string|null)}|null}
+ * @returns {{fitment_id: (number|null), label: string}|null}
  *   `null` when there is no garage selection or no matching registry path;
- *   otherwise `fitment_id` is `null` for an un-filterable (no-id) generation,
- *   and `label` falls back to the make/model/generation slug string.
+ *   otherwise `fitment_id` is `null` for an un-filterable (no-id) generation.
  */
 export function resolveGarageFitment(registry, garage) {
     if (!registry || !garage || !garage.make || !garage.model || !garage.generation) {
@@ -62,10 +67,14 @@ export function resolveGarageFitment(registry, garage) {
     const genNode = model.generations[garage.generation];
     if (!genNode) return null;
 
-    const label = generationLabel(genNode);
+    const brands = registry.brands || {};
+    const brandNode = brands[garage.make];
+    const makeName = (brandNode && brandNode.name) ? brandNode.name : garage.make;
+    const modelName = model.name || garage.model;
+
     return {
         fitment_id: generationFitmentId(genNode),
-        label: label || garage.generation,
+        label: `${makeName} ${modelName}`,
     };
 }
 

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -25,6 +25,8 @@ $cs-product-max-width: 1440px;
 $cs-badge-max-width: 128px;
 $cs-modal-media-width: 220px;
 $cs-button-height: 50px;
+// Active fitment-chip accent — literal (no matching stencil token); ~5.1:1 on #fff.
+$cs-fitment-active: #06c;
 
 @mixin shimmer {
   background: #e0e0e0;
@@ -854,12 +856,23 @@ $cs-button-height: 50px;
   color: stencilColor('color-textBase');
   font-size: 0.875rem;
   font-weight: 600;
+  line-height: 1;
   cursor: pointer;
 
   &.is-active {
-    border-color: stencilColor('color-primary');
-    background: stencilColor('color-primary');
-    color: stencilColor('color-textInverse');
+    border-color: $cs-fitment-active;
+    background: $cs-fitment-active;
+    color: #fff;
+
+    .cs-fitment-chip-count {
+      background: #fff;
+      color: $cs-fitment-active;
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid stencilColor('color-primary');
+    outline-offset: 2px;
   }
 }
 
@@ -873,6 +886,7 @@ $cs-button-height: 50px;
   border-radius: 999px;
   background: rgba(0, 0, 0, 0.08);
   font-size: 0.75rem;
+  line-height: 1;
 }
 
 .cs-fitment-chip-clear {
@@ -888,6 +902,11 @@ $cs-button-height: 50px;
   font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid stencilColor('color-primary');
+    outline-offset: 2px;
+  }
 }
 
 // Visuals come from the shared .cs-form-select class (the add-to-cart option
@@ -1042,15 +1061,17 @@ $cs-button-height: 50px;
 // system-generated `vehicle_label` (e.g. 'MINI Cooper F56'), display-only.
 // Absent entirely when the item has no vehicle, so no space is reserved.
 .cs-ugc-vehicle-badge {
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
   max-width: 100%;
   padding: 0.125rem spacing('half');
   border: 1px solid stencilColor('color-textSecondary');
   border-radius: 999px;
+  overflow: hidden;
   font-size: 0.8125rem;
   font-weight: 600;
   line-height: 1.4;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .cs-review-vehicle {


### PR DESCRIPTION
First slice of the **#181** visual/UX polish pass over the M9 fitment surfaces. Partial — the chip + badge items; the issue stays open for the remaining tiers.

## Included
- **Fitment chip accessibility:** `:focus-visible` rings on the toggle + clear buttons (they had none; every other interactive element here did).
- **Active-state contrast fix:** the active count pill was unreadable — `color-textInverse` is **undefined** in `config.json`, so the active chip text and pill resolved to nothing. Replaced with literal `#fff`; active pill is now white with a primary-colored number.
- **Active accent recolor:** active chip is blue via a new local var `$cs-fitment-active: #06c` (~5.1:1 on white). Literal, not a new stencil token.
- **Centering:** `line-height: 1` on the chip label + count pill.
- **Badge long-label truncation:** `.cs-ugc-vehicle-badge` → single-line ellipsis (`inline-block` + `nowrap`/`overflow`/`text-overflow`), works as a flex item on the home overview wall too.
- **Chip label fix:** `resolveGarageFitment` now composes the "For your <vehicle>" label as **make + model** ("MINI Cooper") from the registry brand/model names, instead of the generation-only node name ("F56 2014 to 2024").

## Not included (remaining #181)
- Tier 3: chip hover state / 44px touch targets.
- Tier 4: stale JSDoc cleanup. (Vehicle-dropdown styling is moot — #41 replaces that dropdown.)

`npx grunt check` green (eslint + 331 Jest + stylelint). Built object-only on `cs-ugc-frontend`.

Tracks **CravenSpeed/cs-ugc#181**. Related: the submission vehicle-field redesign is #41.