### PR TITLE
M9 UGC: fitment chip-slot states, country flags, token auto-open, toolbar polish

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -873,7 +873,7 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
         expect(qParamsOfCall(api, 3).fitment_only).toBeNull();
     });
 
-    it('hides the Q&A chip when fitment_question_count is 0 (universal / no match)', async () => {
+    it('shows a "no questions for your vehicle" status when fitment_question_count is 0', async () => {
         const api = buildQaApi(okQuestions({ fitment_question_count: 0 }));
         const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
 
@@ -881,8 +881,12 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
         await flush();
 
         const chip = document.querySelector('[data-questions-fitment-chip]');
-        expect(chip.innerHTML).toBe('');
-        expect(chip.style.visibility).toBe('hidden');
+        const empty = chip.querySelector('.cs-fitment-empty');
+        expect(empty).not.toBeNull();
+        expect(empty.textContent).toContain('No questions');
+        expect(empty.textContent).toContain('MINI Cooper');
+        expect(chip.querySelector('[data-fitment-chip-toggle]')).toBeNull();
+        expect(chip.style.visibility).toBe('visible');
     });
 
     it('does not fetch questions when the Q&A DOM is absent', async () => {
@@ -976,15 +980,19 @@ describe('UgcProduct (slice A — fitment filter chip, reviews)', () => {
         expect(chip.style.visibility).toBe('visible');
     });
 
-    it('hides the chip when fitment_review_count is 0 (universal / no match)', async () => {
+    it('shows a "no reviews for your vehicle" status when fitment_review_count is 0', async () => {
         const api = buildReviewsApi(0);
         const global = buildGlobalStateManager({ vehicle: F56_GARAGE, registry: F56_REGISTRY });
         new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global);
         await flush();
 
         const chip = reviewsChip();
-        expect(chip.innerHTML).toBe('');
-        expect(chip.style.visibility).toBe('hidden');
+        const empty = chip.querySelector('.cs-fitment-empty');
+        expect(empty).not.toBeNull();
+        expect(empty.textContent).toContain('No reviews');
+        expect(empty.textContent).toContain('MINI Cooper');
+        expect(chip.querySelector('[data-fitment-chip-toggle]')).toBeNull();
+        expect(chip.style.visibility).toBe('visible');
     });
 
     it('hard-filters with fitment_only=true on chip click and resets to page 1', async () => {
@@ -1365,6 +1373,136 @@ describe('UgcProduct (issue #45 — click a vehicle badge to filter)', () => {
             expect(last.page).toBe(1);
             expect(document.querySelector('[data-questions-fitment-chip] .cs-fitment-showing')).not.toBeNull();
         });
+    });
+});
+
+describe('UgcProduct (vehicle-filter prompt when no vehicle is selected)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    const reviewsChip = () => document.querySelector('[data-reviews-fitment-chip]');
+
+    const buildReviewsApi = (count = 0) => ({
+        getReviews: jest.fn(() => Promise.resolve(okEnvelope({ fitment_review_count: count }))),
+    });
+
+    const ARCH_WITH_FITMENTS = {
+        make_model_index: {
+            mini: {
+                name: 'MINI',
+                models: {
+                    cooper: {
+                        name: 'Cooper',
+                        generations: { f56: { name: 'F56 2014 to 2024', fitment_id: 87 } },
+                    },
+                },
+            },
+        },
+    };
+
+    it('shows the "select your vehicle" prompt on a fitment-capable product with no garage vehicle', async () => {
+        mountScaffold();
+        const global = buildGlobalStateManager({ registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildReviewsApi(0), undefined, global, ARCH_WITH_FITMENTS);
+        await flush();
+
+        const prompt = reviewsChip().querySelector('[data-fitment-prompt]');
+        expect(prompt).not.toBeNull();
+        expect(prompt.textContent).toContain('Select your vehicle');
+        expect(reviewsChip().style.visibility).toBe('visible');
+    });
+
+    it('shows no prompt on a universal product (no archetype fitments)', async () => {
+        mountScaffold();
+        const global = buildGlobalStateManager({ registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildReviewsApi(0), undefined, global, { universal_product: true });
+        await flush();
+
+        expect(reviewsChip().querySelector('[data-fitment-prompt]')).toBeNull();
+        expect(reviewsChip().style.visibility).toBe('hidden');
+    });
+
+    it('replaces the prompt with the live chip once a vehicle resolves', async () => {
+        mountScaffold();
+        const global = buildGlobalStateManager({ registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildReviewsApi(4), undefined, global, ARCH_WITH_FITMENTS);
+        await flush();
+        expect(reviewsChip().querySelector('[data-fitment-prompt]')).not.toBeNull();
+
+        global._set({
+            vehicle: { selected: F56_GARAGE },
+            search: { data: { vehicle_registry: F56_REGISTRY } },
+        });
+        await flush();
+
+        expect(reviewsChip().querySelector('[data-fitment-prompt]')).toBeNull();
+        expect(reviewsChip().querySelector('[data-fitment-chip-toggle]')).not.toBeNull();
+    });
+
+    it('scrolls to and focuses the make picker when the prompt is clicked', async () => {
+        mountScaffold();
+        const makeSelect = document.createElement('select');
+        makeSelect.setAttribute('data-product-option', 'make');
+        makeSelect.innerHTML = '<option>MINI</option>';
+        document.body.appendChild(makeSelect);
+        const scrollSpy = jest.fn();
+        makeSelect.scrollIntoView = scrollSpy;
+
+        const global = buildGlobalStateManager({ registry: F56_REGISTRY });
+        new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildReviewsApi(0), undefined, global, ARCH_WITH_FITMENTS);
+        await flush();
+
+        reviewsChip().querySelector('[data-fitment-prompt]').click();
+
+        expect(scrollSpy).toHaveBeenCalled();
+        expect(document.activeElement).toBe(makeSelect);
+    });
+});
+
+describe('UgcProduct (country flag on review cards)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    const buildUgc = () => {
+        mountScaffold();
+        return new UgcProduct(
+            ARCHETYPE_ID,
+            buildStateManager(),
+            { getReviews: jest.fn(() => Promise.resolve(okEnvelope())) },
+        );
+    };
+
+    const review = over => ({
+        author: 'Jane D.', rating: 5, title: 't', body: 'b', ...over,
+    });
+
+    it('renders a lazy-loaded flag from the ISO-3166 alpha-2 country code', async () => {
+        const ugc = buildUgc();
+        await flush();
+
+        const html = ugc._buildReview(review({ country: 'US' }));
+        expect(html).toContain('class="cs-review-flag"');
+        expect(html).toContain('src="https://flagcdn.com/us.svg"');
+        expect(html).toContain('alt="US"');
+        expect(html).toContain('loading="lazy"');
+    });
+
+    it('omits the flag when country is null', async () => {
+        const ugc = buildUgc();
+        await flush();
+
+        expect(ugc._buildReview(review({ country: null }))).not.toContain('cs-review-flag');
+    });
+
+    it('omits the flag for a value that is not a two-letter code', async () => {
+        const ugc = buildUgc();
+        await flush();
+
+        expect(ugc._buildReview(review({ country: 'USA' }))).not.toContain('cs-review-flag');
+        expect(ugc._buildReview(review({ country: '12' }))).not.toContain('cs-review-flag');
+        expect(ugc._buildReview(review({ country: '' }))).not.toContain('cs-review-flag');
     });
 });
 
@@ -2277,6 +2415,57 @@ describe('UgcProduct (slice 6f — verified-purchaser token capture)', () => {
             await flush();
 
             expect(api.postReview.mock.calls[0][0]).not.toHaveProperty('ugc_token');
+        });
+    });
+
+    describe('auto-open from the tokenized email link', () => {
+        const reviewModal = () => document.querySelector('[data-review-modal]');
+
+        it('opens the review submission modal when landing with a valid token', async () => {
+            setUrl('?ugc_token=abc123');
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildTokenApi());
+            await flush();
+
+            expect(reviewModal().hidden).toBe(false);
+        });
+
+        it('still opens the modal when the token is invalid/expired (unverified)', async () => {
+            setUrl('?ugc_token=expired');
+            const api = buildTokenApi({ validateResult: { ok: false, status: 400, error: 'Invalid' } });
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            expect(reviewModal().hidden).toBe(false);
+        });
+
+        it('leaves the modal closed when no token is present', async () => {
+            setUrl('');
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildTokenApi());
+            await flush();
+
+            expect(reviewModal().hidden).toBe(true);
+        });
+
+        it('activates the reviews tab when the tab strip is present', async () => {
+            setUrl('?ugc_token=abc123');
+            const tabs = document.createElement('ul');
+            tabs.className = 'tabs';
+            tabs.innerHTML = '<li class="tab"><a class="tab-title" href="#tab-reviews">Reviews</a></li>';
+            document.body.appendChild(tabs);
+            // preventDefault mirrors Foundation's tab handler and stops jsdom
+            // from logging a not-implemented navigation on the hash link.
+            const tabClick = jest.fn(event => event.preventDefault());
+            document.querySelector('ul.tabs a[href="#tab-reviews"]').addEventListener('click', tabClick);
+
+            // eslint-disable-next-line no-new
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), buildTokenApi());
+            await flush();
+
+            expect(tabClick).toHaveBeenCalled();
+            expect(reviewModal().hidden).toBe(false);
         });
     });
 });

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -184,6 +184,7 @@ const MESSAGES = {
     mediaUploadError: 'A file failed to upload. Please remove it and try again.',
     mediaProcessing: 'Processing media… this can take up to 30 seconds for video.',
     fitmentChipClear: 'Clear filter',
+    fitmentPrompt: 'Select your vehicle to filter',
     vehicleSectionLabel: 'Your Vehicle',
     vehicleSectionLabelOptional: 'Your Vehicle (optional)',
     vehicleMakeDefault: 'Select Make',
@@ -199,6 +200,11 @@ const fitmentChipLabel = vehicle => `For your ${vehicle}`;
 // Active click-filter chip label (issue #45) — names the clicked review/question
 // vehicle that the list is currently restricted to.
 const showingChipLabel = vehicle => `Showing: ${vehicle}`;
+
+// Passive status shown in place of the chip when a resolved garage vehicle has
+// no matching reviews/questions on this product — explains why no filter chip
+// is offered. `noun` is 'reviews' or 'questions'.
+const noFitmentMatchLabel = (vehicle, noun) => `No ${noun} yet for your ${vehicle}`;
 
 export default class UgcProduct {
     /**
@@ -1221,6 +1227,33 @@ export default class UgcProduct {
                 ? fitmentId
                 : null;
         }
+
+        // Arrived from the email's tokenized review link — take the customer
+        // straight to writing. Done after validate resolves so the modal's
+        // vehicle section reflects verified (silent attach) vs unverified
+        // (waterfall); opened regardless of validity, since an expired token
+        // still means they came to leave a review (just unverified).
+        this._openReviewSubmissionFromToken();
+    }
+
+    /**
+     * Activate the reviews tab and open the submission modal, for a visitor who
+     * landed via the tokenized email link (SRS §3.2.8). The tab is switched the
+     * same way a click does (mirrors tabDeepLink), so closing the modal leaves
+     * them on the reviews tab rather than the description. No-op when the page
+     * has no review modal (e.g. a questions-only layout).
+     */
+    _openReviewSubmissionFromToken() {
+        if (!this.reviewModalElement) {
+            return;
+        }
+
+        const reviewsTab = document.querySelector('ul.tabs a[href="#tab-reviews"]');
+        if (reviewsTab) {
+            reviewsTab.click();
+        }
+
+        this.openModal(this.reviewModalElement, this.reviewFormElement);
     }
 
     /**
@@ -1728,6 +1761,15 @@ export default class UgcProduct {
      * @param {Event} event
      */
     onFitmentChipClick(event) {
+        // "Select your vehicle to filter" prompt (shown when no vehicle is
+        // resolved) — scroll to the make/model/generation picker so the visitor
+        // can set one, which then resolves the garage fitment and the chip.
+        if (event.target.closest('[data-fitment-prompt]')) {
+            event.preventDefault();
+            this._scrollToVehiclePicker();
+            return;
+        }
+
         const trigger = event.target.closest('[data-fitment-chip-toggle], [data-fitment-chip-clear]');
         if (!trigger) {
             return;
@@ -1759,6 +1801,27 @@ export default class UgcProduct {
 
         this.fitmentOnly = nextOnly;
         this._refilter();
+    }
+
+    /**
+     * Scroll the make/model/generation picker into view (and focus Make) from
+     * the "Select your vehicle to filter" prompt. Selecting a vehicle there
+     * drives the global garage state, which resolves the fitment and swaps the
+     * prompt for the live chip. No-op if the picker is absent.
+     */
+    _scrollToVehiclePicker() {
+        const make = document.querySelector('[data-product-option="make"]');
+        if (!make) {
+            return;
+        }
+
+        if (typeof make.scrollIntoView === 'function') {
+            make.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+
+        if (!make.disabled) {
+            make.focus({ preventScroll: true });
+        }
     }
 
     /**
@@ -1843,11 +1906,30 @@ export default class UgcProduct {
             return;
         }
 
-        const count = kind === 'questions' ? this.fitmentQuestionCount : this.fitmentReviewCount;
+        // No garage vehicle resolved yet. On a fitment-capable product, prompt
+        // the visitor to pick one so the filter becomes available; on a universal
+        // product (no archetype fitments) there is nothing to filter, so stay
+        // hidden. The prompt scrolls to the make/model/generation picker on click.
+        if (this.fitmentId === null) {
+            if (this.archetypeFitments.length > 0) {
+                container.innerHTML = `<button type="button" class="cs-fitment-prompt" data-fitment-prompt>${this._escape(MESSAGES.fitmentPrompt)}</button>`;
+                container.style.visibility = 'visible';
+            } else {
+                container.innerHTML = '';
+                container.style.visibility = 'hidden';
+            }
+            return;
+        }
 
-        if (!this.fitmentLabel || count <= 0) {
-            container.innerHTML = '';
-            container.style.visibility = 'hidden';
+        // Garage vehicle resolved but with no matching items on this product —
+        // surface a passive "No reviews yet for your <vehicle>" status so the
+        // absent filter chip is explained rather than silently missing.
+        const count = kind === 'questions' ? this.fitmentQuestionCount : this.fitmentReviewCount;
+        if (count <= 0) {
+            const noun = kind === 'questions' ? 'questions' : 'reviews';
+            const message = this._escape(noFitmentMatchLabel(this.fitmentLabel, noun));
+            container.innerHTML = `<span class="cs-fitment-empty">${message}</span>`;
+            container.style.visibility = 'visible';
             return;
         }
 
@@ -2711,6 +2793,30 @@ export default class UgcProduct {
         return `<p class="cs-ugc-vehicle-badge ${modifier}">${label}</p>`;
     }
 
+    /**
+     * Render a small country flag from the review's ISO-3166 alpha-2 `country`
+     * (SRS §3.2.1, derived server-side from the submission IP; null on imported
+     * or un-geolocated rows). Served as SVG from flagcdn.com and lazy-loaded.
+     * Returns '' when there is no valid two-letter code, so older reviews simply
+     * show no flag. The code is validated to `[a-z]{2}`, so it is safe to
+     * interpolate into the URL/alt without further escaping.
+     * @param {string} code - The review's `country`.
+     * @returns {string}
+     */
+    _countryFlag(code) {
+        if (typeof code !== 'string') {
+            return '';
+        }
+
+        const cc = code.trim().toLowerCase();
+        if (!/^[a-z]{2}$/.test(cc)) {
+            return '';
+        }
+
+        const label = cc.toUpperCase();
+        return `<img class="cs-review-flag" src="https://flagcdn.com/${cc}.svg" alt="${label}" title="${label}" loading="lazy">`;
+    }
+
     _buildReview(review, includeMedia = true, clickableVehicle = true) {
         const author = this._escape(review.author) || MESSAGES.anonymous;
         const title = this._escape(review.title);
@@ -2744,6 +2850,7 @@ export default class UgcProduct {
                 </div>
                 <p class="cs-review-meta">
                     <span class="cs-review-author">${author}</span>
+                    ${this._countryFlag(review.country)}
                     ${verified}
                     ${edited}
                 </p>

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -853,7 +853,7 @@ $cs-fitment-active-hover: #05a;
   min-height: 44px;
   padding: 0 spacing('half');
   border: 1px solid stencilColor('color-textSecondary');
-  border-radius: 999px;
+  border-radius: spacing('half'); // matches the selects + button (_custom.scss:57)
   background: transparent;
   color: stencilColor('color-textBase');
   font-size: 0.875rem;
@@ -928,6 +928,52 @@ $cs-fitment-active-hover: #05a;
   }
 }
 
+// "Select your vehicle to filter" prompt: shown in the chip slot on a
+// fitment-capable product when no garage vehicle is resolved. A dashed ghost
+// button (distinct from the solid active chip) that scrolls to the vehicle
+// picker on click; the trailing arrow signals the jump.
+.cs-fitment-prompt {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  max-width: 100%;
+  padding: 0 spacing('half');
+  border: 1px dashed stencilColor('color-textSecondary');
+  border-radius: spacing('half'); // matches the selects + button (_custom.scss:57)
+  background: transparent;
+  color: stencilColor('color-textSecondary');
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+
+  &::after {
+    content: '→';
+    margin-left: spacing('quarter');
+  }
+
+  &:hover {
+    border-color: $cs-fitment-active;
+    color: $cs-fitment-active;
+  }
+
+  &:focus-visible {
+    outline: 2px solid stencilColor('color-primary');
+    outline-offset: 2px;
+  }
+}
+
+// Passive status when a resolved garage vehicle has no reviews/questions on this
+// product: explains why no "For your <vehicle>" filter chip is offered. Muted,
+// italic, non-interactive — distinct from the dashed prompt and the blue chip.
+.cs-fitment-empty {
+  color: stencilColor('color-textSecondary');
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
 // Active click-filter label (issue #45): when a customer clicks a review/question
 // vehicle badge, this replaces the garage chip with "Showing: <vehicle>". Mirrors
 // the active chip's blue pill but is non-interactive — the adjacent
@@ -938,7 +984,7 @@ $cs-fitment-active-hover: #05a;
   min-height: 44px;
   max-width: 100%;
   padding: 0 spacing('half');
-  border-radius: 999px;
+  border-radius: spacing('half'); // matches the selects + button (_custom.scss:57)
   background: $cs-fitment-active;
   color: #fff;
   font-size: 0.875rem;
@@ -1067,6 +1113,16 @@ $cs-fitment-active-hover: #05a;
 .cs-review-author {
   color: stencilColor('color-textBase');
   font-weight: 600;
+}
+
+// Reviewer country flag (SRS §3.2.1 `country`). Sized to the meta line; a hairline
+// border keeps white-edged flags (Japan, Finland…) visible on the white card. The
+// flex meta row centers it; absent entirely when the review carries no country.
+.cs-review-flag {
+  height: 1em;
+  width: auto;
+  border-radius: 2px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .cs-review-verified {
@@ -1292,9 +1348,11 @@ button.cs-ugc-vehicle-badge {
 .cs-ugc-submit-open {
   margin-top: spacing('half');
 
+  // Drop Foundation's default `.button` bottom margin so the button bottom-aligns
+  // flush with the toolbar's select inputs (the row is align-items: flex-end, so
+  // that ~1rem bottom margin was lifting the button above the selects' baseline).
   @include breakpoint('medium') {
-    margin-top: 0;
-    margin-left: auto;
+    margin: 0 0 0 auto;
   }
 }
 


### PR DESCRIPTION
A second UGC storefront polish pass on `cs-ugc-frontend`. All storefront-only — no cs-ugc contract change.

## Fitment chip slot — full state coverage
The toolbar chip slot now communicates every state instead of silently going empty:
- **"Select your vehicle to filter →"** — fitment-capable product with no garage vehicle resolved; a dashed prompt that smooth-scrolls to the make/model/generation picker and focuses Make. Hidden on universal products.
- **"No reviews yet for your &lt;vehicle&gt;"** (and the Q&A equivalent) — a resolved garage vehicle with zero matching items (`fitment_*_count === 0`), a muted status so the absent filter chip is explained.
- These join the existing "For your &lt;vehicle&gt;" chip and the click-filter "Showing: &lt;vehicle&gt;" takeover.

## Country flags on review cards
- Renders a flag from the §3.2.1 `country` field (flagcdn SVG, lazy-loaded, hairline border for white-edged flags). Code is regex-validated `[a-z]{2}`, so it's injection-safe. Omitted when `country` is null/invalid. Reviews only — questions carry no country in the contract.

## Auto-open submission from the tokenized email link
- Landing with `?ugc_token=…` now activates the reviews tab and opens the submission modal (after token validation, so the modal's vehicle section reflects verified silent-attach vs the unverified waterfall). Opens regardless of token validity — an expired token still means the customer came to write a review.

## Toolbar alignment
- **Write-a-review button:** drops Foundation's default `.button` bottom margin (which, under the toolbar's `align-items: flex-end`, lifted the button above the selects' baseline) so it bottom-aligns with the selects.
- **Chip radius:** references `spacing('half')` to match the toolbar selects/button (`_custom.scss:57`), rather than a hardcoded value.

`npx grunt check` green (eslint + 356 Jest + stylelint). Built object-only on `cs-ugc-frontend`.