### PR TITLE
M9 UGC: click-to-open review lightbox with prev/next navigation

### DIFF
--- a/assets/js/test-unit/theme/global/ugcOverview.spec.js
+++ b/assets/js/test-unit/theme/global/ugcOverview.spec.js
@@ -284,3 +284,110 @@ describe('UgcOverview controller', () => {
         expect(document.querySelector('.cs-ugc-vehicle-badge')).toBeNull();
     });
 });
+
+describe('UgcOverview review lightbox', () => {
+    let api;
+    let overview;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div class="cs-ugc-overview" data-ugc-overview></div>';
+        api = { getOverview: jest.fn() };
+    });
+
+    afterEach(() => {
+        if (overview) {
+            overview.destroy();
+            overview = null;
+        }
+        document.querySelectorAll('[data-ugc-overview-lightbox]').forEach(el => el.remove());
+    });
+
+    const mountInit = async (reviews) => {
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        overview = new UgcOverview({ api });
+        await overview.init();
+        return overview;
+    };
+
+    it('renders media thumbs as buttons carrying their filtered index', async () => {
+        await mountInit(makeReviews(10, { withMediaEvery: 5 }));
+
+        const openers = document.querySelectorAll('[data-ugc-review-open]');
+        expect(Array.from(openers).map(b => b.dataset.ugcIndex)).toEqual(['0', '5']);
+        expect(document.querySelectorAll('button.cs-ugc-overview-thumb')).toHaveLength(2);
+        // No-media thumbs stay non-interactive divs, not openers.
+        expect(document.querySelectorAll('div.cs-ugc-overview-thumb.is-empty')).toHaveLength(8);
+    });
+
+    it('opens the clicked review and steps through the filtered set, incl. no-photo reviews', async () => {
+        await mountInit(makeReviews(10, { withMediaEvery: 5 }));
+
+        document.querySelector('[data-ugc-review-open][data-ugc-index="5"]').click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        expect(lightbox.hidden).toBe(false);
+        expect(lightbox.textContent).toContain('Body 6');
+
+        // Next lands on a review with no photo — still reachable (Decision A).
+        lightbox.querySelector('[data-ugc-review-next]').click();
+        expect(lightbox.textContent).toContain('Body 7');
+
+        lightbox.querySelector('[data-ugc-review-prev]').click();
+        lightbox.querySelector('[data-ugc-review-prev]').click();
+        expect(lightbox.textContent).toContain('Body 5');
+    });
+
+    it('disables prev at the first review and next at the last', async () => {
+        await mountInit(makeReviews(3));
+
+        overview.openLightbox(0);
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        const prev = lightbox.querySelector('[data-ugc-review-prev]');
+        const next = lightbox.querySelector('[data-ugc-review-next]');
+        expect(prev.disabled).toBe(true);
+        expect(next.disabled).toBe(false);
+
+        next.click(); // index 1
+        next.click(); // index 2 (last)
+        expect(next.disabled).toBe(true);
+        expect(prev.disabled).toBe(false);
+    });
+
+    it('steps only within the active filter', async () => {
+        await mountInit(makeReviews(25, { withMediaEvery: 5 }));
+
+        document.querySelector('[data-ugc-filter="photos"]').click();
+        // 5 media reviews (ids 1, 6, 11, 16, 21) collapse to filtered indices 0..4.
+        document.querySelector('[data-ugc-review-open][data-ugc-index="0"]').click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        expect(lightbox.textContent).toContain('Body 1');
+
+        lightbox.querySelector('[data-ugc-review-next]').click();
+        // The next media review, not the immediately-following no-photo one.
+        expect(lightbox.textContent).toContain('Body 6');
+    });
+
+    it('closes via the close control and restores focus to the opening thumb', async () => {
+        await mountInit(makeReviews(5, { withMediaEvery: 5 }));
+
+        const opener = document.querySelector('[data-ugc-review-open]');
+        opener.focus();
+        opener.click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        expect(lightbox.hidden).toBe(false);
+
+        lightbox.querySelector('[data-ugc-lightbox-close]').click();
+        expect(lightbox.hidden).toBe(true);
+        expect(document.activeElement).toBe(opener);
+    });
+
+    it('closes on Escape', async () => {
+        await mountInit(makeReviews(5, { withMediaEvery: 5 }));
+
+        document.querySelector('[data-ugc-review-open]').click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        expect(lightbox.hidden).toBe(false);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(lightbox.hidden).toBe(true);
+    });
+});

--- a/assets/js/test-unit/theme/global/ugcOverview.spec.js
+++ b/assets/js/test-unit/theme/global/ugcOverview.spec.js
@@ -390,4 +390,34 @@ describe('UgcOverview review lightbox', () => {
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
         expect(lightbox.hidden).toBe(true);
     });
