### PR TITLE
#45: click a review/question vehicle badge to filter that vehicle

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -1119,6 +1119,234 @@ describe('UgcProduct (slice A — fitment filter chip, reviews)', () => {
     });
 });
 
+describe('UgcProduct (issue #45 — click a vehicle badge to filter)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    const paramsOfCall = (api, n) => api.getReviews.mock.calls[n - 1][1];
+    const lastReviewParams = api => paramsOfCall(api, api.getReviews.mock.calls.length);
+    const reviewsChip = () => document.querySelector('[data-reviews-fitment-chip]');
+    const reviewBadges = () => document.querySelectorAll('#product-reviews .cs-ugc-vehicle-badge');
+
+    const reviewItem = (over = {}) => ({
+        id: 1,
+        author: 'Jane D.',
+        rating: 5,
+        title: 't',
+        body: 'b',
+        fitment_id: 42,
+        vehicle_label: 'MINI Cooper R53 2002 to 2006',
+        ...over,
+    });
+
+    const buildReviewsApiWith = (items, count) => ({
+        getReviews: jest.fn(() => Promise.resolve(okEnvelope({
+            items,
+            total: items.length,
+            fitment_review_count: count === undefined ? items.length : count,
+        }))),
+    });
+
+    describe('reviews', () => {
+        beforeEach(() => {
+            mountScaffold();
+        });
+
+        it('renders a clickable button badge for a review with a fitment_id, a static <p> without', async () => {
+            const items = [
+                reviewItem({ id: 1, fitment_id: 42, vehicle_label: 'MINI Cooper R53 2002 to 2006' }),
+                reviewItem({ id: 2, fitment_id: null, vehicle_label: 'Legacy Vehicle' }),
+            ];
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildReviewsApiWith(items));
+            await flush();
+
+            const badges = reviewBadges();
+            expect(badges.length).toBe(2);
+            expect(badges[0].tagName).toBe('BUTTON');
+            expect(badges[0].dataset.fitmentFilter).toBe('42');
+            expect(badges[0].dataset.fitmentLabel).toBe('MINI Cooper R53 2002 to 2006');
+            expect(badges[1].tagName).toBe('P');
+            expect(badges[1].hasAttribute('data-fitment-filter')).toBe(false);
+        });
+
+        it('renders a static (non-clickable) badge for the lightbox review, a button in the list', async () => {
+            const ugc = new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildReviewsApiWith([]));
+            await flush();
+            const review = reviewItem({ fitment_id: 42 });
+
+            // List context (default): a clickable filter button.
+            expect(ugc._buildReview(review)).toContain('data-fitment-filter="42"');
+
+            // Lightbox context (clickable=false): a static <p>, no filter hook.
+            const lightbox = ugc._buildReview(review, false, false);
+            expect(lightbox).toContain('<p class="cs-ugc-vehicle-badge cs-review-vehicle">');
+            expect(lightbox).not.toContain('data-fitment-filter');
+        });
+
+        it('filters to the clicked vehicle (fitment_only + that fitment_id, page 1) on badge click', async () => {
+            const api = buildReviewsApiWith([reviewItem({ fitment_id: 42 })], 4);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            reviewBadges()[0].click();
+            await flush();
+
+            expect(api.getReviews).toHaveBeenCalledTimes(2);
+            expect(paramsOfCall(api, 2).fitment_id).toBe(42);
+            expect(paramsOfCall(api, 2).fitment_only).toBe(true);
+            expect(paramsOfCall(api, 2).page).toBe(1);
+        });
+
+        it('shows a "Showing: <vehicle>" takeover chip and clears back to the default view', async () => {
+            const api = buildReviewsApiWith([reviewItem({ fitment_id: 42 })], 4);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            reviewBadges()[0].click();
+            await flush();
+
+            const showing = reviewsChip().querySelector('.cs-fitment-showing');
+            expect(showing).not.toBeNull();
+            expect(showing.textContent).toContain('Showing: MINI Cooper R53 2002 to 2006');
+            expect(reviewsChip().querySelector('[data-fitment-chip-clear]')).not.toBeNull();
+            expect(reviewsChip().style.visibility).toBe('visible');
+
+            reviewsChip().querySelector('[data-fitment-chip-clear]').click();
+            await flush();
+
+            expect(api.getReviews).toHaveBeenCalledTimes(3);
+            expect(paramsOfCall(api, 3).fitment_id).toBeNull();
+            expect(paramsOfCall(api, 3).fitment_only).toBeNull();
+            expect(reviewsChip().querySelector('.cs-fitment-showing')).toBeNull();
+        });
+
+        it('activates the garage chip (no takeover) when the clicked badge is the garage vehicle', async () => {
+            const api = buildReviewsApiWith([reviewItem({ fitment_id: 87, vehicle_label: 'MINI Cooper F56 2014 to 2024' })], 5);
+            const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+            await flush();
+
+            reviewBadges()[0].click();
+            await flush();
+
+            expect(reviewsChip().querySelector('.cs-fitment-showing')).toBeNull();
+            expect(reviewsChip().querySelector('[data-fitment-chip-toggle]').classList).toContain('is-active');
+            expect(lastReviewParams(api).fitment_id).toBe(87);
+            expect(lastReviewParams(api).fitment_only).toBe(true);
+        });
+
+        it('takes over the garage chip with a non-garage vehicle and restores it on clear', async () => {
+            const api = buildReviewsApiWith([reviewItem({ fitment_id: 42 })], 5);
+            const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+            await flush();
+            expect(reviewsChip().textContent).toContain('For your MINI Cooper');
+
+            reviewBadges()[0].click();
+            await flush();
+
+            expect(reviewsChip().querySelector('[data-fitment-chip-toggle]')).toBeNull();
+            expect(reviewsChip().querySelector('.cs-fitment-showing').textContent).toContain('Showing: MINI Cooper R53');
+            expect(lastReviewParams(api).fitment_id).toBe(42);
+
+            reviewsChip().querySelector('[data-fitment-chip-clear]').click();
+            await flush();
+
+            expect(lastReviewParams(api).fitment_id).toBe(87);
+            expect(lastReviewParams(api).fitment_only).toBeNull();
+            expect(reviewsChip().textContent).toContain('For your MINI Cooper');
+        });
+
+        it('drops an active click-filter when the garage vehicle is swapped', async () => {
+            const registry = {
+                brands: { mini: { name: 'MINI', models: ['cooper'] } },
+                models: {
+                    cooper: {
+                        name: 'Cooper',
+                        generations: {
+                            f56: { name: 'F56 2014 to 2024', fitment_id: 87 },
+                            r53: { name: 'R53 2002 to 2006', fitment_id: 42 },
+                            r56: { name: 'R56 2007 to 2013', fitment_id: 99 },
+                        },
+                    },
+                },
+            };
+            const api = buildReviewsApiWith([reviewItem({ fitment_id: 42 })], 5);
+            const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry });
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
+            await flush();
+
+            // Click a non-garage vehicle (R53, 42) → takeover.
+            reviewBadges()[0].click();
+            await flush();
+            expect(lastReviewParams(api).fitment_id).toBe(42);
+            expect(reviewsChip().querySelector('.cs-fitment-showing')).not.toBeNull();
+
+            // Swap the garage to R56 (99): the click-filter is dropped and the
+            // view returns to the new garage's default (unfiltered).
+            global._set({
+                vehicle: { selected: { make: 'mini', model: 'cooper', generation: 'r56' } },
+                search: { data: { vehicle_registry: registry } },
+            });
+            await flush();
+
+            expect(lastReviewParams(api).fitment_id).toBe(99);
+            expect(lastReviewParams(api).fitment_only).toBeNull();
+            expect(reviewsChip().querySelector('.cs-fitment-showing')).toBeNull();
+        });
+    });
+
+    describe('questions', () => {
+        const mountQaScaffold = () => {
+            document.body.innerHTML = `
+                <div class="cs-questions-toolbar" data-questions-toolbar>
+                    <select data-questions-control="sort">
+                        <option value="date_desc">Newest</option>
+                    </select>
+                    <div class="cs-fitment-chip-slot" data-questions-fitment-chip></div>
+                </div>
+                <div id="product-questions"></div>
+                <div class="cs-questions-pagination" data-questions-pagination></div>
+            `;
+        };
+
+        beforeEach(() => {
+            mountQaScaffold();
+        });
+
+        it('filters the Q&A list to a clicked question vehicle', async () => {
+            const questionItems = [{
+                id: 1, author: 'A', body: 'b', fitment_id: 42, vehicle_label: 'MINI Cooper R53 2002 to 2006', staff_answer: 'ans',
+            }];
+            const api = {
+                getReviews: jest.fn(() => Promise.resolve(okEnvelope())),
+                getQuestions: jest.fn(() => Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    data: {
+                        items: questionItems, total: 1, page: 1, per_page: 10, fitment_question_count: 3,
+                    },
+                })),
+            };
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const badge = document.querySelector('#product-questions .cs-ugc-vehicle-badge');
+            expect(badge.tagName).toBe('BUTTON');
+            badge.click();
+            await flush();
+
+            const calls = api.getQuestions.mock.calls;
+            const last = calls[calls.length - 1][1];
+            expect(last.fitment_id).toBe(42);
+            expect(last.fitment_only).toBe(true);
+            expect(last.page).toBe(1);
+            expect(document.querySelector('[data-questions-fitment-chip] .cs-fitment-showing')).not.toBeNull();
+        });
+    });
+});
+
 describe('UgcProduct (slice 6e — submission modal)', () => {
     // A reviews + questions api that resolves both list fetches inertly, plus
     // injectable postReview/postQuestion spies for the submission paths.

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -1184,6 +1184,27 @@ describe('UgcProduct (issue #45 — click a vehicle badge to filter)', () => {
             expect(lightbox).not.toContain('data-fitment-filter');
         });
 
+        it('escapes a vehicle_label with quotes/angle brackets through the data attr and the takeover chip', async () => {
+            const label = '26" Wheels <script>';
+            const api = buildReviewsApiWith([reviewItem({ fitment_id: 42, vehicle_label: label })], 4);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            // The badge label is inert text, and the raw label round-trips
+            // through the escaped data attribute (the browser decodes it back).
+            const badge = reviewBadges()[0];
+            expect(badge.querySelector('script')).toBeNull();
+            expect(badge.dataset.fitmentLabel).toBe(label);
+
+            badge.click();
+            await flush();
+
+            // The "Showing:" takeover chip renders the label as text, not markup.
+            const showing = reviewsChip().querySelector('.cs-fitment-showing');
+            expect(showing.querySelector('script')).toBeNull();
+            expect(showing.textContent).toBe(`Showing: ${label}`);
+        });
+
         it('filters to the clicked vehicle (fitment_only + that fitment_id, page 1) on badge click', async () => {
             const api = buildReviewsApiWith([reviewItem({ fitment_id: 42 })], 4);
             new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -196,6 +196,10 @@ const MESSAGES = {
 // is the resolver's label.
 const fitmentChipLabel = vehicle => `For your ${vehicle}`;
 
+// Active click-filter chip label (issue #45) — names the clicked review/question
+// vehicle that the list is currently restricted to.
+const showingChipLabel = vehicle => `Showing: ${vehicle}`;
+
 export default class UgcProduct {
     /**
      * @param {number|string} archetypeId - QTY archetype id, from the archetype
@@ -284,6 +288,14 @@ export default class UgcProduct {
         this.fitmentReviewCount = 0;
         this.fitmentQuestionCount = 0;
         this.reviewsLoaded = false;
+
+        // Click-to-filter overlay (issue #45): when the visitor clicks a
+        // review/question vehicle badge, this holds that badge's `fitment_id` +
+        // label and takes over the chip slot ("Showing: <vehicle>"), driving the
+        // same `fitment_only` query at the clicked fitment instead of the garage
+        // one. Null = no click-filter, so the garage chip behaves as before.
+        this.clickFilterId = null;
+        this.clickFilterLabel = null;
 
         // Init-race guard (Slice A review nit): a garage/registry change can fire
         // between seeding the fitment and the initial fetch completing, while
@@ -398,6 +410,7 @@ export default class UgcProduct {
         this.onLightboxClick = this.onLightboxClick.bind(this);
         this.onGalleryModalClick = this.onGalleryModalClick.bind(this);
         this.onFitmentChipClick = this.onFitmentChipClick.bind(this);
+        this.onVehicleBadgeClick = this.onVehicleBadgeClick.bind(this);
         this.onReviewVehicleChange = this.onReviewVehicleChange.bind(this);
         this.onQuestionVehicleChange = this.onQuestionVehicleChange.bind(this);
 
@@ -457,6 +470,16 @@ export default class UgcProduct {
         // survive every innerHTML re-render without rebinding (issue #30).
         if (this.listElement) {
             this.listElement.addEventListener('click', this.onMediaTileClick);
+        }
+
+        // Vehicle-badge clicks filter the lists to that review/question's vehicle
+        // (issue #45), delegated on each list so the badges survive re-renders.
+        if (this.listElement) {
+            this.listElement.addEventListener('click', this.onVehicleBadgeClick);
+        }
+
+        if (this.questionsElement) {
+            this.questionsElement.addEventListener('click', this.onVehicleBadgeClick);
         }
 
         if (this.mediaGridElement) {
@@ -1546,18 +1569,34 @@ export default class UgcProduct {
      * @returns {Object}
      */
     buildParams() {
-        // Gate fitment_only on a resolved fitment_id (Slice A review nit): the API
-        // requires fitment_id for fitment_only, so never send the flag without one.
-        const fitmentOnly = (this.fitmentOnly && this.fitmentId !== null) ? true : null;
+        const fitment = this._fitmentParams();
         return {
             page: this.query.page,
             sort: this.query.sort,
             rating: this.query.rating,
             verified: this.query.verified,
             media: this.query.media,
-            fitment_id: this.fitmentId,
-            fitment_only: fitmentOnly,
+            fitment_id: fitment.fitment_id,
+            fitment_only: fitment.fitment_only,
         };
+    }
+
+    /**
+     * Resolve the `fitment_id` + `fitment_only` to send on a list fetch. An
+     * active click-filter (a clicked review/question vehicle, issue #45) wins —
+     * it hard-filters at that fitment. Otherwise the garage fitment drives the
+     * query, with `fitment_only` gated on a resolved id (Slice A review nit: the
+     * API requires `fitment_id` for `fitment_only`, so never send the flag
+     * without one).
+     * @returns {{fitment_id: number|null, fitment_only: boolean|null}}
+     */
+    _fitmentParams() {
+        if (this.clickFilterId !== null) {
+            return { fitment_id: this.clickFilterId, fitment_only: true };
+        }
+
+        const fitmentOnly = (this.fitmentOnly && this.fitmentId !== null) ? true : null;
+        return { fitment_id: this.fitmentId, fitment_only: fitmentOnly };
     }
 
     renderPage(data) {
@@ -1655,8 +1694,12 @@ export default class UgcProduct {
         }
 
         // The new vehicle's chip starts unselected — the honest default is the
-        // unfiltered newest-first view (SRS §3.4.1).
+        // unfiltered newest-first view (SRS §3.4.1). A garage swap is a fresh
+        // vehicle context, so also drop any active click-to-filter takeover
+        // (issue #45) rather than leaving the view pinned to a clicked vehicle.
         this.fitmentOnly = false;
+        this.clickFilterId = null;
+        this.clickFilterLabel = null;
 
         // Before a list has loaded, the in-flight init fetch already captured the
         // prior params — defer the refetch until init completes rather than drop
@@ -1686,19 +1729,77 @@ export default class UgcProduct {
      */
     onFitmentChipClick(event) {
         const trigger = event.target.closest('[data-fitment-chip-toggle], [data-fitment-chip-clear]');
-        if (!trigger || this.fitmentId === null) {
+        if (!trigger) {
             return;
         }
 
         event.preventDefault();
 
         const isClear = trigger.dataset.fitmentChipClear !== undefined;
+
+        // Clearing while a clicked-vehicle filter is active drops back to the
+        // default view — the garage chip reappears (issue #45).
+        if (isClear && this.clickFilterId !== null) {
+            this.clickFilterId = null;
+            this.clickFilterLabel = null;
+            this.fitmentOnly = false;
+            this._refilter();
+            return;
+        }
+
+        // Garage chip toggle — needs a resolved garage fitment.
+        if (this.fitmentId === null) {
+            return;
+        }
+
         const nextOnly = !isClear;
         if (nextOnly === this.fitmentOnly) {
             return;
         }
 
         this.fitmentOnly = nextOnly;
+        this._refilter();
+    }
+
+    /**
+     * Filter both lists to a clicked review/question vehicle (issue #45). The
+     * badge carries the review's own `fitment_id` (SRS §3.2.1) — guaranteed
+     * present whenever the badge renders, since `vehicle_label` is null whenever
+     * `fitment_id` is. Clicking the visitor's own garage vehicle just activates
+     * the garage chip rather than a redundant "Showing:" takeover.
+     * @param {Event} event
+     */
+    onVehicleBadgeClick(event) {
+        const badge = event.target.closest('[data-fitment-filter]');
+        if (!badge) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const fitmentId = parseInt(badge.dataset.fitmentFilter, 10);
+        if (!Number.isInteger(fitmentId) || fitmentId <= 0) {
+            return;
+        }
+
+        if (fitmentId === this.fitmentId) {
+            this.clickFilterId = null;
+            this.clickFilterLabel = null;
+            this.fitmentOnly = true;
+        } else {
+            this.clickFilterId = fitmentId;
+            this.clickFilterLabel = badge.dataset.fitmentLabel || '';
+        }
+
+        this._refilter();
+    }
+
+    /**
+     * Re-render both fitment chips and refetch both loaded lists from page 1
+     * under the current fitment filter (garage toggle or click-filter, issue
+     * #45). Composes with the active sort/rating/verified/media.
+     */
+    _refilter() {
         this.renderFitmentChip('reviews');
         this.renderFitmentChip('questions');
 
@@ -1727,6 +1828,18 @@ export default class UgcProduct {
             ? this.questionsFitmentChipElement
             : this.reviewsFitmentChipElement;
         if (!container) {
+            return;
+        }
+
+        // An active click-filter (a clicked review/question vehicle, issue #45)
+        // takes over the slot with a "Showing: <vehicle>" label + clear control,
+        // replacing the garage chip until cleared. Shown regardless of count —
+        // it is an explicit choice, not the count-gated discovery affordance.
+        if (this.clickFilterId !== null) {
+            const showing = this._escape(showingChipLabel(this.clickFilterLabel));
+            const clearControl = `<button type="button" class="cs-fitment-chip-clear" data-fitment-chip-clear aria-label="${this._escapeAttr(MESSAGES.fitmentChipClear)}">&times;</button>`;
+            container.innerHTML = `<span class="cs-fitment-showing">${showing}</span>${clearControl}`;
+            container.style.visibility = 'visible';
             return;
         }
 
@@ -1861,13 +1974,12 @@ export default class UgcProduct {
      * @returns {Object}
      */
     buildQuestionParams() {
-        // Gate fitment_only on a resolved fitment_id (Slice A review nit).
-        const fitmentOnly = (this.fitmentOnly && this.fitmentId !== null) ? true : null;
+        const fitment = this._fitmentParams();
         return {
             page: this.questionQuery.page,
             sort: this.questionQuery.sort,
-            fitment_id: this.fitmentId,
-            fitment_only: fitmentOnly,
+            fitment_id: fitment.fitment_id,
+            fitment_only: fitment.fitment_only,
         };
     }
 
@@ -1995,7 +2107,6 @@ export default class UgcProduct {
     _buildQuestion(question) {
         const author = this._escape(question.author) || MESSAGES.anonymous;
         const body = this._escape(question.body);
-        const vehicle = this._escape(question.vehicle_label);
         const date = this._formatDate(question.date);
         const answerAuthor = this._escape(question.staff_answer_author) || 'CravenSpeed';
         const answer = question.staff_answer
@@ -2008,7 +2119,7 @@ export default class UgcProduct {
                     <span class="cs-question-author">${author}</span>
                     ${date ? `<span class="cs-question-date">${date}</span>` : ''}
                 </p>
-                ${vehicle ? `<p class="cs-ugc-vehicle-badge cs-question-vehicle">${vehicle}</p>` : ''}
+                ${this._vehicleBadge(question.vehicle_label, question.fitment_id, 'cs-question-vehicle')}
                 <p class="cs-question-body">${body}</p>
                 ${answer}
             </article>`;
@@ -2504,7 +2615,7 @@ export default class UgcProduct {
             ? null
             : this.gridMedia[parseInt(dataset.ugcMediaIndex, 10)];
         if (entry && entry.review) {
-            review = `<div class="cs-ugc-lightbox-review">${this._buildReview(entry.review, false)}</div>`;
+            review = `<div class="cs-ugc-lightbox-review">${this._buildReview(entry.review, false, false)}</div>`;
         }
 
         content.innerHTML = media + review;
@@ -2572,11 +2683,38 @@ export default class UgcProduct {
         return count === 1 ? '1 review' : `${count} reviews`;
     }
 
-    _buildReview(review, includeMedia = true) {
+    /**
+     * Build a structured-vehicle badge (issue #45). When `clickable` and the
+     * item carries a positive `fitment_id`, it renders a `<button>` that filters
+     * the list to that vehicle on click; otherwise a static `<p>` (the SRS
+     * guarantees `vehicle_label` is null whenever `fitment_id` is, so that branch
+     * is also the defensive fallback). Empty string when there is no vehicle
+     * label. The lightbox review passes `clickable=false` — there is no list to
+     * filter from inside the media modal.
+     * @param {string} rawLabel - The item's `vehicle_label` (unescaped).
+     * @param {number|string} fitmentId - The item's `fitment_id`.
+     * @param {string} modifier - The card-specific class (cs-review-vehicle / cs-question-vehicle).
+     * @param {boolean} [clickable] - Whether the badge filters on click.
+     * @returns {string}
+     */
+    _vehicleBadge(rawLabel, fitmentId, modifier, clickable = true) {
+        const label = this._escape(rawLabel);
+        if (!label) {
+            return '';
+        }
+
+        const id = parseInt(fitmentId, 10);
+        if (clickable && Number.isInteger(id) && id > 0) {
+            return `<button type="button" class="cs-ugc-vehicle-badge ${modifier}" data-fitment-filter="${id}" data-fitment-label="${this._escapeAttr(rawLabel)}">${label}</button>`;
+        }
+
+        return `<p class="cs-ugc-vehicle-badge ${modifier}">${label}</p>`;
+    }
+
+    _buildReview(review, includeMedia = true, clickableVehicle = true) {
         const author = this._escape(review.author) || MESSAGES.anonymous;
         const title = this._escape(review.title);
         const body = this._escape(review.body);
-        const vehicle = this._escape(review.vehicle_label);
         const date = this._formatDate(review.date);
         const verified = review.verified_purchaser
             ? '<span class="cs-review-verified">Verified Purchaser</span>'
@@ -2609,7 +2747,7 @@ export default class UgcProduct {
                     ${verified}
                     ${edited}
                 </p>
-                ${vehicle ? `<p class="cs-ugc-vehicle-badge cs-review-vehicle">${vehicle}</p>` : ''}
+                ${this._vehicleBadge(review.vehicle_label, review.fitment_id, 'cs-review-vehicle', clickableVehicle)}
                 <p class="cs-review-body">${body}</p>
                 ${media}
                 ${staff}
@@ -2688,6 +2826,11 @@ export default class UgcProduct {
 
         if (this.listElement) {
             this.listElement.removeEventListener('click', this.onMediaTileClick);
+            this.listElement.removeEventListener('click', this.onVehicleBadgeClick);
+        }
+
+        if (this.questionsElement) {
+            this.questionsElement.removeEventListener('click', this.onVehicleBadgeClick);
         }
 
         if (this.mediaGridElement) {

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -928,6 +928,25 @@ $cs-fitment-active-hover: #05a;
   }
 }
 
+// Active click-filter label (issue #45): when a customer clicks a review/question
+// vehicle badge, this replaces the garage chip with "Showing: <vehicle>". Mirrors
+// the active chip's blue pill but is non-interactive — the adjacent
+// .cs-fitment-chip-clear button (a sibling in the slot) drops the filter.
+.cs-fitment-showing {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  max-width: 100%;
+  padding: 0 spacing('half');
+  border-radius: 999px;
+  background: $cs-fitment-active;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
 // Visuals come from the shared .cs-form-select class (the add-to-cart option
 // dropdowns) on the same element — identical by construction.
 
@@ -1100,6 +1119,27 @@ $cs-fitment-active-hover: #05a;
   line-height: 1.4;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+// Card badges are clickable buttons (issue #45) — filtering the list to that
+// review/question's vehicle. Reset the button chrome the shared rule above
+// doesn't cover, and deepen to the same hover blue as the active fitment chip.
+// Only buttons match, so the home overview-wall <p> badge stays static. (A
+// <button> also sidesteps the `.cs-product-container p` reset entirely.)
+button.cs-ugc-vehicle-badge {
+  border: 0;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background: $cs-fitment-active-hover;
+  }
+
+  &:focus-visible {
+    outline: 2px solid stencilColor('color-primary');
+    outline-offset: 2px;
+  }
 }
 
 .cs-review .cs-review-vehicle {


### PR DESCRIPTION
Closes #45. Makes each review/question **vehicle badge** clickable to hard-filter both lists to that vehicle. Storefront-only — the per-item `fitment_id` is already in the §3.2.1 payload and `buildParams`/`buildQuestionParams` already send `fitment_id` + `fitment_only`.

## Behavior (single-chip takeover)
- **Click a badge** (vehicle ≠ garage) → query switches to that `fitment_id`, `fitment_only=true`; the toolbar's "For your <garage>" chip is replaced by "Showing: <vehicle> ✕". Applies to both tabs (shared fitment state), composes with sort/rating/verified/media.
- **Click your own garage vehicle's badge** → just activates the existing garage chip (no redundant takeover).
- **Clear ✕** → `fitment_id` reverts to garage, `fitment_only` off → default newest-first view; garage chip reappears.
- **Garage swap** while a click-filter is active drops it (fresh vehicle context), same as it already resets the garage toggle.
- No count-caching needed: the garage chip is hidden during takeover, and clearing refetches the garage `fitment_id`.

## Where badges are / aren't clickable
- **Clickable `<button>`:** review + question list cards (a11y: focusable, keyboard, hover→`#05a`, focus ring). Button badges also sidestep the `.cs-product-container p` reset.
- **Static `<p>`:** the home overview wall (no filter context) and the **image-lightbox review** (no list to filter from inside the media modal).
- Defensive `<p>` fallback if an item ever lacks a positive `fitment_id` (the SRS guarantees `vehicle_label` is null whenever `fitment_id` is).

## Implementation
- `_fitmentParams()` centralizes the effective fitment (click-filter wins over garage) for both param builders; `_refilter()` shared by the chip + badge handlers.
- New `clickFilterId`/`clickFilterLabel` overlay state; `onVehicleBadgeClick` delegated on both lists; `onFitmentChipClick` extended to clear a click-filter; `renderFitmentChip` gained the "Showing:" takeover branch.
- Shared `_vehicleBadge(rawLabel, fitmentId, modifier, clickable)` helper for reviews + questions.

8 new Jest tests (reviews, Q&A, garage-swap clears filter, lightbox-static). `npx grunt check` green (eslint + 344 Jest + stylelint). Built object-only on `cs-ugc-frontend`.