### PR TITLE
cs-ugc#209: resolve verified review label from make_model_index, not the registry

### DIFF
--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -2164,7 +2164,7 @@ describe('UgcProduct (#41 — tailored vehicle field by scenario, SRS §3.4.1)',
             expect(container.querySelector('[data-vehicle-append]')).toBeNull();
         });
 
-        it('silently attaches the token fitment_id + full canonical label resolved from the registry', async () => {
+        it('silently attaches the token fitment_id + full canonical label resolved from make_model_index', async () => {
             const global = buildGlobalStateManager({ registry: F56_REGISTRY });
             window.history.replaceState({}, '', '/products/x?ugc_token=abc123');
             const api = buildSubmitApi();
@@ -2180,6 +2180,50 @@ describe('UgcProduct (#41 — tailored vehicle field by scenario, SRS §3.4.1)',
             expect(payload.fitment_id).toBe(87);
             expect(payload.vehicle_label).toBe('MINI Cooper F56 2014 to 2024');
             expect(payload.ugc_token).toBe('abc123');
+        });
+
+        it('resolves the verified label from make_model_index (correct make) when the registry slug collides (#209)', async () => {
+            // The registry's "3" slug is shared by two makes; makeNameForModel
+            // returns the first brand listing it (Polestar here), so the registry
+            // alone would mislabel a Mazda 3 fitment. The archetype make_model_index
+            // is make-namespaced, so resolving from it yields the correct make.
+            const collidedRegistry = {
+                brands: {
+                    polestar: { name: 'Polestar', models: ['3'] },
+                    mazda: { name: 'Mazda', models: ['3'] },
+                },
+                models: {
+                    3: { name: '3', generations: { shared: { name: 'gen', fitment_id: 555 } } },
+                },
+            };
+            const mazda3Archetype = {
+                make_model_index: {
+                    mazda: {
+                        name: 'Mazda',
+                        models: {
+                            mazda3: {
+                                name: '3',
+                                generations: { mazda34th: { name: '4th gen BP 2019 to 2026', fitment_id: 555 } },
+                            },
+                        },
+                    },
+                },
+            };
+            const global = buildGlobalStateManager({ registry: collidedRegistry });
+            window.history.replaceState({}, '', '/products/mazda-3?ugc_token=tok');
+            const api = buildSubmitApi({ ok: true, status: 200, data: { archetype_id: ARCHETYPE_ID, alias_id: 1, fitment_id: 555 } });
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api, undefined, global, mazda3Archetype);
+            await flush();
+
+            document.querySelector('[data-review-modal-open]').click();
+            fillReview('review');
+            submitForm('review');
+            await flush();
+
+            const payload = api.postReview.mock.calls[0][0];
+            expect(payload.fitment_id).toBe(555);
+            expect(payload.vehicle_label).toBe('Mazda 3 4th gen BP 2019 to 2026');
+            expect(payload.vehicle_label).not.toContain('Polestar');
         });
 
         it('falls back to the waterfall when the token carries no fitment_id', async () => {

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -613,6 +613,20 @@ export default class UgcProduct {
     }
 
     /**
+     * Resolve a `fitment_id` to its full canonical `vehicle_label` from this
+     * archetype's `make_model_index` (cs-ugc #209). Unlike the global registry,
+     * the archetype index is make-namespaced, so a model slug shared across two
+     * makes (Mazda 3 vs Polestar 3, etc.) resolves to the correct make. Returns
+     * '' when the fitment isn't one of this archetype's fitments.
+     * @param {number} fitmentId
+     * @returns {string}
+     */
+    _labelFromArchetype(fitmentId) {
+        const match = this.archetypeFitments.find(f => f.fitment_id === fitmentId);
+        return match ? match.label : '';
+    }
+
+    /**
      * Paint the vehicle section for a submission modal, tailored to the reviewer's
      * scenario (SRS §3.4.1, issue #41). There is no free-text input and no
      * append/opt-in checkbox:
@@ -640,7 +654,14 @@ export default class UgcProduct {
         }
 
         if (kind === 'review' && this.verifiedFitmentId !== null) {
-            const label = fitmentIdToLabel(this._registry(), this.verifiedFitmentId);
+            // Resolve the token's fitment from the archetype's make_model_index
+            // first (make-namespaced), not the global registry — the registry's
+            // models map is keyed by bare model slug, so for the handful of model
+            // names shared across two makes (e.g. Mazda 3 vs Polestar 3) it can
+            // resolve the wrong make (cs-ugc #209). The registry stays a fallback
+            // for the edge where the token's fitment isn't in this archetype.
+            const label = this._labelFromArchetype(this.verifiedFitmentId)
+                || fitmentIdToLabel(this._registry(), this.verifiedFitmentId);
             if (label) {
                 // Fully silent: no UI, attach on submit (SRS §3.4.1, issue #41).
                 this.verifiedSilentVehicle = {


### PR DESCRIPTION
Storefront-actionable half of **cs-ugc#209**. Storefront-only.

## Bug
A **verified** reviewer's `vehicle_label` was resolved with `fitmentIdToLabel(registry, fitmentId)`. The search-JSON `vehicle_registry.models` map is keyed by **bare model slug** (no make namespacing), and `makeNameForModel` returns the *first* brand whose models list contains that slug. So for the 6 model names shared across two makes — `2`/`3` (Mazda + Polestar), `sprinter` (Mercedes + Dodge), `ls` (Lexus + Lincoln), `continental` (Bentley + Lincoln), `dakota` (Dodge + Ram) — the resolved make can be wrong.

## Fix
Resolve the token's `fitment_id` → label from **this archetype's `make_model_index`** (already make-namespaced) first, via a new `_labelFromArchetype()`. The registry stays a fallback for the edge where the token's fitment isn't one of this archetype's fitments. Since the verified label is for the *purchased* product = the current archetype, the index is the authoritative, unambiguous source.

```js
const label = this._labelFromArchetype(this.verifiedFitmentId)
    || fitmentIdToLabel(this._registry(), this.verifiedFitmentId);
```

## Tests
- New: a registry where `"3"` is shared by Polestar + Mazda (so `fitmentIdToLabel` alone mislabels it **Polestar**) → the archetype resolution yields the correct **"Mazda 3 4th gen BP 2019 to 2026"**.
- Existing silent-attach test still green (label unchanged, now sourced from the index).
- `npx grunt check` green (eslint + 357 Jest + stylelint).

## Out of scope (QTY's lane)
- **Registry namespacing** (acceptance #1) — the upstream fix in `qty.info` publish code.
- **Home-page global vehicle selector** (`vehicleSelector.js`) — reads the global registry with bare slugs; can't be disambiguated storefront-side (no per-make data to fall back to), so it depends on the QTY registry fix. The product-page add-to-cart dropdowns (`aliasSelection.js`) read `make_model_index` and are already correct.