+
+    it('renders a video review in the lightbox with its poster frame', async () => {
+        const reviews = makeReviews(1);
+        reviews[0].media = [{ type: 'video', url: 'https://cdn/v.mp4', poster_url: 'https://cdn/p.jpg' }];
+        await mountInit(reviews);
+
+        document.querySelector('[data-ugc-review-open]').click();
+        const video = document.querySelector('[data-ugc-overview-lightbox] video');
+        expect(video.getAttribute('src')).toBe('https://cdn/v.mp4');
+        expect(video.getAttribute('poster')).toBe('https://cdn/p.jpg');
+    });
+
+    it('navigates across page boundaries using absolute filtered indices', async () => {
+        // 15 reviews all carry media → page 1 shows 10, page 2 shows 5.
+        await mountInit(makeReviews(15, { withMediaEvery: 1 }));
+
+        document.querySelector('[data-ugc-page="2"]').click();
+        // Page-2 thumbs carry absolute indices 10..14.
+        document.querySelector('[data-ugc-review-open][data-ugc-index="10"]').click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        expect(lightbox.textContent).toContain('Body 11');
+
+        lightbox.querySelector('[data-ugc-review-next]').click();
+        expect(lightbox.textContent).toContain('Body 12');
+
+        // Stepping back crosses onto page 1's reviews — nav is page-independent.
+        lightbox.querySelector('[data-ugc-review-prev]').click();
+        lightbox.querySelector('[data-ugc-review-prev]').click();
+        expect(lightbox.textContent).toContain('Body 10');
+    });
 });

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -2938,6 +2938,8 @@ describe('UgcProduct (#30 — review media display)', () => {
             <div data-ugc-lightbox hidden>
                 <div data-ugc-lightbox-close></div>
                 <button type="button" data-ugc-lightbox-close>&times;</button>
+                <button type="button" data-ugc-lightbox-prev hidden>&lsaquo;</button>
+                <button type="button" data-ugc-lightbox-next hidden>&rsaquo;</button>
                 <div data-ugc-lightbox-content></div>
             </div>
             <div data-ugc-gallery hidden>
@@ -3435,6 +3437,66 @@ describe('UgcProduct (#30 — review media display)', () => {
 
             expect(lightbox().hidden).toBe(true);
             expect(lightboxContent().innerHTML).toEqual('');
+        });
+
+        it('shows prev/next arrows from a band tile and steps the photo set, clamped at the ends', async () => {
+            const r1 = reviewWith([photoMedia({ id: 1, medium_url: 'https://cdn.example/a.jpg' })], { id: 1, author: 'Alice', body: 'Body A' });
+            const r2 = reviewWith([photoMedia({ id: 2, medium_url: 'https://cdn.example/b.jpg' })], { id: 2, author: 'Bob', body: 'Body B' });
+            const api = buildApi(okEnvelope({ items: [r1, r2], total: 2 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-tile]').click();
+            const prev = lightbox().querySelector('[data-ugc-lightbox-prev]');
+            const next = lightbox().querySelector('[data-ugc-lightbox-next]');
+            expect(prev.hidden).toBe(false);
+            expect(next.hidden).toBe(false);
+            expect(prev.disabled).toBe(true); // first entry
+            expect(next.disabled).toBe(false);
+            expect(lightboxContent().textContent).toContain('Body A');
+
+            next.click();
+            expect(lightboxContent().querySelector('img').getAttribute('src')).toEqual('https://cdn.example/b.jpg');
+            expect(lightboxContent().textContent).toContain('Body B');
+            expect(next.disabled).toBe(true); // last entry
+            expect(prev.disabled).toBe(false);
+
+            prev.click();
+            expect(lightboxContent().textContent).toContain('Body A');
+        });
+
+        it('keeps arrows hidden when opened from a per-review strip tile, even with multiple photos in the set', async () => {
+            const r1 = reviewWith([photoMedia({ id: 1 })], { id: 1, author: 'Alice', body: 'Body A' });
+            const r2 = reviewWith([photoMedia({ id: 2 })], { id: 2, author: 'Bob', body: 'Body B' });
+            const api = buildApi(okEnvelope({ items: [r1, r2], total: 2 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            // A strip tile inside #product-reviews carries no media index → no nav.
+            document.querySelector('#product-reviews [data-ugc-media-tile]').click();
+            expect(lightbox().querySelector('[data-ugc-lightbox-prev]').hidden).toBe(true);
+            expect(lightbox().querySelector('[data-ugc-lightbox-next]').hidden).toBe(true);
+            expect(lightboxContent().querySelector('.cs-ugc-lightbox-review')).toBeNull();
+        });
+
+        it('navigates with arrow keys and closes on Escape', async () => {
+            const r1 = reviewWith([photoMedia({ id: 1, medium_url: 'https://cdn.example/a.jpg' })], { id: 1, body: 'Body A' });
+            const r2 = reviewWith([photoMedia({ id: 2, medium_url: 'https://cdn.example/b.jpg' })], { id: 2, body: 'Body B' });
+            const api = buildApi(okEnvelope({ items: [r1, r2], total: 2 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-tile]').click();
+            expect(lightboxContent().textContent).toContain('Body A');
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+            expect(lightboxContent().textContent).toContain('Body B');
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+            expect(lightboxContent().textContent).toContain('Body A');
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+            expect(lightbox().hidden).toBe(true);
         });
     });
 

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -3498,6 +3498,31 @@ describe('UgcProduct (#30 — review media display)', () => {
             document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
             expect(lightbox().hidden).toBe(true);
         });
+
+        it('navigates onto a video entry and renders it playable with its poster', async () => {
+            const r1 = reviewWith([photoMedia({ id: 1, medium_url: 'https://cdn.example/a.jpg' })], { id: 1, body: 'Body A' });
+            const r2 = reviewWith([videoMedia({ id: 2 })], { id: 2, body: 'Body B' });
+            const api = buildApi(okEnvelope({ items: [r1, r2], total: 2 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-tile]').click(); // index 0 (photo)
+            lightbox().querySelector('[data-ugc-lightbox-next]').click(); // index 1 (video)
+
+            const video = lightboxContent().querySelector('video');
+            expect(video.getAttribute('src')).toEqual('https://cdn.example/ugc/media/u2/video.mp4');
+            expect(video.getAttribute('poster')).toEqual('https://cdn.example/ugc/media/u2/poster.jpg');
+        });
+
+        it('hides the arrows for a single-photo set even from an indexed band tile', async () => {
+            const api = buildApi(okEnvelope({ items: [reviewWith([photoMedia()])], total: 1 }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            grid().querySelector('[data-ugc-media-tile]').click();
+            expect(lightbox().querySelector('[data-ugc-lightbox-prev]').hidden).toBe(true);
+            expect(lightbox().querySelector('[data-ugc-lightbox-next]').hidden).toBe(true);
+        });
     });
 
     describe('escaping', () => {

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -132,7 +132,16 @@ export default class UgcOverview {
         this.ratingValue = null;
         this.page = 1;
 
+        // Review lightbox state. The node is created lazily on first open and
+        // lives on <body>, outside the wall's innerHTML churn. lightboxIndex is
+        // an absolute index into the current filtered set (Decision A).
+        this.lightbox = null;
+        this.lightboxIndex = 0;
+        this.lastFocused = null;
+
         this.handleControlClick = this.handleControlClick.bind(this);
+        this.handleLightboxClick = this.handleLightboxClick.bind(this);
+        this.handleLightboxKeydown = this.handleLightboxKeydown.bind(this);
     }
 
     /**
@@ -166,6 +175,12 @@ export default class UgcOverview {
      * @param {MouseEvent} event
      */
     handleControlClick(event) {
+        const opener = event.target.closest('[data-ugc-review-open]');
+        if (opener) {
+            this.openLightbox(parseInt(opener.dataset.ugcIndex, 10));
+            return;
+        }
+
         const filterButton = event.target.closest('[data-ugc-filter]');
         if (filterButton) {
             const { ugcFilter, ugcRating } = filterButton.dataset;
@@ -189,10 +204,11 @@ export default class UgcOverview {
     render() {
         const filtered = applyFilter(this.reviews, this.filter, this.ratingValue);
         const items = paginate(filtered, this.page);
+        const base = (this.page - 1) * PER_PAGE;
 
         this.container.innerHTML = `
             ${this.buildFilters()}
-            ${this.buildWall(items)}
+            ${this.buildWall(items, base)}
             ${this.buildPagination(filtered.length)}
         `;
     }
@@ -223,16 +239,16 @@ export default class UgcOverview {
         return `<div class="cs-ugc-overview-filters" role="group" aria-label="Filter reviews">${buttons}</div>`;
     }
 
-    buildWall(items) {
+    buildWall(items, base) {
         if (items.length === 0) {
             return '<p class="cs-ugc-overview-empty">No reviews to show yet.</p>';
         }
 
-        const cards = items.map(review => this.buildCard(review)).join('');
+        const cards = items.map((review, i) => this.buildCard(review, base + i)).join('');
         return `<div class="cs-ugc-overview-wall">${cards}</div>`;
     }
 
-    buildCard(review) {
+    buildCard(review, index) {
         const author = escapeHtml(review.author);
         const title = escapeHtml(review.title);
         const body = escapeHtml(review.body);
@@ -243,7 +259,7 @@ export default class UgcOverview {
 
         return `
             <article class="cs-ugc-overview-card">
-                ${this.buildThumb(review)}
+                ${this.buildThumb(review, index)}
                 <div class="cs-ugc-overview-card-body">
                     <div class="cs-ugc-overview-stars" role="img" aria-label="${rating} out of ${MAX_STARS} stars">${stars}</div>
                     ${title ? `<h3 class="cs-ugc-overview-title">${title}</h3>` : ''}
@@ -262,11 +278,14 @@ export default class UgcOverview {
      * Render the first media item as the card thumbnail. Photos use the
      * thumbnail URL; videos fall back to the poster (SRS §3.2.7 / ReviewMedia).
      * The thumb slot reserves space even with no media so the wall stays
-     * layout-stable.
+     * layout-stable. When the review carries a photo the thumb is a button that
+     * opens the review in the lightbox; the `index` is its absolute position in
+     * the current filtered set, which the lightbox steps through.
      * @param {Object} review
+     * @param {number} index
      * @returns {string}
      */
-    buildThumb(review) {
+    buildThumb(review, index) {
         if (!hasMedia(review)) {
             return '<div class="cs-ugc-overview-thumb is-empty" aria-hidden="true"></div>';
         }
@@ -280,9 +299,9 @@ export default class UgcOverview {
 
         const alt = escapeHtml(review.title || review.archetype_name || 'Customer photo');
         return `
-            <div class="cs-ugc-overview-thumb">
+            <button type="button" class="cs-ugc-overview-thumb" data-ugc-review-open data-ugc-index="${index}" aria-label="Open this review">
                 <img src="${escapeHtml(src)}" alt="${alt}" loading="lazy" width="200" height="200">
-            </div>
+            </button>
         `;
     }
 
@@ -302,9 +321,237 @@ export default class UgcOverview {
         `;
     }
 
+    /**
+     * The absolute-index list the lightbox steps through: the active filter
+     * applied to the full feed, in display order (Decision A — includes reviews
+     * without photos). A thumb's data-ugc-index points into this same list.
+     * @returns {Object[]}
+     */
+    filteredReviews() {
+        return applyFilter(this.reviews, this.filter, this.ratingValue);
+    }
+
+    /**
+     * Lazily create the single lightbox node (appended to <body>, outside the
+     * wall's innerHTML churn) and wire its delegated click handler. Reuses the
+     * .cs-ugc-modal / .cs-ugc-lightbox shell from _cs-product.scss.
+     * @returns {HTMLElement}
+     */
+    ensureLightbox() {
+        if (this.lightbox) {
+            return this.lightbox;
+        }
+
+        const el = document.createElement('div');
+        el.className = 'cs-ugc-modal cs-ugc-overview-lightbox';
+        el.dataset.ugcOverviewLightbox = '';
+        el.hidden = true;
+        el.innerHTML = `
+            <div class="cs-ugc-modal-overlay" data-ugc-lightbox-close></div>
+            <div class="cs-ugc-modal-dialog cs-ugc-lightbox-dialog" role="dialog" aria-modal="true" aria-label="Customer review">
+                <button type="button" class="cs-ugc-modal-close" data-ugc-lightbox-close aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <button type="button" class="cs-ugc-lightbox-arrow cs-ugc-lightbox-arrow--prev" data-ugc-review-prev aria-label="Previous review"><span aria-hidden="true">&lsaquo;</span></button>
+                <button type="button" class="cs-ugc-lightbox-arrow cs-ugc-lightbox-arrow--next" data-ugc-review-next aria-label="Next review"><span aria-hidden="true">&rsaquo;</span></button>
+                <div class="cs-ugc-overview-lightbox-content" data-ugc-lightbox-content></div>
+            </div>
+        `;
+
+        document.body.appendChild(el);
+        el.addEventListener('click', this.handleLightboxClick);
+        this.lightbox = el;
+        return el;
+    }
+
+    /**
+     * Open the lightbox at an absolute index into the filtered set and start
+     * keyboard navigation. Out-of-range indices are ignored.
+     * @param {number} index
+     */
+    openLightbox(index) {
+        const reviews = this.filteredReviews();
+        if (!Number.isInteger(index) || index < 0 || index >= reviews.length) {
+            return;
+        }
+
+        this.lastFocused = document.activeElement;
+        this.lightboxIndex = index;
+
+        const el = this.ensureLightbox();
+        this.renderLightbox();
+        el.hidden = false;
+        document.addEventListener('keydown', this.handleLightboxKeydown);
+
+        const close = el.querySelector('[data-ugc-lightbox-close]');
+        if (close) {
+            close.focus();
+        }
+    }
+
+    /**
+     * Step the lightbox by delta within the filtered set, clamped to its ends
+     * (no wrap — the arrows disable at the boundaries).
+     * @param {number} delta
+     */
+    navigateLightbox(delta) {
+        const reviews = this.filteredReviews();
+        const target = this.lightboxIndex + delta;
+        if (target < 0 || target >= reviews.length) {
+            return;
+        }
+
+        this.lightboxIndex = target;
+        this.renderLightbox();
+    }
+
+    /**
+     * Paint the current review into the lightbox and set the arrow disabled
+     * states for the current position.
+     */
+    renderLightbox() {
+        if (!this.lightbox) {
+            return;
+        }
+
+        const reviews = this.filteredReviews();
+        const review = reviews[this.lightboxIndex];
+        if (!review) {
+            return;
+        }
+
+        const content = this.lightbox.querySelector('[data-ugc-lightbox-content]');
+        content.innerHTML = this.buildLightboxMedia(review) + this.buildLightboxReview(review);
+        content.scrollTop = 0;
+
+        const prev = this.lightbox.querySelector('[data-ugc-review-prev]');
+        const next = this.lightbox.querySelector('[data-ugc-review-next]');
+        prev.disabled = this.lightboxIndex <= 0;
+        next.disabled = this.lightboxIndex >= reviews.length - 1;
+    }
+
+    /**
+     * Hide the lightbox, clear its content (which also stops a playing video),
+     * stop keyboard navigation, and restore focus to the thumb that opened it.
+     */
+    closeLightbox() {
+        if (!this.lightbox || this.lightbox.hidden) {
+            return;
+        }
+
+        this.lightbox.hidden = true;
+        const content = this.lightbox.querySelector('[data-ugc-lightbox-content]');
+        if (content) {
+            content.innerHTML = '';
+        }
+
+        document.removeEventListener('keydown', this.handleLightboxKeydown);
+
+        if (this.lastFocused && typeof this.lastFocused.focus === 'function') {
+            this.lastFocused.focus();
+        }
+        this.lastFocused = null;
+    }
+
+    /**
+     * All of a review's media, stacked and rendered large (photo → medium/url,
+     * video → playable with its poster). Reviews without media render no media
+     * block — the text still shows, so arrow navigation never dead-ends on a
+     * no-photo review (SRS §3.2.1 safe media fields).
+     * @param {Object} review
+     * @returns {string}
+     */
+    buildLightboxMedia(review) {
+        if (!hasMedia(review)) {
+            return '';
+        }
+
+        const items = review.media.map((media) => {
+            const label = escapeHtml(review.title || review.archetype_name || 'Customer media');
+
+            if (media.type === 'video') {
+                const videoSrc = escapeHtml(media.url || '');
+                const poster = media.poster_url ? ` poster="${escapeHtml(media.poster_url)}"` : '';
+                return `<video class="cs-ugc-lightbox-video" src="${videoSrc}"${poster} controls playsinline aria-label="${label}"></video>`;
+            }
+
+            const imgSrc = escapeHtml(media.medium_url || media.url || media.thumb_url || '');
+            return `<img class="cs-ugc-lightbox-img" src="${imgSrc}" alt="${label}" loading="lazy">`;
+        }).join('');
+
+        return `<div class="cs-ugc-overview-lightbox-media">${items}</div>`;
+    }
+
+    /**
+     * The review's text content, mirroring the wall card (stars, title, vehicle
+     * badge, body, author + product link) but laid out for the wider lightbox.
+     * @param {Object} review
+     * @returns {string}
+     */
+    buildLightboxReview(review) {
+        const author = escapeHtml(review.author);
+        const title = escapeHtml(review.title);
+        const body = escapeHtml(review.body);
+        const archetypeName = escapeHtml(review.archetype_name);
+        const archetypeUrl = escapeHtml(review.archetype_url);
+        const rating = parseInt(review.rating, 10) || 0;
+        const stars = buildStarIcons(rating);
+
+        return `
+            <div class="cs-ugc-overview-lightbox-review">
+                <div class="cs-ugc-overview-stars" role="img" aria-label="${rating} out of ${MAX_STARS} stars">${stars}</div>
+                ${title ? `<h3 class="cs-ugc-overview-lightbox-title">${title}</h3>` : ''}
+                ${buildVehicleBadge(review.vehicle_label)}
+                <p class="cs-ugc-overview-text">${body}</p>
+                <p class="cs-ugc-overview-meta">
+                    <span class="cs-ugc-overview-author">${author}</span>
+                    ${archetypeUrl ? `<a class="cs-ugc-overview-product" href="${archetypeUrl}">${archetypeName}</a>` : ''}
+                </p>
+            </div>
+        `;
+    }
+
+    handleLightboxClick(event) {
+        if (event.target.closest('[data-ugc-lightbox-close]')) {
+            this.closeLightbox();
+            return;
+        }
+
+        if (event.target.closest('[data-ugc-review-prev]')) {
+            this.navigateLightbox(-1);
+            return;
+        }
+
+        if (event.target.closest('[data-ugc-review-next]')) {
+            this.navigateLightbox(1);
+        }
+    }
+
+    handleLightboxKeydown(event) {
+        switch (event.key) {
+        case 'Escape':
+            this.closeLightbox();
+            break;
+        case 'ArrowLeft':
+            this.navigateLightbox(-1);
+            break;
+        case 'ArrowRight':
+            this.navigateLightbox(1);
+            break;
+        default:
+            break;
+        }
+    }
+
     destroy() {
         if (this.container) {
             this.container.removeEventListener('click', this.handleControlClick);
+        }
+
+        document.removeEventListener('keydown', this.handleLightboxKeydown);
+
+        if (this.lightbox) {
+            this.lightbox.removeEventListener('click', this.handleLightboxClick);
+            this.lightbox.remove();
+            this.lightbox = null;
         }
     }
 }

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -422,6 +422,10 @@ export default class UgcOverview {
         content.innerHTML = this.buildLightboxMedia(review) + this.buildLightboxReview(review);
         content.scrollTop = 0;
 
+        // Overview arrows stay visible and only disable at the ends (a single
+        // filtered review disables both). This differs deliberately from the
+        // product lightbox, which hides its arrows for a single-photo set —
+        // here the review-stepping affordance reads better kept in place.
         const prev = this.lightbox.querySelector('[data-ugc-review-prev]');
         const next = this.lightbox.querySelector('[data-ugc-review-next]');
         prev.disabled = this.lightboxIndex <= 0;
@@ -544,6 +548,12 @@ export default class UgcOverview {
     destroy() {
         if (this.container) {
             this.container.removeEventListener('click', this.handleControlClick);
+        }
+
+        // Close first if open, so teardown stays symmetric: restores focus,
+        // removes the keydown listener, and clears the leaked lastFocused node.
+        if (this.lightbox && !this.lightbox.hidden) {
+            this.closeLightbox();
         }
 
         document.removeEventListener('keydown', this.handleLightboxKeydown);

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -2344,6 +2344,14 @@ export default class UgcProduct {
         }
 
         this.gridMedia = this.gridMedia.concat(this._collectGridMedia(items));
+
+        // If the lightbox is open on a navigable entry, the freshly appended
+        // media extends the set — refresh the arrow disabled state so a
+        // now-reachable neighbour isn't stranded until the next interaction.
+        if (this.lightboxElement && !this.lightboxElement.hidden && this.lightboxIndex >= 0) {
+            this._updateLightboxNav();
+        }
+
         return true;
     }
 

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -365,6 +365,10 @@ export default class UgcProduct {
         this.lightboxElement = document.querySelector('[data-ugc-lightbox]');
         this.galleryModalElement = document.querySelector('[data-ugc-gallery]');
         this.gridMedia = [];
+        // Index of the gridMedia entry the lightbox is showing, so prev/next can
+        // step through the customer-photo set. -1 when the lightbox was opened
+        // from a per-review strip tile (no index → no navigation).
+        this.lightboxIndex = -1;
         this.galleryRequested = false;
         this.galleryLoading = false;
         this.galleryExhausted = false;
@@ -414,6 +418,7 @@ export default class UgcProduct {
         this.onQuestionOpenClick = this.onQuestionOpenClick.bind(this);
         this.onMediaTileClick = this.onMediaTileClick.bind(this);
         this.onLightboxClick = this.onLightboxClick.bind(this);
+        this.onLightboxKeydown = this.onLightboxKeydown.bind(this);
         this.onGalleryModalClick = this.onGalleryModalClick.bind(this);
         this.onFitmentChipClick = this.onFitmentChipClick.bind(this);
         this.onVehicleBadgeClick = this.onVehicleBadgeClick.bind(this);
@@ -2601,6 +2606,37 @@ export default class UgcProduct {
     onLightboxClick(event) {
         if (event.target.closest('[data-ugc-lightbox-close]')) {
             this.closeLightbox();
+            return;
+        }
+
+        if (event.target.closest('[data-ugc-lightbox-prev]')) {
+            this._navLightbox(-1);
+            return;
+        }
+
+        if (event.target.closest('[data-ugc-lightbox-next]')) {
+            this._navLightbox(1);
+        }
+    }
+
+    /**
+     * Keyboard navigation while the lightbox is open: arrows step the photo
+     * set, Escape closes. Bound on open, removed on close.
+     * @param {KeyboardEvent} event
+     */
+    onLightboxKeydown(event) {
+        switch (event.key) {
+        case 'Escape':
+            this.closeLightbox();
+            break;
+        case 'ArrowLeft':
+            this._navLightbox(-1);
+            break;
+        case 'ArrowRight':
+            this._navLightbox(1);
+            break;
+        default:
+            break;
         }
     }
 
@@ -2711,18 +2747,110 @@ export default class UgcProduct {
         }
 
         // Band and gallery-modal tiles carry their gridMedia index — show the
-        // full owning review under the media. Per-review strip tiles don't
-        // (their review is already on screen).
+        // full owning review under the media, and enable prev/next to step the
+        // photo set. Per-review strip tiles don't (their review is already on
+        // screen), so they stay media-only with no arrows.
         let review = '';
-        const entry = dataset.ugcMediaIndex === undefined
-            ? null
-            : this.gridMedia[parseInt(dataset.ugcMediaIndex, 10)];
+        const index = dataset.ugcMediaIndex === undefined
+            ? -1
+            : parseInt(dataset.ugcMediaIndex, 10);
+        const entry = index >= 0 ? this.gridMedia[index] : null;
         if (entry && entry.review) {
             review = `<div class="cs-ugc-lightbox-review">${this._buildReview(entry.review, false, false)}</div>`;
         }
 
         content.innerHTML = media + review;
+        this.lightboxIndex = entry ? index : -1;
+        this._updateLightboxNav();
         this.lightboxElement.hidden = false;
+        document.addEventListener('keydown', this.onLightboxKeydown);
+    }
+
+    /**
+     * Re-render the lightbox at another gridMedia entry (prev/next navigation):
+     * its media plus the full owning review, mirroring an indexed-tile open.
+     * @param {number} index - The target gridMedia index.
+     */
+    _renderLightboxEntry(index) {
+        const content = this.lightboxElement
+            ? this.lightboxElement.querySelector('[data-ugc-lightbox-content]')
+            : null;
+        const entry = this.gridMedia[index];
+        if (!content || !entry) {
+            return;
+        }
+
+        this.lightboxIndex = index;
+        const review = `<div class="cs-ugc-lightbox-review">${this._buildReview(entry.review, false, false)}</div>`;
+        content.innerHTML = this._buildLightboxMedia(entry.media, entry.review.author) + review;
+        this._updateLightboxNav();
+    }
+
+    /**
+     * Build the large lightbox media markup from a §3.2.1 media object (photo →
+     * medium/url, video → url + poster). Mirrors the open-from-dataset path so
+     * navigated and clicked media render identically.
+     * @param {Object} media
+     * @param {string} [author] - Owning review author, for the label.
+     * @returns {string}
+     */
+    _buildLightboxMedia(media, author) {
+        const source = author ? `${author}'s review` : 'a customer review';
+
+        if (media.type === 'video') {
+            const src = this._escapeAttr(media.url || '');
+            const poster = media.poster_url ? ` poster="${this._escapeAttr(media.poster_url)}"` : '';
+            const label = this._escapeAttr(`Video from ${source}`);
+            return `<video class="cs-ugc-lightbox-video" src="${src}"${poster} controls autoplay playsinline aria-label="${label}"></video>`;
+        }
+
+        const src = this._escapeAttr(media.medium_url || media.url || '');
+        const label = this._escapeAttr(`Photo from ${source}`);
+        return `<img class="cs-ugc-lightbox-img" src="${src}" alt="${label}">`;
+    }
+
+    /**
+     * Step the lightbox by delta through the gridMedia photo set, clamped to its
+     * ends. No-op when the current view isn't navigable (per-review strip open).
+     * @param {number} delta
+     */
+    _navLightbox(delta) {
+        if (this.lightboxIndex < 0) {
+            return;
+        }
+
+        const target = this.lightboxIndex + delta;
+        if (target < 0 || target >= this.gridMedia.length) {
+            return;
+        }
+
+        this._renderLightboxEntry(target);
+    }
+
+    /**
+     * Show/hide the prev/next arrows and set their disabled state for the
+     * current position. Arrows appear only for a navigable entry with more than
+     * one photo in the set.
+     */
+    _updateLightboxNav() {
+        if (!this.lightboxElement) {
+            return;
+        }
+
+        const prev = this.lightboxElement.querySelector('[data-ugc-lightbox-prev]');
+        const next = this.lightboxElement.querySelector('[data-ugc-lightbox-next]');
+        if (!prev || !next) {
+            return;
+        }
+
+        const navigable = this.lightboxIndex >= 0 && this.gridMedia.length > 1;
+        prev.hidden = !navigable;
+        next.hidden = !navigable;
+
+        if (navigable) {
+            prev.disabled = this.lightboxIndex <= 0;
+            next.disabled = this.lightboxIndex >= this.gridMedia.length - 1;
+        }
     }
 
     /**
@@ -2740,6 +2868,8 @@ export default class UgcProduct {
         }
 
         this.lightboxElement.hidden = true;
+        this.lightboxIndex = -1;
+        document.removeEventListener('keydown', this.onLightboxKeydown);
     }
 
     renderError() {
@@ -2968,6 +3098,8 @@ export default class UgcProduct {
         if (this.lightboxElement) {
             this.lightboxElement.removeEventListener('click', this.onLightboxClick);
         }
+
+        document.removeEventListener('keydown', this.onLightboxKeydown);
 
         if (this.galleryModalElement) {
             this.galleryModalElement.removeEventListener('click', this.onGalleryModalClick);

--- a/assets/scss/custom/_cs-home.scss
+++ b/assets/scss/custom/_cs-home.scss
@@ -213,7 +213,7 @@
 .cs-ugc-overview-thumb {
   position: relative;
   width: 100%;
-  padding-top: 100%;
+  padding: 100% 0 0; // square aspect via padding box; zeroes a button's UA padding
   background-color: stencilColor('color-greyLightest');
 
   img {
@@ -228,6 +228,29 @@
   &.is-empty {
     padding-top: 0;
     min-height: spacing('double');
+  }
+}
+
+// A media review's thumb is a button that opens the review lightbox. Reset the
+// button chrome and add a subtle zoom + focus affordance to signal it's clickable.
+button.cs-ugc-overview-thumb {
+  display: block;
+  overflow: hidden;
+  border: 0;
+  cursor: pointer;
+
+  img {
+    transition: transform 0.2s ease;
+  }
+
+  &:hover img,
+  &:focus-visible img {
+    transform: scale(1.05);
+  }
+
+  &:focus-visible {
+    outline: 2px solid stencilColor('color-primary');
+    outline-offset: -2px;
   }
 }
 
@@ -327,4 +350,55 @@
 .cs-ugc-overview-page-status {
   font-size: 0.875rem;
   color: stencilColor('color-textSecondary');
+}
+
+// =============================================================================
+// Overview review lightbox: click a wall photo to open that review large, with
+// prev/next arrows stepping through the filtered set. Reuses the .cs-ugc-modal
+// shell + .cs-ugc-lightbox-* media styling from _cs-product.scss.
+// =============================================================================
+.cs-ugc-overview-lightbox {
+  align-items: center;
+}
+
+.cs-ugc-overview-lightbox-content {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('single');
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+
+  // Reserve side gutters so the floating prev/next arrows never overlap the
+  // content — most visible on a text-only review, where there is no image for
+  // the arrows to sit over (2.5rem arrow + its edge offset).
+  padding: 0 2.75rem;
+}
+
+.cs-ugc-overview-lightbox-media {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('half');
+  width: 100%;
+}
+
+.cs-ugc-overview-lightbox-media img,
+.cs-ugc-overview-lightbox-media video {
+  display: block;
+  width: 100%;
+  max-height: 60vh;
+  object-fit: contain;
+}
+
+.cs-ugc-overview-lightbox-review {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('quarter');
+  width: 100%;
+  text-align: left;
+}
+
+.cs-ugc-overview-lightbox-title {
+  margin: 0;
+  font-size: 1.125rem;
 }

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1924,6 +1924,11 @@ button.cs-ugc-vehicle-badge {
   flex-direction: column;
   align-items: center;
   min-height: 4.5rem;
+
+  // Reserve side gutters so the floating prev/next arrows never overlap the
+  // content — including the review text below the media, and the empty space
+  // while media is still loading (2.5rem arrow + its edge offset).
+  padding: 0 2.75rem;
 }
 
 .cs-ugc-lightbox-img,
@@ -1931,4 +1936,52 @@ button.cs-ugc-vehicle-badge {
   display: block;
   max-width: 100%;
   max-height: 60vh;
+}
+
+// Prev/next arrows shared by the product review lightbox and the home overview
+// lightbox. Side-floating circles anchored to the dialog (position: relative).
+// The `display: inline-flex` would otherwise beat the UA [hidden] rule, so the
+// hidden state is restored explicitly for the attribute-driven show/hide.
+.cs-ugc-lightbox-arrow {
+  position: absolute;
+  top: 50%;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: stencilColor('color-textBase');
+  background: stencilColor('color-white');
+  border: 1px solid stencilColor('color-greyLightest');
+  border-radius: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+
+  &[hidden] {
+    display: none;
+  }
+
+  &:hover:not(:disabled),
+  &:focus-visible {
+    color: stencilColor('color-primary');
+    border-color: stencilColor('color-primary');
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+}
+
+.cs-ugc-lightbox-arrow--prev {
+  left: spacing('half');
+}
+
+.cs-ugc-lightbox-arrow--next {
+  right: spacing('half');
 }

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -113,6 +113,8 @@
             <div class="cs-ugc-modal-overlay" data-ugc-lightbox-close></div>
             <div class="cs-ugc-modal-dialog cs-ugc-lightbox-dialog" role="dialog" aria-modal="true" aria-label="Review media">
                 <button type="button" class="cs-ugc-modal-close" data-ugc-lightbox-close aria-label="Close">&times;</button>
+                <button type="button" class="cs-ugc-lightbox-arrow cs-ugc-lightbox-arrow--prev" data-ugc-lightbox-prev aria-label="Previous" hidden><span aria-hidden="true">&lsaquo;</span></button>
+                <button type="button" class="cs-ugc-lightbox-arrow cs-ugc-lightbox-arrow--next" data-ugc-lightbox-next aria-label="Next" hidden><span aria-hidden="true">&rsaquo;</span></button>
                 <div class="cs-ugc-lightbox-content" data-ugc-lightbox-content></div>
             </div>
         </div>


### PR DESCRIPTION
## What

Adds a browsable review **lightbox** on both UGC surfaces. Click a customer photo to open that review large, then step through neighbours with `‹` `›` arrows (also `←`/`→`), `Esc` to close.

### Home overview wall (`ugcOverview.js`)
- Media thumbs become buttons carrying their **absolute index in the current filtered set**; clicking opens a lazily-created lightbox appended to `<body>` (outside the wall's `innerHTML` churn — no template markup needed).
- Arrows traverse the **active filter in display order**, including no-photo reviews (Decision A), clamped at the ends (no wrap). Focus returns to the opening thumb on close.

### Product "Reviews overview" grid (`ugcProduct.js`)
- The existing media-tile lightbox gains **prev/next** stepping the `gridMedia` photo set, each showing its owning review.
- **Open behaviour is unchanged** — a clicked tile still shows *that* media (all prior lightbox tests pass verbatim). Arrows stay hidden for per-review strip tiles (no navigation context) and single-photo sets.

### Shared
- One `.cs-ugc-lightbox-arrow` style for both surfaces.
- Lightbox content reserves side gutters so the floating arrows never overlap text or still-loading media.

## Notes
- Traversal **unit differs by surface, by design**: the home wall is one card per review → arrows step **reviews**; the product band is a photo grid → arrows step **photos** (each showing its review).
- No specific tracking issue — this is a user-requested enhancement to the M9 fitment/reviews surfaces.

## Tests
`npx grunt check` green — 366 tests (9 new: 6 home, 3 product), eslint + stylelint clean.

## Surfaces to verify on a dev server
- Home overview: click a photo → review opens; arrows step the filtered set incl. text-only reviews; ends disable; Esc/focus-restore.
- Product reviews grid + "+N" gallery modal: click a photo → arrows step the photo set; per-review strip tiles show no arrows.