### PR TITLE
M9 UGC: home review wall (toolbar + lightbox) and card-style media lightboxes

### DIFF
--- a/assets/js/test-unit/theme/global/ugcCard.spec.js
+++ b/assets/js/test-unit/theme/global/ugcCard.spec.js
@@ -1,0 +1,76 @@
+import {
+    MAX_STARS,
+    starIcons,
+    scoreBadge,
+    verifiedBadge,
+    editedBadge,
+    countryFlag,
+    formatReviewDate,
+} from '../../../theme/_addons/global/ugcCard';
+
+const countOf = (html, needle) => html.split(needle).length - 1;
+
+describe('ugcCard shared primitives', () => {
+    describe('starIcons', () => {
+        it('renders five sprite stars split at the rating', () => {
+            const html = starIcons(3);
+            expect(countOf(html, 'icon--ratingFull')).toBe(3);
+            expect(countOf(html, 'icon--ratingEmpty')).toBe(MAX_STARS - 3);
+        });
+
+        it('renders all empty stars for a zero rating', () => {
+            const html = starIcons(0);
+            expect(countOf(html, 'icon--ratingFull')).toBe(0);
+            expect(countOf(html, 'icon--ratingEmpty')).toBe(MAX_STARS);
+        });
+    });
+
+    describe('scoreBadge', () => {
+        it('wraps the rating in the shared score class', () => {
+            expect(scoreBadge(4)).toBe('<span class="cs-review-score">4</span>');
+        });
+    });
+
+    describe('verifiedBadge', () => {
+        it('renders the chip only for a verified purchase', () => {
+            expect(verifiedBadge(true)).toContain('cs-review-verified');
+            expect(verifiedBadge(false)).toBe('');
+        });
+    });
+
+    describe('editedBadge', () => {
+        it('renders only on a strict true (never on a missing/falsey flag)', () => {
+            expect(editedBadge(true)).toContain('cs-review-edited');
+            expect(editedBadge(false)).toBe('');
+            expect(editedBadge(undefined)).toBe('');
+            expect(editedBadge('true')).toBe('');
+        });
+    });
+
+    describe('countryFlag', () => {
+        it('builds a flagcdn SVG from a valid alpha-2 code, case-insensitive', () => {
+            const html = countryFlag('DE');
+            expect(html).toContain('src="https://flagcdn.com/de.svg"');
+            expect(html).toContain('cs-review-flag');
+        });
+
+        it('returns empty for non-string or non alpha-2 codes', () => {
+            expect(countryFlag(null)).toBe('');
+            expect(countryFlag('XYZ')).toBe('');
+            expect(countryFlag('1')).toBe('');
+            expect(countryFlag('')).toBe('');
+        });
+    });
+
+    describe('formatReviewDate', () => {
+        it('formats an ISO date as MM/DD/YYYY', () => {
+            expect(formatReviewDate('2026-06-09T15:00:00')).toBe('06/09/2026');
+        });
+
+        it('returns empty for missing or unparseable values', () => {
+            expect(formatReviewDate('')).toBe('');
+            expect(formatReviewDate(null)).toBe('');
+            expect(formatReviewDate('not-a-date')).toBe('');
+        });
+    });
+});

--- a/assets/js/test-unit/theme/global/ugcOverview.spec.js
+++ b/assets/js/test-unit/theme/global/ugcOverview.spec.js
@@ -1,6 +1,4 @@
 import UgcOverview, {
-    FILTERS,
-    applyFilter,
     buildStarIcons,
     buildVehicleBadge,
     paginate,
@@ -29,21 +27,25 @@ const makeReviews = (count, { withMediaEvery = 0, ratingCycle = [5] } = {}) => (
 
 const okResult = reviews => ({ ok: true, status: 200, data: { reviews } });
 
+// Fire a delegated 'change' on a toolbar control (the listener lives on the
+// container, so the event must bubble).
+const fireChange = el => el.dispatchEvent(new Event('change', { bubbles: true }));
+
 describe('ugcOverview pure helpers', () => {
     describe('paginate', () => {
-        it('returns the first 10 for page 1', () => {
+        it('returns the first 12 for page 1', () => {
             const reviews = makeReviews(25);
-            expect(paginate(reviews, 1).map(r => r.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            expect(paginate(reviews, 1).map(r => r.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
         });
 
-        it('returns the next 10 for page 2', () => {
+        it('returns the next 12 for page 2', () => {
             const reviews = makeReviews(25);
-            expect(paginate(reviews, 2).map(r => r.id)).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+            expect(paginate(reviews, 2).map(r => r.id)).toEqual([13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]);
         });
 
         it('returns the remainder on the last page', () => {
             const reviews = makeReviews(25);
-            expect(paginate(reviews, 3).map(r => r.id)).toEqual([21, 22, 23, 24, 25]);
+            expect(paginate(reviews, 3).map(r => r.id)).toEqual([25]);
         });
 
         it('returns nothing past the end', () => {
@@ -52,52 +54,14 @@ describe('ugcOverview pure helpers', () => {
     });
 
     describe('pageCount', () => {
-        it('ceils to whole pages of 10', () => {
+        it('ceils to whole pages of 12', () => {
             expect(pageCount(25)).toBe(3);
-            expect(pageCount(20)).toBe(2);
+            expect(pageCount(24)).toBe(2);
             expect(pageCount(1)).toBe(1);
         });
 
         it('is at least 1 even when empty', () => {
             expect(pageCount(0)).toBe(1);
-        });
-    });
-
-    describe('applyFilter', () => {
-        it('returns everything for ALL', () => {
-            const reviews = makeReviews(6, { withMediaEvery: 2 });
-            expect(applyFilter(reviews, FILTERS.ALL)).toHaveLength(6);
-        });
-
-        it('keeps only reviews with media for WITH_PHOTOS', () => {
-            const reviews = makeReviews(6, { withMediaEvery: 2 });
-            const filtered = applyFilter(reviews, FILTERS.WITH_PHOTOS);
-            expect(filtered).toHaveLength(3);
-            expect(filtered.every(r => r.media.length > 0)).toBe(true);
-        });
-
-        it('keeps only reviews without media for BASIC', () => {
-            const reviews = makeReviews(6, { withMediaEvery: 2 });
-            const filtered = applyFilter(reviews, FILTERS.BASIC);
-            expect(filtered).toHaveLength(3);
-            expect(filtered.every(r => r.media.length === 0)).toBe(true);
-        });
-
-        it('filters by exact star rating for RATING', () => {
-            const reviews = makeReviews(6, { ratingCycle: [5, 4] });
-            expect(applyFilter(reviews, FILTERS.RATING, 5)).toHaveLength(3);
-            expect(applyFilter(reviews, FILTERS.RATING, 4)).toHaveLength(3);
-        });
-
-        it('ignores a null rating value and returns everything', () => {
-            const reviews = makeReviews(6, { ratingCycle: [5, 4] });
-            expect(applyFilter(reviews, FILTERS.RATING, null)).toHaveLength(6);
-        });
-
-        it('treats a non-array media field as no-media', () => {
-            const reviews = [{ rating: 5 }, { rating: 5, media: null }];
-            expect(applyFilter(reviews, FILTERS.WITH_PHOTOS)).toHaveLength(0);
-            expect(applyFilter(reviews, FILTERS.BASIC)).toHaveLength(2);
         });
     });
 
@@ -149,7 +113,7 @@ describe('UgcOverview controller', () => {
 
     const mount = () => new UgcOverview({ api });
 
-    it('renders the first page of 10 from GET /api/overview', async () => {
+    it('renders the first page of 12 from GET /api/overview', async () => {
         api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
         const overview = mount();
 
@@ -157,7 +121,7 @@ describe('UgcOverview controller', () => {
 
         expect(api.getOverview).toHaveBeenCalledTimes(1);
         const cards = document.querySelectorAll('.cs-ugc-overview-card');
-        expect(cards).toHaveLength(10);
+        expect(cards).toHaveLength(12);
     });
 
     it('paginates client-side with no further fetches', async () => {
@@ -165,12 +129,16 @@ describe('UgcOverview controller', () => {
         const overview = mount();
         await overview.init();
 
-        document.querySelector('[data-ugc-page="2"]').click();
+        // data-page-key is unambiguous (the numbered "2" button, not the
+        // next-arrow which also carries data-ugc-page="2" from page 1).
+        document.querySelector('[data-page-key="2"]').click();
 
         expect(api.getOverview).toHaveBeenCalledTimes(1);
-        const status = document.querySelector('.cs-ugc-overview-page-status');
-        expect(status.textContent).toMatch(/Page 2 of 3/);
-        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(10);
+        const current = document.querySelector('.cs-ugc-overview-page.is-current');
+        expect(current.textContent).toBe('2');
+        expect(current.getAttribute('aria-current')).toBe('page');
+        // 25 reviews → pages of 12, 12, 1; page 2 is a full 12.
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(12);
     });
 
     it('clamps pagination within range', async () => {
@@ -185,28 +153,32 @@ describe('UgcOverview controller', () => {
         expect(next.hasAttribute('disabled')).toBe(true);
     });
 
-    it('filters client-side with no further fetches and resets to page 1', async () => {
-        api.getOverview.mockResolvedValue(okResult(makeReviews(25, { withMediaEvery: 5 })));
+    it('renders page controls both above and below the wall', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
         const overview = mount();
         await overview.init();
 
-        document.querySelector('[data-ugc-page="2"]').click();
-        document.querySelector('[data-ugc-filter="photos"]').click();
-
-        expect(api.getOverview).toHaveBeenCalledTimes(1);
-        // 5 of 25 carry media; all fit on one page.
-        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(5);
-        expect(document.querySelector('.cs-ugc-overview-pagination')).toBeNull();
+        const navs = document.querySelectorAll('.cs-ugc-overview-pagination');
+        expect(navs).toHaveLength(2);
+        expect(document.querySelector('.cs-ugc-overview-pagination--top')).not.toBeNull();
+        expect(document.querySelector('.cs-ugc-overview-pagination--bottom')).not.toBeNull();
+        // Distinct landmark names (axe landmark-unique).
+        const labels = Array.from(navs).map(n => n.getAttribute('aria-label'));
+        expect(new Set(labels).size).toBe(2);
     });
 
-    it('filters by rating when a star button is clicked', async () => {
-        api.getOverview.mockResolvedValue(okResult(makeReviews(20, { ratingCycle: [5, 4, 3, 2] })));
+    it('renders the sort/filter toolbar but no "write a review" submit button', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(5)));
         const overview = mount();
         await overview.init();
 
-        document.querySelector('[data-ugc-filter="rating"][data-ugc-rating="5"]').click();
-
-        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(5);
+        expect(document.querySelector('.cs-reviews-toolbar')).not.toBeNull();
+        expect(document.querySelector('[data-ugc-control="sort"]')).not.toBeNull();
+        expect(document.querySelector('[data-ugc-control="rating"]')).not.toBeNull();
+        expect(document.querySelector('[data-ugc-control="verified"]')).not.toBeNull();
+        expect(document.querySelector('[data-ugc-control="media"]')).not.toBeNull();
+        // No single archetype to submit to from home, so no submit opener.
+        expect(document.querySelector('[data-review-modal-open]')).toBeNull();
     });
 
     it('renders the empty state when the feed has no reviews', async () => {
@@ -256,7 +228,7 @@ describe('UgcOverview controller', () => {
         const overview = mount();
         await overview.init();
 
-        const img = document.querySelector('.cs-ugc-overview-thumb img');
+        const img = document.querySelector('.cs-ugc-overview-media img');
         expect(img.getAttribute('src')).toBe('https://cdn/0/thumb.jpg');
     });
 
@@ -282,6 +254,239 @@ describe('UgcOverview controller', () => {
 
         expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(2);
         expect(document.querySelector('.cs-ugc-vehicle-badge')).toBeNull();
+    });
+
+    it('renders the numeric score, verified badge, flag, date, and edited marker', async () => {
+        const reviews = makeReviews(1);
+        Object.assign(reviews[0], {
+            rating: 4,
+            verified_purchaser: true,
+            country: 'DE',
+            date: '2026-06-09T15:00:00',
+            edited: true,
+        });
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        const card = document.querySelector('.cs-ugc-overview-card');
+        expect(card.querySelector('.cs-review-score').textContent).toBe('4');
+        expect(card.querySelector('.cs-review-verified')).not.toBeNull();
+        const flag = card.querySelector('.cs-review-flag');
+        expect(flag.getAttribute('src')).toBe('https://flagcdn.com/de.svg');
+        expect(card.querySelector('.cs-review-date').textContent).toBe('06/09/2026');
+        expect(card.querySelector('.cs-review-edited')).not.toBeNull();
+    });
+
+    it('omits the verified/flag/edited markers when the data is absent or invalid', async () => {
+        const reviews = makeReviews(1);
+        Object.assign(reviews[0], {
+            verified_purchaser: false,
+            country: 'XYZ',
+            edited: false,
+        });
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        const card = document.querySelector('.cs-ugc-overview-card');
+        expect(card.querySelector('.cs-review-verified')).toBeNull();
+        expect(card.querySelector('.cs-review-flag')).toBeNull();
+        expect(card.querySelector('.cs-review-edited')).toBeNull();
+    });
+
+    it('smoothly scrolls the wall into view on a page change', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
+        const overview = mount();
+        await overview.init();
+        const container = document.querySelector('[data-ugc-overview]');
+        container.scrollIntoView = jest.fn();
+
+        document.querySelector('[data-page-key="2"]').click();
+
+        expect(container.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    });
+
+    it('does not scroll when the clicked page is already current', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
+        const overview = mount();
+        await overview.init();
+        const container = document.querySelector('[data-ugc-overview]');
+        container.scrollIntoView = jest.fn();
+
+        document.querySelector('[data-page-key="1"]').click();
+
+        expect(container.scrollIntoView).not.toHaveBeenCalled();
+    });
+});
+
+describe('UgcOverview toolbar (client-side sort & filters)', () => {
+    let api;
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div class="cs-ugc-overview" data-ugc-overview></div>';
+        api = { getOverview: jest.fn() };
+    });
+
+    const mount = () => new UgcOverview({ api });
+    const titles = () => Array.from(document.querySelectorAll('.cs-ugc-overview-title')).map(t => t.textContent);
+    const cardCount = () => document.querySelectorAll('.cs-ugc-overview-card').length;
+
+    it('sorts the wall by the selected order without refetching', async () => {
+        const reviews = makeReviews(3);
+        Object.assign(reviews[0], { date: '2026-01-01', rating: 3 }); // Title 1
+        Object.assign(reviews[1], { date: '2026-03-01', rating: 5 }); // Title 2
+        Object.assign(reviews[2], { date: '2026-02-01', rating: 1 }); // Title 3
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        // Default: newest first.
+        expect(titles()).toEqual(['Title 2', 'Title 3', 'Title 1']);
+
+        const sort = document.querySelector('[data-ugc-control="sort"]');
+        sort.value = 'date_asc';
+        fireChange(sort);
+        expect(titles()).toEqual(['Title 1', 'Title 3', 'Title 2']);
+
+        sort.value = 'rating_desc';
+        fireChange(sort);
+        expect(titles()).toEqual(['Title 2', 'Title 1', 'Title 3']);
+
+        sort.value = 'rating_asc';
+        fireChange(sort);
+        expect(titles()).toEqual(['Title 3', 'Title 1', 'Title 2']);
+
+        // All client-side: the feed was fetched exactly once.
+        expect(api.getOverview).toHaveBeenCalledTimes(1);
+    });
+
+    it('filters the wall by the selected rating, and clears back to all', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(4, { ratingCycle: [5, 4, 5, 3] })));
+        const overview = mount();
+        await overview.init();
+        expect(cardCount()).toBe(4);
+
+        const rating = document.querySelector('[data-ugc-control="rating"]');
+        rating.value = '5';
+        fireChange(rating);
+        expect(cardCount()).toBe(2);
+
+        rating.value = '';
+        fireChange(rating);
+        expect(cardCount()).toBe(4);
+    });
+
+    it('filters the wall to verified purchasers', async () => {
+        const reviews = makeReviews(3);
+        reviews[0].verified_purchaser = true;
+        reviews[1].verified_purchaser = false;
+        reviews[2].verified_purchaser = true;
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        const verified = document.querySelector('[data-ugc-control="verified"]');
+        verified.checked = true;
+        fireChange(verified);
+        expect(cardCount()).toBe(2);
+
+        verified.checked = false;
+        fireChange(verified);
+        expect(cardCount()).toBe(3);
+    });
+
+    it('filters the wall to reviews with photos & videos', async () => {
+        // withMediaEvery 2 → indices 0 and 2 carry media → 2 of 4.
+        api.getOverview.mockResolvedValue(okResult(makeReviews(4, { withMediaEvery: 2 })));
+        const overview = mount();
+        await overview.init();
+
+        const media = document.querySelector('[data-ugc-control="media"]');
+        media.checked = true;
+        fireChange(media);
+        expect(cardCount()).toBe(2);
+    });
+
+    it('composes rating + verified filters together', async () => {
+        const reviews = makeReviews(4, { ratingCycle: [5, 5, 4, 5] });
+        reviews[0].verified_purchaser = true; // 5, verified ✓
+        reviews[1].verified_purchaser = false; // 5, unverified ✗
+        reviews[2].verified_purchaser = true; // 4 ✗ (rating)
+        reviews[3].verified_purchaser = true; // 5, verified ✓
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        document.querySelector('[data-ugc-control="rating"]').value = '5';
+        fireChange(document.querySelector('[data-ugc-control="rating"]'));
+        document.querySelector('[data-ugc-control="verified"]').checked = true;
+        fireChange(document.querySelector('[data-ugc-control="verified"]'));
+
+        expect(cardCount()).toBe(2);
+    });
+
+    it('resets to page 1 on any sort or filter change', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(25)));
+        const overview = mount();
+        await overview.init();
+
+        document.querySelector('[data-page-key="2"]').click();
+        expect(document.querySelector('.cs-ugc-overview-page.is-current').textContent).toBe('2');
+
+        const sort = document.querySelector('[data-ugc-control="sort"]');
+        sort.value = 'date_asc';
+        fireChange(sort);
+        expect(document.querySelector('.cs-ugc-overview-page.is-current').textContent).toBe('1');
+    });
+
+    it('reflects the current sort/filter state in the toolbar after a full repaint', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(5)));
+        const overview = mount();
+        await overview.init();
+
+        overview.sort = 'rating_asc';
+        overview.rating = 4;
+        overview.verified = true;
+        overview.media = true;
+        overview.render();
+
+        expect(document.querySelector('[data-ugc-control="sort"]').value).toBe('rating_asc');
+        expect(document.querySelector('[data-ugc-control="rating"]').value).toBe('4');
+        expect(document.querySelector('[data-ugc-control="verified"]').checked).toBe(true);
+        expect(document.querySelector('[data-ugc-control="media"]').checked).toBe(true);
+    });
+
+    it('shows the empty message but keeps the toolbar when filters exclude every review', async () => {
+        api.getOverview.mockResolvedValue(okResult(makeReviews(3, { ratingCycle: [5] })));
+        const overview = mount();
+        await overview.init();
+
+        const rating = document.querySelector('[data-ugc-control="rating"]');
+        rating.value = '1';
+        fireChange(rating);
+
+        expect(cardCount()).toBe(0);
+        expect(document.querySelector('.cs-ugc-overview-empty')).not.toBeNull();
+        // The toolbar stays so the visitor can relax the filter.
+        expect(document.querySelector('.cs-reviews-toolbar')).not.toBeNull();
+    });
+
+    it('does not mutate the source feed when sorting', async () => {
+        const reviews = makeReviews(3);
+        Object.assign(reviews[0], { date: '2026-01-01' });
+        Object.assign(reviews[1], { date: '2026-03-01' });
+        Object.assign(reviews[2], { date: '2026-02-01' });
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const overview = mount();
+        await overview.init();
+
+        const sort = document.querySelector('[data-ugc-control="sort"]');
+        sort.value = 'date_asc';
+        fireChange(sort);
+
+        // The in-memory feed is still in fetch order (ids 1, 2, 3).
+        expect(overview.reviews.map(r => r.id)).toEqual([1, 2, 3]);
     });
 });
 
@@ -309,14 +514,17 @@ describe('UgcOverview review lightbox', () => {
         return overview;
     };
 
-    it('renders media thumbs as buttons carrying their filtered index', async () => {
+    it('makes every card openable and shows a photo only on media reviews', async () => {
         await mountInit(makeReviews(10, { withMediaEvery: 5 }));
 
-        const openers = document.querySelectorAll('[data-ugc-review-open]');
-        expect(Array.from(openers).map(b => b.dataset.ugcIndex)).toEqual(['0', '5']);
-        expect(document.querySelectorAll('button.cs-ugc-overview-thumb')).toHaveLength(2);
-        // No-media thumbs stay non-interactive divs, not openers.
-        expect(document.querySelectorAll('div.cs-ugc-overview-thumb.is-empty')).toHaveLength(8);
+        // The whole-card opener carries each card's absolute filtered index, so
+        // no-photo reviews open too — not just the two with a photo.
+        const openers = document.querySelectorAll('.cs-ugc-overview-open[data-ugc-review-open]');
+        expect(Array.from(openers).map(b => b.dataset.ugcIndex))
+            .toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
+        // Photo blocks only on the media reviews; no empty placeholder slots.
+        expect(document.querySelectorAll('.cs-ugc-overview-media')).toHaveLength(2);
+        expect(document.querySelectorAll('.cs-ugc-overview-thumb')).toHaveLength(0);
     });
 
     it('opens the clicked review and steps through the filtered set, incl. no-photo reviews', async () => {
@@ -350,20 +558,6 @@ describe('UgcOverview review lightbox', () => {
         next.click(); // index 2 (last)
         expect(next.disabled).toBe(true);
         expect(prev.disabled).toBe(false);
-    });
-
-    it('steps only within the active filter', async () => {
-        await mountInit(makeReviews(25, { withMediaEvery: 5 }));
-
-        document.querySelector('[data-ugc-filter="photos"]').click();
-        // 5 media reviews (ids 1, 6, 11, 16, 21) collapse to filtered indices 0..4.
-        document.querySelector('[data-ugc-review-open][data-ugc-index="0"]').click();
-        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
-        expect(lightbox.textContent).toContain('Body 1');
-
-        lightbox.querySelector('[data-ugc-review-next]').click();
-        // The next media review, not the immediately-following no-photo one.
-        expect(lightbox.textContent).toContain('Body 6');
     });
 
     it('closes via the close control and restores focus to the opening thumb', async () => {
@@ -402,22 +596,244 @@ describe('UgcOverview review lightbox', () => {
         expect(video.getAttribute('poster')).toBe('https://cdn/p.jpg');
     });
 
-    it('navigates across page boundaries using absolute filtered indices', async () => {
-        // 15 reviews all carry media → page 1 shows 10, page 2 shows 5.
-        await mountInit(makeReviews(15, { withMediaEvery: 1 }));
+    it('renders no thumbnail strip for a single-media review', async () => {
+        await mountInit(makeReviews(1, { withMediaEvery: 1 }));
 
-        document.querySelector('[data-ugc-page="2"]').click();
-        // Page-2 thumbs carry absolute indices 10..14.
-        document.querySelector('[data-ugc-review-open][data-ugc-index="10"]').click();
+        document.querySelector('[data-ugc-review-open]').click();
         const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
-        expect(lightbox.textContent).toContain('Body 11');
+        expect(lightbox.querySelector('.cs-ugc-overview-lightbox-hero')).not.toBeNull();
+        expect(lightbox.querySelector('[data-ugc-media-thumb]')).toBeNull();
+    });
+
+    it('shows one hero plus a thumbnail strip for a multi-media review, swapping the hero on click', async () => {
+        const reviews = makeReviews(1);
+        reviews[0].media = [
+            { type: 'photo', thumb_url: 'https://cdn/0t.jpg', medium_url: 'https://cdn/0m.jpg' },
+            { type: 'photo', thumb_url: 'https://cdn/1t.jpg', medium_url: 'https://cdn/1m.jpg' },
+            { type: 'video', url: 'https://cdn/2v.mp4', poster_url: 'https://cdn/2p.jpg', thumb_url: 'https://cdn/2t.jpg' },
+        ];
+        await mountInit(reviews);
+
+        document.querySelector('[data-ugc-review-open]').click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+
+        // One hero (the first item), and a 3-thumb strip with the first active.
+        expect(lightbox.querySelector('.cs-ugc-overview-lightbox-hero img').getAttribute('src')).toBe('https://cdn/0m.jpg');
+        const thumbs = lightbox.querySelectorAll('[data-ugc-media-thumb]');
+        expect(thumbs).toHaveLength(3);
+        expect(thumbs[0].classList.contains('is-active')).toBe(true);
+
+        // Click the 2nd thumb → hero swaps and the active marker moves.
+        thumbs[1].click();
+        expect(lightbox.querySelector('.cs-ugc-overview-lightbox-hero img').getAttribute('src')).toBe('https://cdn/1m.jpg');
+        expect(lightbox.querySelectorAll('[data-ugc-media-thumb]')[1].classList.contains('is-active')).toBe(true);
+
+        // Click the video thumb → hero becomes a <video> with its poster.
+        lightbox.querySelectorAll('[data-ugc-media-thumb]')[2].click();
+        const video = lightbox.querySelector('.cs-ugc-overview-lightbox-hero video');
+        expect(video.getAttribute('src')).toBe('https://cdn/2v.mp4');
+        expect(video.getAttribute('poster')).toBe('https://cdn/2p.jpg');
+    });
+
+    it('resets to the first media when navigating to another review', async () => {
+        const reviews = makeReviews(2);
+        reviews[0].media = [
+            { type: 'photo', thumb_url: 'https://cdn/a0t.jpg', medium_url: 'https://cdn/a0m.jpg' },
+            { type: 'photo', thumb_url: 'https://cdn/a1t.jpg', medium_url: 'https://cdn/a1m.jpg' },
+        ];
+        reviews[1].media = [{ type: 'photo', thumb_url: 'https://cdn/b0t.jpg', medium_url: 'https://cdn/b0m.jpg' }];
+        await mountInit(reviews);
+
+        overview.openLightbox(0);
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+
+        // Switch to review 0's second photo, then step to review 1.
+        lightbox.querySelectorAll('[data-ugc-media-thumb]')[1].click();
+        expect(lightbox.querySelector('.cs-ugc-overview-lightbox-hero img').getAttribute('src')).toBe('https://cdn/a1m.jpg');
 
         lightbox.querySelector('[data-ugc-review-next]').click();
-        expect(lightbox.textContent).toContain('Body 12');
+        expect(lightbox.querySelector('.cs-ugc-overview-lightbox-hero img').getAttribute('src')).toBe('https://cdn/b0m.jpg');
+    });
+
+    it('navigates across page boundaries using absolute filtered indices', async () => {
+        // 18 reviews all carry media → page 1 shows 12, page 2 shows 6.
+        await mountInit(makeReviews(18, { withMediaEvery: 1 }));
+
+        document.querySelector('[data-ugc-page="2"]').click();
+        // Page-2 openers carry absolute indices 12..17.
+        document.querySelector('[data-ugc-review-open][data-ugc-index="12"]').click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        expect(lightbox.textContent).toContain('Body 13');
+
+        lightbox.querySelector('[data-ugc-review-next]').click();
+        expect(lightbox.textContent).toContain('Body 14');
 
         // Stepping back crosses onto page 1's reviews — nav is page-independent.
         lightbox.querySelector('[data-ugc-review-prev]').click();
         lightbox.querySelector('[data-ugc-review-prev]').click();
-        expect(lightbox.textContent).toContain('Body 10');
+        expect(lightbox.textContent).toContain('Body 12');
+    });
+});
+
+describe('UgcOverview vehicle filter', () => {
+    let api;
+    let overview;
+
+    // Minimal search registry: MINI Cooper F56 → fitment_id 87.
+    const REGISTRY = {
+        brands: { MINI: { name: 'MINI' } },
+        models: {
+            Cooper: { name: 'Cooper', generations: { F56: { name: 'F56 2014 to 2024', fitment_id: 87 } } },
+        },
+    };
+    const GARAGE = { make: 'MINI', model: 'Cooper', generation: 'F56' };
+
+    // A GlobalStateManager stand-in whose vehicle can change and notify.
+    const makeGlobal = (vehicle, registry) => {
+        const store = { vehicle, registry };
+        let cb = null;
+        const getState = () => ({
+            vehicle: { selected: store.vehicle },
+            search: { data: store.registry ? { vehicle_registry: store.registry } : null },
+        });
+        return {
+            getState,
+            subscribe: (fn) => { cb = fn; return () => { cb = null; }; },
+            setVehicle: (v) => { store.vehicle = v; if (cb) cb(getState()); },
+        };
+    };
+
+    // 4 reviews; ids 1 and 3 fit fitment_id 87, ids 2 and 4 do not.
+    const reviewsWithFitment = () => {
+        const reviews = makeReviews(4);
+        reviews[0].fitment_id = 87;
+        reviews[1].fitment_id = 12;
+        reviews[2].fitment_id = 87;
+        reviews[3].fitment_id = null;
+        return reviews;
+    };
+
+    const mountWith = async (vehicle, registry, reviews) => {
+        api.getOverview.mockResolvedValue(okResult(reviews));
+        const globalStateManager = makeGlobal(vehicle, registry);
+        overview = new UgcOverview({ api, globalStateManager });
+        await overview.init();
+        return globalStateManager;
+    };
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div class="cs-ugc-overview" data-ugc-overview></div>';
+        api = { getOverview: jest.fn() };
+    });
+
+    afterEach(() => {
+        if (overview) {
+            overview.destroy();
+            overview = null;
+        }
+        document.querySelectorAll('[data-ugc-overview-lightbox]').forEach(el => el.remove());
+    });
+
+    it('renders a "For your <vehicle>" chip (no count) inside the toolbar slot when the garage vehicle matches loaded reviews', async () => {
+        await mountWith(GARAGE, REGISTRY, reviewsWithFitment());
+
+        // The chip now lives in the toolbar's reserved slot, made visible only
+        // once populated (the product page's CLS pattern).
+        const slot = document.querySelector('.cs-fitment-chip-slot[data-ugc-fitment-chip]');
+        expect(slot).not.toBeNull();
+        expect(slot.style.visibility).toBe('visible');
+
+        const chip = document.querySelector('[data-ugc-fitment-toggle]');
+        expect(chip).not.toBeNull();
+        expect(slot.contains(chip)).toBe(true);
+        expect(chip.textContent).toContain('For your MINI Cooper');
+        expect(document.querySelector('.cs-fitment-chip-count')).toBeNull();
+    });
+
+    it('shows the "select your vehicle" prompt when no garage vehicle is resolved', async () => {
+        await mountWith(null, REGISTRY, reviewsWithFitment());
+
+        expect(document.querySelector('[data-ugc-fitment-prompt]')).not.toBeNull();
+        expect(document.querySelector('[data-ugc-fitment-toggle]')).toBeNull();
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(4);
+    });
+
+    it('scrolls to the vehicle selector when the prompt is clicked', async () => {
+        document.body.insertAdjacentHTML(
+            'beforeend',
+            '<select data-car-selection-field="make"></select>',
+        );
+        const make = document.querySelector('[data-car-selection-field="make"]');
+        make.scrollIntoView = jest.fn();
+        make.focus = jest.fn();
+        await mountWith(null, REGISTRY, reviewsWithFitment());
+
+        document.querySelector('[data-ugc-fitment-prompt]').click();
+
+        expect(make.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+        expect(make.focus).toHaveBeenCalled();
+    });
+
+    it('leaves the chip slot empty and hidden without a GlobalStateManager', async () => {
+        api.getOverview.mockResolvedValue(okResult(reviewsWithFitment()));
+        overview = new UgcOverview({ api });
+        await overview.init();
+
+        // The toolbar (and its slot) still render, but the vehicle filter is
+        // inert: the slot stays empty and its reserved space hidden.
+        const slot = document.querySelector('[data-ugc-fitment-chip]');
+        expect(slot).not.toBeNull();
+        expect(slot.innerHTML).toBe('');
+        expect(slot.style.visibility).toBe('hidden');
+        expect(document.querySelector('[data-ugc-fitment-toggle]')).toBeNull();
+        expect(document.querySelector('[data-ugc-fitment-prompt]')).toBeNull();
+    });
+
+    it('toggles the wall to matching reviews and clears back to all', async () => {
+        await mountWith(GARAGE, REGISTRY, reviewsWithFitment());
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(4);
+
+        document.querySelector('[data-ugc-fitment-toggle]').click();
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(2);
+        expect(document.querySelector('[data-ugc-fitment-toggle]').getAttribute('aria-pressed')).toBe('true');
+
+        document.querySelector('[data-ugc-fitment-clear]').click();
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(4);
+    });
+
+    it('explains the absent filter when the vehicle resolves but no loaded review matches', async () => {
+        const reviews = makeReviews(3).map(review => ({ ...review, fitment_id: 999 }));
+        await mountWith(GARAGE, REGISTRY, reviews);
+
+        expect(document.querySelector('[data-ugc-fitment-toggle]')).toBeNull();
+        expect(document.querySelector('.cs-fitment-empty').textContent)
+            .toContain('No reviews yet for your MINI Cooper');
+    });
+
+    it('re-resolves and drops the active filter when the garage vehicle changes', async () => {
+        const globalStateManager = await mountWith(GARAGE, REGISTRY, reviewsWithFitment());
+        document.querySelector('[data-ugc-fitment-toggle]').click();
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(2);
+
+        // Swap to a vehicle absent from the registry → unresolved → prompt
+        // returns and the filter is dropped.
+        globalStateManager.setVehicle({ make: 'AUDI', model: 'A3', generation: '8V' });
+        expect(document.querySelector('[data-ugc-fitment-prompt]')).not.toBeNull();
+        expect(document.querySelector('[data-ugc-fitment-toggle]')).toBeNull();
+        expect(document.querySelectorAll('.cs-ugc-overview-card')).toHaveLength(4);
+    });
+
+    it('steps the lightbox only through the filtered subset when the filter is active', async () => {
+        await mountWith(GARAGE, REGISTRY, reviewsWithFitment());
+        document.querySelector('[data-ugc-fitment-toggle]').click();
+
+        // Subset in display order: id 1 (index 0), id 3 (index 1).
+        document.querySelector('[data-ugc-review-open][data-ugc-index="0"]').click();
+        const lightbox = document.querySelector('[data-ugc-overview-lightbox]');
+        expect(lightbox.textContent).toContain('Body 1');
+
+        lightbox.querySelector('[data-ugc-review-next]').click();
+        expect(lightbox.textContent).toContain('Body 3'); // skips non-matching id 2
+        expect(lightbox.querySelector('[data-ugc-review-next]').disabled).toBe(true);
     });
 });

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -93,8 +93,9 @@ const mountScaffold = () => {
             <input type="checkbox" data-reviews-control="media">
             <div class="cs-fitment-chip-slot" data-reviews-fitment-chip></div>
         </div>
+        <div class="cs-reviews-pagination cs-reviews-pagination--top" data-reviews-pagination></div>
         <div id="product-reviews"></div>
-        <div class="cs-reviews-pagination" data-reviews-pagination></div>
+        <div class="cs-reviews-pagination cs-reviews-pagination--bottom" data-reviews-pagination></div>
     `;
 };
 
@@ -471,11 +472,43 @@ describe('UgcProduct (slice 6b — sort, filter, pagination)', () => {
             new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
             await flush();
 
-            // 25 / 10 => ceil 3 numbered pages.
-            const numbered = document.querySelectorAll('[data-page-key="1"], [data-page-key="2"], [data-page-key="3"]');
+            // 25 / 10 => ceil 3 numbered pages, scoped to one container.
+            const bottom = document.querySelector('.cs-reviews-pagination--bottom');
+            const numbered = bottom.querySelectorAll('[data-page-key="1"], [data-page-key="2"], [data-page-key="3"]');
             expect(numbered).toHaveLength(3);
-            expect(document.querySelector('[data-reviews-page="2"]')).not.toBeNull();
-            expect(document.querySelector('[data-reviews-page="4"]')).toBeNull();
+            expect(bottom.querySelector('[data-reviews-page="2"]')).not.toBeNull();
+            expect(bottom.querySelector('[data-reviews-page="4"]')).toBeNull();
+        });
+
+        it('paints the same controls into both the top and bottom containers', async () => {
+            const api = buildApi(okEnvelope({ total: 25, page: 1, per_page: 10, items: [{ id: 1, rating: 5, date: '2026-01-01' }] }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const navs = document.querySelectorAll('[data-reviews-pagination] .cs-reviews-pages');
+            expect(navs).toHaveLength(2);
+            document.querySelectorAll('[data-reviews-pagination]').forEach((container) => {
+                expect(container.querySelectorAll('[data-page-key]')).toHaveLength(5);
+                expect(container.style.visibility).toBe('visible');
+            });
+            // Distinct landmark names (axe landmark-unique).
+            const labels = Array.from(navs).map(n => n.getAttribute('aria-label'));
+            expect(new Set(labels).size).toBe(2);
+        });
+
+        it('clicking the top controls pages the list just like the bottom', async () => {
+            const api = buildSequencedApi([
+                okEnvelope({ total: 25, page: 1, per_page: 10 }),
+                okEnvelope({ total: 25, page: 2, per_page: 10 }),
+            ]);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('.cs-reviews-pagination--top [data-reviews-page="2"]').click();
+            await flush();
+
+            expect(api.getReviews).toHaveBeenCalledTimes(2);
+            expect(paramsOfCall(api, 2).page).toBe(2);
         });
 
         it('hides pagination when a single page covers all results', async () => {
@@ -512,6 +545,35 @@ describe('UgcProduct (slice 6b — sort, filter, pagination)', () => {
             await flush();
 
             expect(api.getReviews).toHaveBeenCalledTimes(1);
+        });
+
+        it('smoothly scrolls the list header into view on a page change', async () => {
+            const api = buildSequencedApi([
+                okEnvelope({ total: 25, page: 1, per_page: 10 }),
+                okEnvelope({ total: 25, page: 2, per_page: 10 }),
+            ]);
+            const toolbar = document.querySelector('[data-reviews-toolbar]');
+            toolbar.scrollIntoView = jest.fn();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-reviews-page="2"]').click();
+            await flush();
+
+            expect(toolbar.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+        });
+
+        it('does not scroll when the clicked page is already current', async () => {
+            const api = buildApi(okEnvelope({ total: 25, page: 1, per_page: 10 }));
+            const toolbar = document.querySelector('[data-reviews-toolbar]');
+            toolbar.scrollIntoView = jest.fn();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-reviews-page="1"]').click();
+            await flush();
+
+            expect(toolbar.scrollIntoView).not.toHaveBeenCalled();
         });
     });
 
@@ -613,8 +675,9 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
                 </select>
                 <div class="cs-fitment-chip-slot" data-questions-fitment-chip></div>
             </div>
+            <div class="cs-questions-pagination cs-questions-pagination--top" data-questions-pagination></div>
             <div id="product-questions"></div>
-            <div class="cs-questions-pagination" data-questions-pagination></div>
+            <div class="cs-questions-pagination cs-questions-pagination--bottom" data-questions-pagination></div>
         `;
     };
 
@@ -793,10 +856,47 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
             new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
             await flush();
 
-            const numbered = document.querySelectorAll('[data-page-key="1"], [data-page-key="2"], [data-page-key="3"]');
+            // 25 / 10 => ceil 3 numbered pages, scoped to one container.
+            const bottom = document.querySelector('.cs-questions-pagination--bottom');
+            const numbered = bottom.querySelectorAll('[data-page-key="1"], [data-page-key="2"], [data-page-key="3"]');
             expect(numbered).toHaveLength(3);
-            expect(document.querySelector('[data-questions-page="2"]')).not.toBeNull();
-            expect(document.querySelector('[data-questions-page="4"]')).toBeNull();
+            expect(bottom.querySelector('[data-questions-page="2"]')).not.toBeNull();
+            expect(bottom.querySelector('[data-questions-page="4"]')).toBeNull();
+        });
+
+        it('paints the same controls into both the top and bottom containers', async () => {
+            const api = buildQaApi(okQuestions({
+                total: 25,
+                page: 1,
+                per_page: 10,
+                items: [{ id: 1, body: 'Q?', date: '2026-01-01' }],
+            }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const navs = document.querySelectorAll('[data-questions-pagination] .cs-questions-pages');
+            expect(navs).toHaveLength(2);
+            document.querySelectorAll('[data-questions-pagination]').forEach((container) => {
+                expect(container.querySelectorAll('[data-page-key]')).toHaveLength(5);
+                expect(container.style.visibility).toBe('visible');
+            });
+            const labels = Array.from(navs).map(n => n.getAttribute('aria-label'));
+            expect(new Set(labels).size).toBe(2);
+        });
+
+        it('clicking the top controls pages the list just like the bottom', async () => {
+            const api = buildSequencedQaApi([
+                okQuestions({ total: 25, page: 1, per_page: 10 }),
+                okQuestions({ total: 25, page: 2, per_page: 10 }),
+            ]);
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('.cs-questions-pagination--top [data-questions-page="2"]').click();
+            await flush();
+
+            expect(api.getQuestions).toHaveBeenCalledTimes(2);
+            expect(qParamsOfCall(api, 2).page).toBe(2);
         });
 
         it('hides pagination when a single page covers all results', async () => {
@@ -833,6 +933,22 @@ describe('UgcProduct (slice 6c — Q&A tab)', () => {
             await flush();
 
             expect(api.getQuestions).toHaveBeenCalledTimes(1);
+        });
+
+        it('smoothly scrolls the list header into view on a page change', async () => {
+            const api = buildSequencedQaApi([
+                okQuestions({ total: 25, page: 1, per_page: 10 }),
+                okQuestions({ total: 25, page: 2, per_page: 10 }),
+            ]);
+            const toolbar = document.querySelector('[data-questions-toolbar]');
+            toolbar.scrollIntoView = jest.fn();
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            document.querySelector('[data-questions-page="2"]').click();
+            await flush();
+
+            expect(toolbar.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
         });
     });
 

--- a/assets/js/theme/_addons/global/ugcCard.js
+++ b/assets/js/theme/_addons/global/ugcCard.js
@@ -1,0 +1,113 @@
+/**
+ * @file ugcCard
+ * @description Shared, pure card-rendering primitives for the UGC surfaces — the
+ * product reviews/Q&A lists (ugcProduct.js) and the home overview wall
+ * (ugcOverview.js). Each returns an HTML-string fragment and emits the same
+ * class names the product stylesheet already styles (cs-review-score / -flag /
+ * -verified / -edited / -date), so both surfaces render these bits identically
+ * from one source of truth (cs-ugc SRS §3.2.1, §3.4.1, §3.4.2).
+ *
+ * None of these escape free-text: star/score/verified/edited render fixed markup
+ * or numbers, the country code is validated to `[a-z]{2}` before interpolation,
+ * and the date is machine-formatted. Callers escape any free-text upstream.
+ */
+
+export const MAX_STARS = 5;
+
+/**
+ * The inner sprite-star spans for a whole-star count, split at `count` full
+ * stars. Returns only the icons — callers wrap them in their own labelled
+ * container. The sprite (#icon-star) is injected globally in layout/base.html.
+ * @param {number} count - Whole filled stars, 0-5.
+ * @returns {string}
+ */
+export function starIcons(count) {
+    let stars = '';
+
+    for (let i = 1; i <= MAX_STARS; i += 1) {
+        const modifier = i <= count ? 'ratingFull' : 'ratingEmpty';
+        stars += `<span class="icon icon--${modifier}"><svg><use href="#icon-star" /></svg></span>`;
+    }
+
+    return stars;
+}
+
+/**
+ * The numeric-score pill that sits beside the stars.
+ * @param {number} rating - The whole-star rating.
+ * @returns {string}
+ */
+export function scoreBadge(rating) {
+    return `<span class="cs-review-score">${rating}</span>`;
+}
+
+/**
+ * The "Verified Purchaser" chip (SRS §3.2.1 `verified_purchaser`). Empty string
+ * when the review is not a verified purchase.
+ * @param {boolean} isVerified
+ * @returns {string}
+ */
+export function verifiedBadge(isVerified) {
+    return isVerified
+        ? '<span class="cs-review-verified">Verified Purchaser</span>'
+        : '';
+}
+
+/**
+ * The staff-edit disclosure marker (SRS §3.2.1 `edited` / §3.1.1, cs-ugc #145).
+ * Strict `=== true` so a missing flag on an older payload renders nothing — the
+ * card must never break on an absent field, and it never reveals who edited.
+ * @param {boolean} isEdited
+ * @returns {string}
+ */
+export function editedBadge(isEdited) {
+    return isEdited === true
+        ? '<span class="cs-review-edited">Edited by CravenSpeed</span>'
+        : '';
+}
+
+/**
+ * A small country flag from an ISO-3166 alpha-2 `country` (SRS §3.2.1, derived
+ * server-side from the submission IP; null on imported/un-geolocated rows).
+ * Served as SVG from flagcdn.com and lazy-loaded. Returns '' for any non
+ * two-letter code, so older reviews simply show no flag. The code is validated
+ * to `[a-z]{2}`, so it is safe to interpolate without further escaping.
+ * @param {string} code
+ * @returns {string}
+ */
+export function countryFlag(code) {
+    if (typeof code !== 'string') {
+        return '';
+    }
+
+    const cc = code.trim().toLowerCase();
+    if (!/^[a-z]{2}$/.test(cc)) {
+        return '';
+    }
+
+    const label = cc.toUpperCase();
+    return `<img class="cs-review-flag" src="https://flagcdn.com/${cc}.svg" alt="${label}" title="${label}" loading="lazy">`;
+}
+
+/**
+ * Format a review's ISO `date` as a localized MM/DD/YYYY string. Returns '' for
+ * an empty or unparseable value so the card simply shows no date.
+ * @param {string} value
+ * @returns {string}
+ */
+export function formatReviewDate(value) {
+    if (!value) {
+        return '';
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return '';
+    }
+
+    return parsed.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    });
+}

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -2,26 +2,69 @@
  * @file ugcOverview
  * @description Home-page overview photo wall (cs-ugc SRS §3.4.2, §3.2.3).
  * Fetches the latest approved reviews across all archetypes once via
- * GET /api/overview, then paginates and filters that single dataset entirely
- * client-side at 10 per page. Replaces the removed Stamped home wall.
+ * GET /api/overview, then sorts, filters, and paginates that single dataset
+ * entirely client-side (the product reviews list, by contrast, refetches the API
+ * on every change). It mirrors the product reviews toolbar — sort, rating filter,
+ * verified-purchasers and with-media toggles, plus the garage vehicle chip — all
+ * composed over the in-memory feed. The "Write a review" button is omitted (no
+ * single archetype to submit to from home). 12 cards per page, with controls
+ * above and below the wall. Replaces the removed Stamped home wall.
+ *
+ * The toolbar is painted once; sort/filter/page/chip changes repaint only the
+ * vehicle-chip slot and/or the wall region ([data-ugc-wall]) — never the toolbar
+ * — so the controls keep focus and value, and the delegated click/change
+ * listeners on the container survive every wall rebuild.
+ *
+ * SRS §3.4.2 formally defers home-wall filtering to v1.1; this client-side
+ * divergence is accepted by the product owner (no cs-ugc change needed) — every
+ * overview review already carries the fields used (rating, verified_purchaser,
+ * media, date, fitment_id).
  *
  * Initialised from the home entry point (homeController.js).
  */
 
 import ugcApi from './ugcApi';
 import { escapeHtml } from './search/utils';
+import { resolveGarageFitment } from './vehicleFitment';
+import {
+    starIcons,
+    scoreBadge,
+    verifiedBadge,
+    editedBadge,
+    countryFlag,
+    formatReviewDate,
+    MAX_STARS,
+} from './ugcCard';
 
-const PER_PAGE = 10;
-const MAX_STARS = 5;
+// 12 divides evenly by the 1 / 2 / 3 responsive column counts, so every full
+// page forms complete rows — a neat rectangle with no trailing orphan card.
+const PER_PAGE = 12;
 
-// Client-side display filters (SRS §3.4.2). `rating` carries a 1-5 value when
-// the user picks a star count; the others ignore it.
-export const FILTERS = {
-    ALL: 'all',
-    BASIC: 'basic',
-    WITH_PHOTOS: 'photos',
-    RATING: 'rating',
-};
+// Accepted sort values, mirroring the product reviews toolbar (ugcProduct.js).
+// Anything else falls back to date_desc — the honest newest-first default.
+const SORT_VALUES = ['date_desc', 'date_asc', 'rating_desc', 'rating_asc'];
+
+/**
+ * A review's timestamp for date sorting. Unparseable / absent dates collapse to
+ * 0 so the comparator stays a real number (never NaN) and the sort stays stable.
+ * @param {Object} review
+ * @returns {number}
+ */
+function reviewTime(review) {
+    const t = new Date(review.date).getTime();
+    return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * A review's whole-star rating as an integer (0 when absent/unparseable),
+ * matching how the cards coerce `rating`. Used by the rating filter and the
+ * rating sort comparators.
+ * @param {Object} review
+ * @returns {number}
+ */
+function reviewRating(review) {
+    return parseInt(review.rating, 10) || 0;
+}
 
 /**
  * A review has media when its media array holds at least one entry. The
@@ -35,29 +78,6 @@ function hasMedia(review) {
 }
 
 /**
- * Apply the active display filter to the full dataset. Pure — no fetches.
- * @param {Object[]} reviews
- * @param {string} filter - One of FILTERS.
- * @param {number|null} ratingValue - Star count when filter is RATING.
- * @returns {Object[]}
- */
-export function applyFilter(reviews, filter, ratingValue = null) {
-    if (filter === FILTERS.WITH_PHOTOS) {
-        return reviews.filter(hasMedia);
-    }
-
-    if (filter === FILTERS.BASIC) {
-        return reviews.filter(review => !hasMedia(review));
-    }
-
-    if (filter === FILTERS.RATING && ratingValue !== null) {
-        return reviews.filter(review => review.rating === ratingValue);
-    }
-
-    return reviews;
-}
-
-/**
  * Build the 5-star strip from the shared icon sprite — the same
  * icon--ratingFull / icon--ratingEmpty + #icon-star markup the product page
  * renders (ugcProduct.js), so stars look identical on both surfaces. The
@@ -67,14 +87,7 @@ export function applyFilter(reviews, filter, ratingValue = null) {
  * @returns {string}
  */
 export function buildStarIcons(rating) {
-    let stars = '';
-
-    for (let i = 1; i <= MAX_STARS; i += 1) {
-        const modifier = i <= rating ? 'ratingFull' : 'ratingEmpty';
-        stars += `<span class="icon icon--${modifier}"><svg><use href="#icon-star" /></svg></span>`;
-    }
-
-    return stars;
+    return starIcons(rating);
 }
 
 /**
@@ -122,24 +135,49 @@ export default class UgcOverview {
      * @param {Object} [options]
      * @param {string} [options.selector] - Mount-point selector.
      * @param {Object} [options.api] - Injectable UgcApi (defaults to singleton).
+     * @param {Object} [options.globalStateManager] - The site-wide StateManager
+     *   singleton, source of the garage vehicle (`vehicle.selected`) and search
+     *   `vehicle_registry` (`search.data`). Absent → the vehicle filter is inert
+     *   (no chip), mirroring ugcProduct on a page with no garage.
      */
-    constructor({ selector = '[data-ugc-overview]', api = ugcApi } = {}) {
+    constructor({ selector = '[data-ugc-overview]', api = ugcApi, globalStateManager = null } = {}) {
         this.container = document.querySelector(selector);
         this.api = api;
+        this.globalStateManager = globalStateManager;
 
         this.reviews = [];
-        this.filter = FILTERS.ALL;
-        this.ratingValue = null;
         this.page = 1;
+
+        // Client-side toolbar state (mirrors the product reviews toolbar, but
+        // composed over the pre-fetched feed rather than refetched). `rating` is
+        // the star filter (int) or null for all ratings; `verified`/`media` are
+        // the two checkbox filters; `sort` is one of SORT_VALUES.
+        this.sort = 'date_desc';
+        this.rating = null;
+        this.verified = false;
+        this.media = false;
+
+        // Garage vehicle filter (mirrors the product chip, client-side over the
+        // pre-fetched feed). fitmentId/Label come from resolving the global
+        // garage selection against the search registry; fitmentOnly is the
+        // opt-in hard filter — off by default (never auto-applied).
+        this.fitmentId = null;
+        this.fitmentLabel = null;
+        this.fitmentOnly = false;
+        this.unsubscribeGlobal = null;
 
         // Review lightbox state. The node is created lazily on first open and
         // lives on <body>, outside the wall's innerHTML churn. lightboxIndex is
-        // an absolute index into the current filtered set (Decision A).
+        // an absolute index into the displayed (filtered) set (Decision A);
+        // lightboxMediaIndex is which of the open review's media items is the
+        // displayed hero (reset to 0 whenever the open review changes).
         this.lightbox = null;
         this.lightboxIndex = 0;
+        this.lightboxMediaIndex = 0;
         this.lastFocused = null;
 
         this.handleControlClick = this.handleControlClick.bind(this);
+        this.handleToolbarChange = this.handleToolbarChange.bind(this);
         this.handleLightboxClick = this.handleLightboxClick.bind(this);
         this.handleLightboxKeydown = this.handleLightboxKeydown.bind(this);
     }
@@ -162,16 +200,76 @@ export default class UgcOverview {
         }
 
         this.bindEvents();
+        this.subscribeGlobalFitment();
         this.render();
     }
 
     bindEvents() {
         this.container.addEventListener('click', this.handleControlClick);
+        // Delegated so the toolbar's selects/checkboxes are reachable however the
+        // wall region below them is rebuilt (the toolbar itself is painted once).
+        this.container.addEventListener('change', this.handleToolbarChange);
     }
 
     /**
-     * Delegate clicks for filter buttons and pagination. Filter changes reset
-     * to page 1; page changes clamp within range. No network calls.
+     * Subscribe to the global garage state and seed the initial fitment. No-op
+     * without a GlobalStateManager (the vehicle filter is then inert). Resolves
+     * once synchronously so the first render can show the chip, then re-resolves
+     * on every change (a late-arriving registry or a garage swap).
+     */
+    subscribeGlobalFitment() {
+        if (!this.globalStateManager) {
+            return;
+        }
+
+        this.resolveFitmentFromGlobal(this.globalStateManager.getState());
+        this.unsubscribeGlobal = this.globalStateManager.subscribe(
+            state => this.onGlobalFitmentChange(state),
+        );
+    }
+
+    /**
+     * Resolve and store the garage fitment from a global state snapshot, without
+     * re-rendering. Reads `vehicle.selected` + `search.data.vehicle_registry`
+     * and resolves via the shared vehicleFitment resolver — the same inputs the
+     * product page uses, both available on the home page.
+     * @param {Object} [globalState]
+     */
+    resolveFitmentFromGlobal(globalState) {
+        const vehicle = globalState && globalState.vehicle ? globalState.vehicle.selected : null;
+        const registry = globalState && globalState.search && globalState.search.data
+            ? globalState.search.data.vehicle_registry
+            : null;
+
+        const resolved = resolveGarageFitment(registry, vehicle);
+        this.fitmentId = resolved ? resolved.fitment_id : null;
+        this.fitmentLabel = resolved ? resolved.label : null;
+    }
+
+    /**
+     * Global state changed. Re-resolve the garage fitment; if it changed (garage
+     * swap, or the registry arriving and resolving a previously-unresolvable
+     * selection), drop any active filter — a new vehicle context defaults to the
+     * honest unfiltered view — reset to page 1, and re-render.
+     * @param {Object} [globalState]
+     */
+    onGlobalFitmentChange(globalState) {
+        const previousId = this.fitmentId;
+        this.resolveFitmentFromGlobal(globalState);
+
+        if (this.fitmentId === previousId) {
+            return;
+        }
+
+        this.fitmentOnly = false;
+        this.page = 1;
+        this.renderFitmentChip();
+        this.renderWall();
+    }
+
+    /**
+     * Delegate clicks for the lightbox openers and pagination. Page changes
+     * clamp within range. No network calls.
      * @param {MouseEvent} event
      */
     handleControlClick(event) {
@@ -181,62 +279,286 @@ export default class UgcOverview {
             return;
         }
 
-        const filterButton = event.target.closest('[data-ugc-filter]');
-        if (filterButton) {
-            const { ugcFilter, ugcRating } = filterButton.dataset;
-            this.filter = ugcFilter;
-            this.ratingValue = ugcRating ? parseInt(ugcRating, 10) : null;
+        // "Select your vehicle to filter" prompt (shown when no vehicle is
+        // resolved) — scroll to the home vehicle selector so the visitor can
+        // set one, which then resolves the fitment and turns the chip on.
+        if (event.target.closest('[data-ugc-fitment-prompt]')) {
+            this.scrollToVehicleSelector();
+            return;
+        }
+
+        // "For your <vehicle>" chip — toggle the opt-in vehicle hard filter on,
+        // or clear it off. Either way reset to page 1 and repaint.
+        const fitmentControl = event.target.closest('[data-ugc-fitment-toggle], [data-ugc-fitment-clear]');
+        if (fitmentControl) {
+            const isClear = fitmentControl.dataset.ugcFitmentClear !== undefined;
+            const nextOnly = !isClear;
+            if (nextOnly === this.fitmentOnly) {
+                return;
+            }
+
+            this.fitmentOnly = nextOnly;
             this.page = 1;
-            this.render();
+            this.renderFitmentChip();
+            this.renderWall();
             return;
         }
 
         const pageButton = event.target.closest('[data-ugc-page]');
         if (pageButton) {
-            const filtered = applyFilter(this.reviews, this.filter, this.ratingValue);
             const target = parseInt(pageButton.dataset.ugcPage, 10);
-            const max = pageCount(filtered.length);
-            this.page = Math.min(Math.max(1, target), max);
-            this.render();
+            const max = pageCount(this.displayedReviews().length);
+            const next = Math.min(Math.max(1, target), max);
+            if (next === this.page) {
+                return;
+            }
+
+            this.page = next;
+            this.renderWall();
+            // A page change from either control set would otherwise strand the
+            // reader mid-wall — bring the wall top into view.
+            this.scrollToTop();
         }
     }
 
+    /**
+     * Toolbar sort/filter change (mirrors the product page's onToolbarChange, but
+     * over the in-memory feed). Reads which control fired from its
+     * `data-ugc-control`, updates the matching state, resets to page 1, and
+     * repaints only the wall — the toolbar itself is left in place so the changed
+     * control keeps its focus and value.
+     * @param {Event} event
+     */
+    handleToolbarChange(event) {
+        const target = event.target;
+        const control = target && target.dataset ? target.dataset.ugcControl : null;
+        if (!control) {
+            return;
+        }
+
+        if (control === 'sort') {
+            this.sort = SORT_VALUES.indexOf(target.value) === -1 ? 'date_desc' : target.value;
+        } else if (control === 'rating') {
+            const parsed = parseInt(target.value, 10);
+            this.rating = Number.isNaN(parsed) ? null : parsed;
+        } else if (control === 'verified') {
+            this.verified = target.checked;
+        } else if (control === 'media') {
+            this.media = target.checked;
+        } else {
+            return;
+        }
+
+        this.page = 1;
+        this.renderWall();
+    }
+
+    /**
+     * The reviews currently shown: the full feed run through every active toolbar
+     * filter (vehicle → rating → verified → media) and then sorted. This is the
+     * single set that pagination, the wall, and the lightbox all index into, so a
+     * card opener's absolute index always lines up with the lightbox. The sort
+     * always copies the list, so `this.reviews` is never mutated.
+     * @returns {Object[]}
+     */
+    displayedReviews() {
+        let list = this.reviews;
+
+        if (this.fitmentOnly && this.fitmentId !== null) {
+            list = list.filter(review => review.fitment_id === this.fitmentId);
+        }
+
+        if (this.rating !== null) {
+            list = list.filter(review => reviewRating(review) === this.rating);
+        }
+
+        if (this.verified) {
+            list = list.filter(review => review.verified_purchaser);
+        }
+
+        if (this.media) {
+            list = list.filter(hasMedia);
+        }
+
+        return this.sortReviews(list);
+    }
+
+    /**
+     * Sort a COPY of the list by the active sort. Date sorts compare timestamps;
+     * the rating sorts break ties newest-first so equal-rated reviews stay in a
+     * stable, sensible order. Never mutates the input (which may be the original
+     * `this.reviews` reference when no filter ran).
+     * @param {Object[]} list
+     * @returns {Object[]}
+     */
+    sortReviews(list) {
+        const sorted = [...list];
+
+        switch (this.sort) {
+        case 'date_asc':
+            sorted.sort((a, b) => reviewTime(a) - reviewTime(b));
+            break;
+        case 'rating_desc':
+            sorted.sort((a, b) => (reviewRating(b) - reviewRating(a))
+                || (reviewTime(b) - reviewTime(a)));
+            break;
+        case 'rating_asc':
+            sorted.sort((a, b) => (reviewRating(a) - reviewRating(b))
+                || (reviewTime(b) - reviewTime(a)));
+            break;
+        case 'date_desc':
+        default:
+            sorted.sort((a, b) => reviewTime(b) - reviewTime(a));
+            break;
+        }
+
+        return sorted;
+    }
+
+    /**
+     * Paint the full surface: the toolbar (once) plus the wall region it scopes.
+     * A truly-empty feed shows just the empty message — no toolbar to operate on
+     * an empty set. Sort/filter/page/chip changes thereafter repaint only the
+     * chip slot and/or the wall region, never the toolbar, so the controls keep
+     * their focus and value across interactions.
+     */
     render() {
-        const filtered = applyFilter(this.reviews, this.filter, this.ratingValue);
-        const items = paginate(filtered, this.page);
-        const base = (this.page - 1) * PER_PAGE;
+        if (this.reviews.length === 0) {
+            this.container.innerHTML = '<p class="cs-ugc-overview-empty">No reviews to show yet.</p>';
+            return;
+        }
 
         this.container.innerHTML = `
-            ${this.buildFilters()}
+            ${this.buildToolbar()}
+            <div data-ugc-wall></div>
+        `;
+
+        this.renderFitmentChip();
+        this.renderWall();
+    }
+
+    /**
+     * Repaint only the wall region (top pagination + cards + bottom pagination)
+     * from the current displayed set. No-op if the region is absent (empty feed).
+     */
+    renderWall() {
+        const wall = this.container.querySelector('[data-ugc-wall]');
+        if (!wall) {
+            return;
+        }
+
+        const all = this.displayedReviews();
+        const items = paginate(all, this.page);
+        const base = (this.page - 1) * PER_PAGE;
+
+        wall.innerHTML = `
+            ${this.buildPagination(all.length, 'top')}
             ${this.buildWall(items, base)}
-            ${this.buildPagination(filtered.length)}
+            ${this.buildPagination(all.length, 'bottom')}
         `;
     }
 
-    buildFilters() {
-        const options = [
-            { filter: FILTERS.ALL, label: 'All', rating: null },
-            { filter: FILTERS.WITH_PHOTOS, label: 'With Photos', rating: null },
-            { filter: FILTERS.BASIC, label: 'No Photos', rating: null },
-            { filter: FILTERS.RATING, label: '5 Stars', rating: 5 },
-            { filter: FILTERS.RATING, label: '4 Stars', rating: 4 },
-        ];
+    /**
+     * The sort/filter toolbar, reusing the product reviews control markup/classes
+     * (all bare classes in _cs-product.scss). Rendered once; the controls reflect
+     * the current state so a full repaint never drops a selection. The "Write a
+     * review" button is intentionally omitted (no single archetype to submit to
+     * from home). The vehicle chip lives in the trailing slot, filled by
+     * renderFitmentChip.
+     * @returns {string}
+     */
+    buildToolbar() {
+        const sortOptions = [
+            ['date_desc', 'Newest'],
+            ['date_asc', 'Oldest'],
+            ['rating_desc', 'Highest rated'],
+            ['rating_asc', 'Lowest rated'],
+        ].map(([value, label]) => `<option value="${value}"${value === this.sort ? ' selected' : ''}>${label}</option>`).join('');
 
-        const buttons = options.map((option) => {
-            const isActive = this.filter === option.filter
-                && this.ratingValue === option.rating;
-            const ratingAttr = option.rating === null ? '' : ` data-ugc-rating="${option.rating}"`;
-            return `
-                <button
-                    type="button"
-                    class="cs-ugc-overview-filter${isActive ? ' is-active' : ''}"
-                    data-ugc-filter="${option.filter}"${ratingAttr}
-                    aria-pressed="${isActive}"
-                >${option.label}</button>
-            `;
+        const ratingOptions = ['', '5', '4', '3', '2', '1'].map((value) => {
+            const label = value === '' ? 'All ratings' : value;
+            const isSelected = value === '' ? this.rating === null : parseInt(value, 10) === this.rating;
+            return `<option value="${value}"${isSelected ? ' selected' : ''}>${label}</option>`;
         }).join('');
 
-        return `<div class="cs-ugc-overview-filters" role="group" aria-label="Filter reviews">${buttons}</div>`;
+        const verifiedChecked = this.verified ? ' checked' : '';
+        const mediaChecked = this.media ? ' checked' : '';
+
+        return `
+            <div class="cs-reviews-toolbar cs-ugc-overview-toolbar">
+                <label class="cs-reviews-control cs-reviews-control--sort">
+                    <span class="cs-reviews-control-label">Sort by</span>
+                    <select class="cs-reviews-select cs-form-select" data-ugc-control="sort">${sortOptions}</select>
+                </label>
+                <label class="cs-reviews-control cs-reviews-control--rating">
+                    <span class="cs-reviews-control-label">Rating</span>
+                    <select class="cs-reviews-select cs-form-select" data-ugc-control="rating">${ratingOptions}</select>
+                </label>
+                <label class="cs-reviews-control cs-reviews-control--toggle">
+                    <input type="checkbox" data-ugc-control="verified"${verifiedChecked}>
+                    <span class="cs-reviews-control-label">Verified purchasers</span>
+                </label>
+                <label class="cs-reviews-control cs-reviews-control--toggle">
+                    <input type="checkbox" data-ugc-control="media"${mediaChecked}>
+                    <span class="cs-reviews-control-label">With photos &amp; videos</span>
+                </label>
+                <div class="cs-fitment-chip-slot" data-ugc-fitment-chip></div>
+            </div>
+        `;
+    }
+
+    /**
+     * Fill the toolbar's vehicle-chip slot from the current fitment state and flip
+     * its reserved visibility (hidden by default in SCSS) to visible only when
+     * populated — the CLS pattern the product page uses. No-op if the slot is
+     * absent (empty feed); leaves it hidden when the filter is inert.
+     */
+    renderFitmentChip() {
+        const slot = this.container.querySelector('[data-ugc-fitment-chip]');
+        if (!slot) {
+            return;
+        }
+
+        const html = this.buildFitmentChip();
+        slot.innerHTML = html;
+        slot.style.visibility = html ? 'visible' : 'hidden';
+    }
+
+    /**
+     * The inner markup for the toolbar's vehicle-chip slot (mirrors the product
+     * chip; SRS §3.4.1 phrasing, count dropped). Returned without a wrapper — the
+     * `.cs-fitment-chip-slot` is the container. With no garage vehicle resolved it
+     * is the "Select your vehicle" prompt (clicking scrolls to the home vehicle
+     * selector). When a vehicle is resolved but no loaded review matches it, a
+     * passive note explains the absent filter rather than leaving it silently
+     * missing. Empty only when the vehicle filter is inert (no StateManager).
+     * @returns {string}
+     */
+    buildFitmentChip() {
+        if (!this.globalStateManager) {
+            return '';
+        }
+
+        // No garage vehicle resolved yet — prompt the visitor to pick one, which
+        // resolves the fitment and turns the chip on.
+        if (this.fitmentId === null) {
+            return '<button type="button" class="cs-fitment-prompt" data-ugc-fitment-prompt>Select your vehicle to filter</button>';
+        }
+
+        const label = escapeHtml(this.fitmentLabel || '');
+        const matchCount = this.reviews.filter(review => review.fitment_id === this.fitmentId).length;
+
+        if (matchCount <= 0) {
+            return `<span class="cs-fitment-empty">No reviews yet for your ${label}</span>`;
+        }
+
+        const activeClass = this.fitmentOnly ? ' is-active' : '';
+        const pressed = this.fitmentOnly ? 'true' : 'false';
+        const clear = this.fitmentOnly
+            ? '<button type="button" class="cs-fitment-chip-clear" data-ugc-fitment-clear aria-label="Clear vehicle filter">&times;</button>'
+            : '';
+
+        return `<button type="button" class="cs-fitment-chip${activeClass}" data-ugc-fitment-toggle aria-pressed="${pressed}"><span class="cs-fitment-chip-label">For your ${label}</span></button>${clear}`;
     }
 
     buildWall(items, base) {
@@ -251,84 +573,156 @@ export default class UgcOverview {
     buildCard(review, index) {
         const author = escapeHtml(review.author);
         const title = escapeHtml(review.title);
-        const body = escapeHtml(review.body);
-        const archetypeName = escapeHtml(review.archetype_name);
-        const archetypeUrl = escapeHtml(review.archetype_url);
-        const rating = parseInt(review.rating, 10) || 0;
-        const stars = buildStarIcons(rating);
+        const openLabel = escapeHtml(`Open review: ${review.title || 'customer review'}`);
+        const hasPhoto = hasMedia(review);
 
+        // The whole card opens the lightbox via a stretched, visually-empty
+        // button (inset:0 in SCSS) so no-photo cards are openable too — not just
+        // the photo. The product-link below sits above it (z-index) and still
+        // navigates on its own click.
         return `
-            <article class="cs-ugc-overview-card">
-                ${this.buildThumb(review, index)}
+            <article class="cs-ugc-overview-card${hasPhoto ? ' cs-ugc-overview-card--media' : ''}">
+                <button type="button" class="cs-ugc-overview-open" data-ugc-review-open data-ugc-index="${index}" aria-label="${openLabel}"></button>
+                ${this.buildThumb(review)}
                 <div class="cs-ugc-overview-card-body">
-                    <div class="cs-ugc-overview-stars" role="img" aria-label="${rating} out of ${MAX_STARS} stars">${stars}</div>
-                    ${title ? `<h3 class="cs-ugc-overview-title">${title}</h3>` : ''}
-                    ${buildVehicleBadge(review.vehicle_label)}
-                    <p class="cs-ugc-overview-text">${body}</p>
-                    <p class="cs-ugc-overview-meta">
-                        <span class="cs-ugc-overview-author">${author}</span>
-                        ${archetypeUrl ? `<a class="cs-ugc-overview-product" href="${archetypeUrl}">${archetypeName}</a>` : ''}
-                    </p>
+                    ${this.buildCardContent(review, title, author)}
                 </div>
             </article>
         `;
     }
 
     /**
-     * Render the first media item as the card thumbnail. Photos use the
-     * thumbnail URL; videos fall back to the poster (SRS §3.2.7 / ReviewMedia).
-     * The thumb slot reserves space even with no media so the wall stays
-     * layout-stable. When the review carries a photo the thumb is a button that
-     * opens the review in the lightbox; the `index` is its absolute position in
-     * the current filtered set, which the lightbox steps through.
+     * The shared review content block (header, vehicle badge, clamped body,
+     * meta footer, product link) used by both the wall card and the lightbox.
+     * Pre-escaped title/author are passed in; the rest is escaped here.
      * @param {Object} review
-     * @param {number} index
+     * @param {string} title - Pre-escaped title.
+     * @param {string} author - Pre-escaped author.
      * @returns {string}
      */
-    buildThumb(review, index) {
+    buildCardContent(review, title, author) {
+        const body = escapeHtml(review.body);
+        const archetypeName = escapeHtml(review.archetype_name);
+        const archetypeUrl = escapeHtml(review.archetype_url);
+        const rating = parseInt(review.rating, 10) || 0;
+        const date = formatReviewDate(review.date);
+
+        return `
+            <div class="cs-ugc-overview-header">
+                <div class="cs-ugc-overview-stars" role="img" aria-label="${rating} out of ${MAX_STARS} stars">${starIcons(rating)}</div>
+                ${scoreBadge(rating)}
+            </div>
+            ${title ? `<h3 class="cs-ugc-overview-title">${title}</h3>` : ''}
+            ${buildVehicleBadge(review.vehicle_label)}
+            <p class="cs-ugc-overview-text">${body}</p>
+            <p class="cs-ugc-overview-meta">
+                <span class="cs-ugc-overview-author">${author}</span>
+                ${countryFlag(review.country)}
+                ${date ? `<span class="cs-review-date">${date}</span>` : ''}
+                ${verifiedBadge(review.verified_purchaser)}
+                ${editedBadge(review.edited)}
+            </p>
+            ${archetypeUrl ? `<a class="cs-ugc-overview-product" href="${archetypeUrl}">${archetypeName}</a>` : ''}
+        `;
+    }
+
+    /**
+     * Render the first media item as the card thumbnail. Photos use the
+     * thumbnail URL; videos fall back to the poster (SRS §3.2.7 / ReviewMedia).
+     * Reviews with no media render no thumb at all — the card is text-forward
+     * rather than reserving an empty placeholder slot.
+     * @param {Object} review
+     * @returns {string}
+     */
+    buildThumb(review) {
         if (!hasMedia(review)) {
-            return '<div class="cs-ugc-overview-thumb is-empty" aria-hidden="true"></div>';
+            return '';
         }
 
         const media = review.media[0];
         const src = media.thumb_url || media.poster_url || media.medium_url || media.url;
 
         if (!src) {
-            return '<div class="cs-ugc-overview-thumb is-empty" aria-hidden="true"></div>';
+            return '';
         }
 
         const alt = escapeHtml(review.title || review.archetype_name || 'Customer photo');
-        return `
-            <button type="button" class="cs-ugc-overview-thumb" data-ugc-review-open data-ugc-index="${index}" aria-label="Open this review">
-                <img src="${escapeHtml(src)}" alt="${alt}" loading="lazy" width="200" height="200">
-            </button>
-        `;
+        return `<div class="cs-ugc-overview-media"><img src="${escapeHtml(src)}" alt="${alt}" loading="lazy" width="320" height="240"></div>`;
     }
 
-    buildPagination(total) {
+    buildPagination(total, position) {
         const pages = pageCount(total);
         if (pages <= 1) return '';
 
-        const prevDisabled = this.page <= 1 ? ' disabled' : '';
-        const nextDisabled = this.page >= pages ? ' disabled' : '';
+        const buttons = [];
+        buttons.push(this.pageButton('prev', this.page - 1, this.page <= 1, 'Previous'));
 
-        return `
-            <div class="cs-ugc-overview-pagination">
-                <button type="button" class="cs-ugc-overview-page" data-ugc-page="${this.page - 1}"${prevDisabled}>Previous</button>
-                <span class="cs-ugc-overview-page-status">Page ${this.page} of ${pages}</span>
-                <button type="button" class="cs-ugc-overview-page" data-ugc-page="${this.page + 1}"${nextDisabled}>Next</button>
-            </div>
-        `;
+        for (let page = 1; page <= pages; page += 1) {
+            buttons.push(this.pageButton(page, page, false, String(page), page === this.page));
+        }
+
+        buttons.push(this.pageButton('next', this.page + 1, this.page >= pages, 'Next'));
+
+        // Distinct accessible names per landmark (axe landmark-unique) — the two
+        // navs are otherwise identical.
+        return `<nav class="cs-ugc-overview-pagination cs-ugc-overview-pagination--${position}" aria-label="Reviews pagination, ${position} of wall">${buttons.join('')}</nav>`;
     }
 
     /**
-     * The absolute-index list the lightbox steps through: the active filter
-     * applied to the full feed, in display order (Decision A — includes reviews
-     * without photos). A thumb's data-ugc-index points into this same list.
+     * A single numbered/prev/next page button, matching the product module's
+     * `.cs-reviews-page` treatment (44px target, is-current/aria-current).
+     * @param {string|number} key - Stable key for the slot (prev/next/page no.).
+     * @param {number} page - The page the button targets.
+     * @param {boolean} disabled
+     * @param {string} label
+     * @param {boolean} [isCurrent]
+     * @returns {string}
+     */
+    pageButton(key, page, disabled, label, isCurrent = false) {
+        const current = isCurrent ? ' is-current' : '';
+        const aria = isCurrent ? ' aria-current="page"' : '';
+        const disabledAttr = disabled ? ' disabled' : '';
+        return `<button type="button" class="cs-ugc-overview-page${current}" data-ugc-page="${page}" data-page-key="${key}"${aria}${disabledAttr}>${label}</button>`;
+    }
+
+    /**
+     * Smoothly bring the wall top into view after a page change. No-op when the
+     * mount is absent or scrollIntoView is unavailable (jsdom).
+     */
+    scrollToTop() {
+        if (this.container && typeof this.container.scrollIntoView === 'function') {
+            this.container.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    /**
+     * Scroll the home vehicle selector into view and focus its first field, so
+     * the "Select your vehicle" prompt leads straight to the picker. No-op when
+     * the selector is absent or scrollIntoView is unavailable (jsdom).
+     */
+    scrollToVehicleSelector() {
+        const make = document.querySelector('[data-car-selection-field="make"]');
+        if (!make) {
+            return;
+        }
+
+        if (typeof make.scrollIntoView === 'function') {
+            make.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+
+        make.focus({ preventScroll: true });
+    }
+
+    /**
+     * The absolute-index list the lightbox steps through: the currently
+     * displayed set (full feed, or the vehicle-filtered subset), in display
+     * order (Decision A — includes reviews without photos). A card opener's
+     * data-ugc-index points into this same list, so navigation stays aligned
+     * whether or not the vehicle filter is active.
      * @returns {Object[]}
      */
     filteredReviews() {
-        return applyFilter(this.reviews, this.filter, this.ratingValue);
+        return this.displayedReviews();
     }
 
     /**
@@ -375,6 +769,7 @@ export default class UgcOverview {
 
         this.lastFocused = document.activeElement;
         this.lightboxIndex = index;
+        this.lightboxMediaIndex = 0;
 
         const el = this.ensureLightbox();
         this.renderLightbox();
@@ -400,6 +795,7 @@ export default class UgcOverview {
         }
 
         this.lightboxIndex = target;
+        this.lightboxMediaIndex = 0;
         this.renderLightbox();
     }
 
@@ -421,6 +817,7 @@ export default class UgcOverview {
         const content = this.lightbox.querySelector('[data-ugc-lightbox-content]');
         content.innerHTML = this.buildLightboxMedia(review) + this.buildLightboxReview(review);
         content.scrollTop = 0;
+        this.preloadLightboxMedia(review);
 
         // Overview arrows stay visible and only disable at the ends (a single
         // filtered review disables both). This differs deliberately from the
@@ -456,10 +853,12 @@ export default class UgcOverview {
     }
 
     /**
-     * All of a review's media, stacked and rendered large (photo → medium/url,
-     * video → playable with its poster). Reviews without media render no media
-     * block — the text still shows, so arrow navigation never dead-ends on a
-     * no-photo review (SRS §3.2.1 safe media fields).
+     * The review's media area: one displayed hero (sized to fit, never cropped)
+     * plus — when the review carries more than one item — a small thumbnail strip
+     * to swap which is shown. A review can hold at most a few photos + one video
+     * (SRS media limits), so the whole set fits a single strip; stacking them all
+     * full-size overflowed the dialog. Reviews without media render no block — the
+     * text still shows, so arrow navigation never dead-ends on a no-photo review.
      * @param {Object} review
      * @returns {string}
      */
@@ -468,20 +867,137 @@ export default class UgcOverview {
             return '';
         }
 
-        const items = review.media.map((media) => {
-            const label = escapeHtml(review.title || review.archetype_name || 'Customer media');
+        return `<div class="cs-ugc-overview-lightbox-media" data-ugc-lightbox-media>${this.buildLightboxMediaInner(review)}</div>`;
+    }
 
-            if (media.type === 'video') {
-                const videoSrc = escapeHtml(media.url || '');
-                const poster = media.poster_url ? ` poster="${escapeHtml(media.poster_url)}"` : '';
-                return `<video class="cs-ugc-lightbox-video" src="${videoSrc}"${poster} controls playsinline aria-label="${label}"></video>`;
-            }
+    /**
+     * The hero + (optional) thumbnail strip for the currently displayed media of
+     * a review. Split out from the wrapper so a thumbnail click can repaint just
+     * this region without rebuilding the review text below.
+     * @param {Object} review
+     * @returns {string}
+     */
+    buildLightboxMediaInner(review) {
+        const items = review.media;
+        const index = Math.min(Math.max(0, this.lightboxMediaIndex), items.length - 1);
+        const hero = this.buildLightboxHero(items[index], review);
+        const strip = items.length > 1 ? this.buildLightboxThumbs(items, index) : '';
+        return hero + strip;
+    }
 
-            const imgSrc = escapeHtml(media.medium_url || media.url || media.thumb_url || '');
-            return `<img class="cs-ugc-lightbox-img" src="${imgSrc}" alt="${label}" loading="lazy">`;
+    /**
+     * The large displayed media item (photo → medium/url, video → playable with
+     * its poster). Sized in SCSS to fit within the dialog (object-fit, capped
+     * height) so a tall item is shown whole rather than cut off.
+     * @param {Object} media
+     * @param {Object} review - For the accessible label.
+     * @returns {string}
+     */
+    buildLightboxHero(media, review) {
+        return `<div class="cs-ugc-overview-lightbox-hero">${this.buildLightboxHeroMedia(media, review)}</div>`;
+    }
+
+    /**
+     * Just the hero's media element (no wrapper), so a thumbnail switch can swap
+     * it in place without rebuilding the surrounding strip.
+     * @param {Object} media
+     * @param {Object} review - For the accessible label.
+     * @returns {string}
+     */
+    buildLightboxHeroMedia(media, review) {
+        const label = escapeHtml(review.title || review.archetype_name || 'Customer media');
+
+        if (media.type === 'video') {
+            const videoSrc = escapeHtml(media.url || '');
+            const poster = media.poster_url ? ` poster="${escapeHtml(media.poster_url)}"` : '';
+            return `<video class="cs-ugc-lightbox-video" src="${videoSrc}"${poster} controls playsinline aria-label="${label}"></video>`;
+        }
+
+        const imgSrc = escapeHtml(media.medium_url || media.url || media.thumb_url || '');
+        return `<img class="cs-ugc-lightbox-img" src="${imgSrc}" alt="${label}" loading="lazy">`;
+    }
+
+    /**
+     * The thumbnail strip for a multi-item review. Each thumb selects which item
+     * is shown as the hero; the active one is marked. Videos show their poster
+     * thumb with a play affordance so they read as video, not photo.
+     * @param {Object[]} items
+     * @param {number} activeIndex
+     * @returns {string}
+     */
+    buildLightboxThumbs(items, activeIndex) {
+        const thumbs = items.map((media, i) => {
+            const src = escapeHtml(media.thumb_url || media.poster_url || media.medium_url || media.url || '');
+            const isVideo = media.type === 'video';
+            const isActive = i === activeIndex;
+            const activeClass = isActive ? ' is-active' : '';
+            const current = isActive ? ' aria-current="true"' : '';
+            const label = escapeHtml(`Show ${isVideo ? 'video' : 'photo'} ${i + 1} of ${items.length}`);
+            const play = isVideo ? '<span class="cs-ugc-overview-lightbox-thumb-play" aria-hidden="true"></span>' : '';
+            return `<button type="button" class="cs-ugc-overview-lightbox-thumb${activeClass}" data-ugc-media-thumb data-ugc-media-thumb-index="${i}" aria-label="${label}"${current}><img src="${src}" alt="" loading="lazy">${play}</button>`;
         }).join('');
 
-        return `<div class="cs-ugc-overview-lightbox-media">${items}</div>`;
+        return `<div class="cs-ugc-overview-lightbox-thumbs" role="group" aria-label="Review media">${thumbs}</div>`;
+    }
+
+    /**
+     * Switch the displayed hero after a thumbnail click. Only the hero's media
+     * element is swapped and the active marker moved — the thumbnail strip's DOM
+     * (and its already-loaded images) stays put. Rebuilding the whole region
+     * reloaded the thumbs and briefly collapsed the container, which is what
+     * flashed on each switch.
+     */
+    renderLightboxMedia() {
+        if (!this.lightbox) {
+            return;
+        }
+
+        const review = this.filteredReviews()[this.lightboxIndex];
+        if (!review || !hasMedia(review)) {
+            return;
+        }
+
+        const items = review.media;
+        const index = Math.min(Math.max(0, this.lightboxMediaIndex), items.length - 1);
+
+        const hero = this.lightbox.querySelector('.cs-ugc-overview-lightbox-hero');
+        if (hero) {
+            hero.innerHTML = this.buildLightboxHeroMedia(items[index], review);
+        }
+
+        Array.from(this.lightbox.querySelectorAll('[data-ugc-media-thumb]')).forEach((thumb) => {
+            const isActive = parseInt(thumb.dataset.ugcMediaThumbIndex, 10) === index;
+            thumb.classList.toggle('is-active', isActive);
+            if (isActive) {
+                thumb.setAttribute('aria-current', 'true');
+            } else {
+                thumb.removeAttribute('aria-current');
+            }
+        });
+    }
+
+    /**
+     * Warm the browser cache with the review's full-size photos as soon as the
+     * lightbox paints, so switching the hero via the thumbnail strip is instant
+     * (no blank-then-load flash). Videos stream on play, so they are skipped.
+     * @param {Object} review
+     */
+    preloadLightboxMedia(review) {
+        if (typeof Image === 'undefined' || !hasMedia(review)) {
+            return;
+        }
+
+        review.media.forEach((media) => {
+            if (media.type === 'video') {
+                return;
+            }
+
+            const src = media.medium_url || media.url || media.thumb_url;
+            if (src) {
+                const img = new Image();
+                img.src = src;
+            }
+        });
     }
 
     /**
@@ -493,24 +1009,9 @@ export default class UgcOverview {
     buildLightboxReview(review) {
         const author = escapeHtml(review.author);
         const title = escapeHtml(review.title);
-        const body = escapeHtml(review.body);
-        const archetypeName = escapeHtml(review.archetype_name);
-        const archetypeUrl = escapeHtml(review.archetype_url);
-        const rating = parseInt(review.rating, 10) || 0;
-        const stars = buildStarIcons(rating);
-
-        return `
-            <div class="cs-ugc-overview-lightbox-review">
-                <div class="cs-ugc-overview-stars" role="img" aria-label="${rating} out of ${MAX_STARS} stars">${stars}</div>
-                ${title ? `<h3 class="cs-ugc-overview-lightbox-title">${title}</h3>` : ''}
-                ${buildVehicleBadge(review.vehicle_label)}
-                <p class="cs-ugc-overview-text">${body}</p>
-                <p class="cs-ugc-overview-meta">
-                    <span class="cs-ugc-overview-author">${author}</span>
-                    ${archetypeUrl ? `<a class="cs-ugc-overview-product" href="${archetypeUrl}">${archetypeName}</a>` : ''}
-                </p>
-            </div>
-        `;
+        // Same content block as the wall card; the body clamp is card-scoped in
+        // SCSS, so the full review text shows here.
+        return `<div class="cs-ugc-overview-lightbox-review">${this.buildCardContent(review, title, author)}</div>`;
     }
 
     handleLightboxClick(event) {
@@ -526,6 +1027,17 @@ export default class UgcOverview {
 
         if (event.target.closest('[data-ugc-review-next]')) {
             this.navigateLightbox(1);
+            return;
+        }
+
+        // Thumbnail strip: swap which of the review's media is the displayed hero.
+        const thumb = event.target.closest('[data-ugc-media-thumb]');
+        if (thumb) {
+            const target = parseInt(thumb.dataset.ugcMediaThumbIndex, 10);
+            if (!Number.isNaN(target) && target !== this.lightboxMediaIndex) {
+                this.lightboxMediaIndex = target;
+                this.renderLightboxMedia();
+            }
         }
     }
 
@@ -548,6 +1060,12 @@ export default class UgcOverview {
     destroy() {
         if (this.container) {
             this.container.removeEventListener('click', this.handleControlClick);
+            this.container.removeEventListener('change', this.handleToolbarChange);
+        }
+
+        if (this.unsubscribeGlobal) {
+            this.unsubscribeGlobal();
+            this.unsubscribeGlobal = null;
         }
 
         // Close first if open, so teardown stays symmetric: restores focus,

--- a/assets/js/theme/_addons/home/homeController.js
+++ b/assets/js/theme/_addons/home/homeController.js
@@ -15,7 +15,7 @@ export default class HomeController extends PageManager {
             showAllText: 'Show All Products',
             showLessText: 'Show Less',
         });
-        this.ugcOverview = new UgcOverview();
+        this.ugcOverview = new UgcOverview({ globalStateManager: StateManager });
         this.searchEngine = null;
         this.searchDataVersion = null;
         this.currentSelection = null;

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -128,6 +128,14 @@ import {
     buildArchetypeFitmentList,
     buildArchetypeFitmentTree,
 } from '../../global/vehicleFitment';
+import {
+    starIcons,
+    scoreBadge,
+    verifiedBadge,
+    editedBadge,
+    countryFlag,
+    formatReviewDate,
+} from '../../global/ugcCard';
 
 const MAX_STARS = 5;
 
@@ -342,11 +350,13 @@ export default class UgcProduct {
         this.ratingElement = document.querySelector('[data-product-rating]');
         this.listElement = document.querySelector('#product-reviews');
         this.toolbarElement = document.querySelector('[data-reviews-toolbar]');
-        this.paginationElement = document.querySelector('[data-reviews-pagination]');
+        // One container above the list and one below — both painted in lockstep.
+        this.paginationElements = Array.from(document.querySelectorAll('[data-reviews-pagination]'));
 
         this.questionsElement = document.querySelector('#product-questions');
         this.questionsToolbarElement = document.querySelector('[data-questions-toolbar]');
-        this.questionsPaginationElement = document.querySelector('[data-questions-pagination]');
+        // One container above the list and one below — both painted in lockstep.
+        this.questionsPaginationElements = Array.from(document.querySelectorAll('[data-questions-pagination]'));
 
         // "For your <vehicle>" fitment chip containers (SRS §3.4.1), one per
         // list. Space is reserved in SCSS (visibility, not display) so the
@@ -455,17 +465,17 @@ export default class UgcProduct {
             this.toolbarElement.addEventListener('change', this.onToolbarChange);
         }
 
-        if (this.paginationElement) {
-            this.paginationElement.addEventListener('click', this.onPaginationClick);
-        }
+        this.paginationElements.forEach((el) => {
+            el.addEventListener('click', this.onPaginationClick);
+        });
 
         if (this.questionsToolbarElement) {
             this.questionsToolbarElement.addEventListener('change', this.onQuestionsToolbarChange);
         }
 
-        if (this.questionsPaginationElement) {
-            this.questionsPaginationElement.addEventListener('click', this.onQuestionsPaginationClick);
-        }
+        this.questionsPaginationElements.forEach((el) => {
+            el.addEventListener('click', this.onQuestionsPaginationClick);
+        });
 
         // Fitment chip clicks are delegated on the chip containers so the chip
         // survives every re-render without rebinding (SRS §3.4.1).
@@ -1851,6 +1861,18 @@ export default class UgcProduct {
     }
 
     /**
+     * Smoothly align a list section's header to the top of the viewport after a
+     * page change. No-op when the anchor is absent or scrollIntoView is
+     * unavailable (jsdom).
+     * @param {Element} element - The section anchor (its toolbar).
+     */
+    _scrollSectionToTop(element) {
+        if (element && typeof element.scrollIntoView === 'function') {
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    }
+
+    /**
      * Filter both lists to a clicked review/question vehicle (issue #45). The
      * badge carries the review's own `fitment_id` (SRS §3.2.1) — guaranteed
      * present whenever the badge renders, since `vehicle_label` is null whenever
@@ -2023,7 +2045,7 @@ export default class UgcProduct {
 
     onPaginationClick(event) {
         const button = event.target.closest('[data-reviews-page]');
-        if (!button || !this.paginationElement.contains(button)) {
+        if (!button) {
             return;
         }
 
@@ -2036,6 +2058,10 @@ export default class UgcProduct {
 
         this.query.page = page;
         this.fetchReviews();
+
+        // A page change from the bottom controls would otherwise strand the
+        // reader at the foot of the new page — bring the list header into view.
+        this._scrollSectionToTop(this.toolbarElement);
     }
 
     /**
@@ -2129,7 +2155,7 @@ export default class UgcProduct {
 
     onQuestionsPaginationClick(event) {
         const button = event.target.closest('[data-questions-page]');
-        if (!button || !this.questionsPaginationElement.contains(button)) {
+        if (!button) {
             return;
         }
 
@@ -2142,6 +2168,8 @@ export default class UgcProduct {
 
         this.questionQuery.page = page;
         this.fetchQuestions();
+
+        this._scrollSectionToTop(this.questionsToolbarElement);
     }
 
     renderQuestionsList(items) {
@@ -2158,7 +2186,7 @@ export default class UgcProduct {
     }
 
     renderQuestionsPagination() {
-        if (!this.questionsPaginationElement) {
+        if (!this.questionsPaginationElements.length) {
             return;
         }
 
@@ -2167,8 +2195,10 @@ export default class UgcProduct {
             : 0;
 
         if (pageCount <= 1) {
-            this.questionsPaginationElement.innerHTML = '';
-            this.questionsPaginationElement.style.visibility = 'hidden';
+            this.questionsPaginationElements.forEach((el) => {
+                el.innerHTML = '';
+                el.style.visibility = 'hidden';
+            });
             return;
         }
 
@@ -2183,8 +2213,13 @@ export default class UgcProduct {
 
         buttons.push(this._questionPageButton('next', current + 1, current >= pageCount, 'Next'));
 
-        this.questionsPaginationElement.innerHTML = `<nav class="cs-questions-pages" aria-label="Questions pagination">${buttons.join('')}</nav>`;
-        this.questionsPaginationElement.style.visibility = 'visible';
+        // Distinct accessible names per landmark (axe landmark-unique) — the two
+        // navs are otherwise identical.
+        this.questionsPaginationElements.forEach((el) => {
+            const position = el.classList.contains('cs-questions-pagination--top') ? 'top' : 'bottom';
+            el.innerHTML = `<nav class="cs-questions-pages" aria-label="Questions pagination, ${position} of list">${buttons.join('')}</nav>`;
+            el.style.visibility = 'visible';
+        });
     }
 
     _questionPageButton(key, page, disabled, label, isCurrent = false) {
@@ -2199,10 +2234,10 @@ export default class UgcProduct {
             this.questionsElement.innerHTML = `<p class="cs-questions-error">${MESSAGES.questionsError}</p>`;
         }
 
-        if (this.questionsPaginationElement) {
-            this.questionsPaginationElement.innerHTML = '';
-            this.questionsPaginationElement.style.visibility = 'hidden';
-        }
+        this.questionsPaginationElements.forEach((el) => {
+            el.innerHTML = '';
+            el.style.visibility = 'hidden';
+        });
     }
 
     /**
@@ -2265,15 +2300,17 @@ export default class UgcProduct {
     }
 
     renderPagination() {
-        if (!this.paginationElement) {
+        if (!this.paginationElements.length) {
             return;
         }
 
         const pageCount = this.perPage > 0 ? Math.ceil(this.total / this.perPage) : 0;
 
         if (pageCount <= 1) {
-            this.paginationElement.innerHTML = '';
-            this.paginationElement.style.visibility = 'hidden';
+            this.paginationElements.forEach((el) => {
+                el.innerHTML = '';
+                el.style.visibility = 'hidden';
+            });
             return;
         }
 
@@ -2288,8 +2325,13 @@ export default class UgcProduct {
 
         buttons.push(this._pageButton('next', current + 1, current >= pageCount, 'Next'));
 
-        this.paginationElement.innerHTML = `<nav class="cs-reviews-pages" aria-label="Reviews pagination">${buttons.join('')}</nav>`;
-        this.paginationElement.style.visibility = 'visible';
+        // Distinct accessible names per landmark (axe landmark-unique) — the two
+        // navs are otherwise identical.
+        this.paginationElements.forEach((el) => {
+            const position = el.classList.contains('cs-reviews-pagination--top') ? 'top' : 'bottom';
+            el.innerHTML = `<nav class="cs-reviews-pages" aria-label="Reviews pagination, ${position} of list">${buttons.join('')}</nav>`;
+            el.style.visibility = 'visible';
+        });
     }
 
     _pageButton(key, page, disabled, label, isCurrent = false) {
@@ -2894,10 +2936,10 @@ export default class UgcProduct {
             this.listElement.innerHTML = `<p class="cs-reviews-error">${MESSAGES.loadError}</p>`;
         }
 
-        if (this.paginationElement) {
-            this.paginationElement.innerHTML = '';
-            this.paginationElement.style.visibility = 'hidden';
-        }
+        this.paginationElements.forEach((el) => {
+            el.innerHTML = '';
+            el.style.visibility = 'hidden';
+        });
 
         // The reviews list is unavailable, so hide the overview panel with it
         // and re-arm the gallery load for the next successful render.
@@ -2909,15 +2951,7 @@ export default class UgcProduct {
     }
 
     _buildStars(average) {
-        const rounded = Math.round(average);
-        let stars = '';
-
-        for (let i = 1; i <= MAX_STARS; i += 1) {
-            const modifier = i <= rounded ? 'ratingFull' : 'ratingEmpty';
-            stars += `<span class="icon icon--${modifier}"><svg><use href="#icon-star" /></svg></span>`;
-        }
-
-        return `<span class="cs-rating-stars" role="img" aria-label="${average} out of ${MAX_STARS} stars">${stars}</span>`;
+        return `<span class="cs-rating-stars" role="img" aria-label="${average} out of ${MAX_STARS} stars">${starIcons(Math.round(average))}</span>`;
     }
 
     _countLabel(count) {
@@ -2963,17 +2997,7 @@ export default class UgcProduct {
      * @returns {string}
      */
     _countryFlag(code) {
-        if (typeof code !== 'string') {
-            return '';
-        }
-
-        const cc = code.trim().toLowerCase();
-        if (!/^[a-z]{2}$/.test(cc)) {
-            return '';
-        }
-
-        const label = cc.toUpperCase();
-        return `<img class="cs-review-flag" src="https://flagcdn.com/${cc}.svg" alt="${label}" title="${label}" loading="lazy">`;
+        return countryFlag(code);
     }
 
     _buildReview(review, includeMedia = true, clickableVehicle = true) {
@@ -2981,17 +3005,13 @@ export default class UgcProduct {
         const title = this._escape(review.title);
         const body = this._escape(review.body);
         const date = this._formatDate(review.date);
-        const verified = review.verified_purchaser
-            ? '<span class="cs-review-verified">Verified Purchaser</span>'
-            : '';
+        const verified = verifiedBadge(review.verified_purchaser);
         // Public disclosure that staff edited this review's content (SRS §3.2.1
         // `edited` / §3.1.1, cs-ugc #145). Strict `=== true` so a missing field
         // on an older payload is treated as false and nothing renders — the card
         // must never break on an absent flag, and it never reveals who edited or
         // how many times (only the derived boolean is exposed).
-        const edited = review.edited === true
-            ? '<span class="cs-review-edited">Edited by CravenSpeed</span>'
-            : '';
+        const edited = editedBadge(review.edited);
         const staff = review.staff_response
             ? `<div class="cs-review-staff"><strong>CravenSpeed:</strong> ${this._escape(review.staff_response)}</div>`
             : '';
@@ -3004,7 +3024,7 @@ export default class UgcProduct {
                 <div class="cs-review-heading">
                     ${date ? `<span class="cs-review-date">${date}</span>` : ''}
                     ${this._buildStars(review.rating || 0)}
-                    <span class="cs-review-score">${review.rating || 0}</span>
+                    ${scoreBadge(review.rating || 0)}
                     ${title ? `<h3 class="cs-review-title">${title}</h3>` : ''}
                 </div>
                 <p class="cs-review-meta">
@@ -3021,20 +3041,7 @@ export default class UgcProduct {
     }
 
     _formatDate(value) {
-        if (!value) {
-            return '';
-        }
-
-        const parsed = new Date(value);
-        if (Number.isNaN(parsed.getTime())) {
-            return '';
-        }
-
-        return parsed.toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-        });
+        return formatReviewDate(value);
     }
 
     _escape(value) {
@@ -3070,17 +3077,17 @@ export default class UgcProduct {
             this.toolbarElement.removeEventListener('change', this.onToolbarChange);
         }
 
-        if (this.paginationElement) {
-            this.paginationElement.removeEventListener('click', this.onPaginationClick);
-        }
+        this.paginationElements.forEach((el) => {
+            el.removeEventListener('click', this.onPaginationClick);
+        });
 
         if (this.questionsToolbarElement) {
             this.questionsToolbarElement.removeEventListener('change', this.onQuestionsToolbarChange);
         }
 
-        if (this.questionsPaginationElement) {
-            this.questionsPaginationElement.removeEventListener('click', this.onQuestionsPaginationClick);
-        }
+        this.questionsPaginationElements.forEach((el) => {
+            el.removeEventListener('click', this.onQuestionsPaginationClick);
+        });
 
         if (this.reviewsFitmentChipElement) {
             this.reviewsFitmentChipElement.removeEventListener('click', this.onFitmentChipClick);

--- a/assets/scss/custom/_cs-home.scss
+++ b/assets/scss/custom/_cs-home.scss
@@ -148,105 +148,67 @@
   min-height: 320px;
 }
 
-.cs-ugc-overview-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: spacing('quarter');
-  justify-content: center;
-  margin-bottom: spacing('single');
-}
+// The sort/filter toolbar reuses the product reviews controls (.cs-reviews-toolbar
+// / -control / -select / .cs-fitment-chip-slot — all bare classes in
+// _cs-product.scss). Its own .cs-reviews-toolbar margin-bottom spaces it off the
+// wall below, so no home-specific override is needed.
 
-.cs-ugc-overview-filter {
-  min-height: 44px;
-  padding: spacing('quarter') spacing('half');
-  border: 1px solid stencilColor('color-greyLight');
-  border-radius: stencilRadius('base');
-  background-color: stencilColor('color-white');
-  color: stencilColor('color-textBase');
-  cursor: pointer;
-
-  &:hover,
-  &:focus-visible {
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-primary');
-  }
-
-  &.is-active {
-    background-color: stencilColor('color-primary');
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-white');
-  }
-}
-
+// Even, uniform columns (1fr each) at every breakpoint — 1 / 2 / 3 down to
+// mobile. With 12 per page every full page fills complete rows, so the grid
+// reads as a neat rectangle without any per-card width variation.
 .cs-ugc-overview-wall {
   display: grid;
   grid-template-columns: 1fr;
-  gap: spacing('half');
+  gap: spacing('single');
+
+  @include breakpoint('small') {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
   @include breakpoint('medium') {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
+// Elevated surface (soft shadow, no outline) instead of a hairline-bordered box.
 .cs-ugc-overview-card {
-  display: flex;
+  position: relative;
+  display: flex; // column layout for the card's own contents (media, body, footer)
   flex-direction: column;
-  border: 1px solid stencilColor('color-greyLight');
-  border-radius: stencilRadius('card');
+  background-color: stencilColor('color-white');
+  border-radius: 0.75rem; // 12px — the product module's standard surface radius
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.1);
   overflow: hidden;
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 
-  &:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  &:hover,
+  &:focus-within {
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
     transform: translateY(-2px);
   }
 
   @media (prefers-reduced-motion: reduce) {
     transition: none;
 
-    &:hover {
+    &:hover,
+    &:focus-within {
       transform: none;
     }
   }
 }
 
-.cs-ugc-overview-thumb {
-  position: relative;
+// Stretched, visually-empty button covering the whole card — the primary
+// affordance opens the review lightbox, so no-photo cards are openable too.
+// The product link sits above it (z-index) and still navigates on its own click.
+.cs-ugc-overview-open {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
   width: 100%;
-  padding: 100% 0 0; // square aspect via padding box; zeroes a button's UA padding
-  background-color: stencilColor('color-greyLightest');
-
-  img {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-  &.is-empty {
-    padding-top: 0;
-    min-height: spacing('double');
-  }
-}
-
-// A media review's thumb is a button that opens the review lightbox. Reset the
-// button chrome and add a subtle zoom + focus affordance to signal it's clickable.
-button.cs-ugc-overview-thumb {
-  display: block;
-  overflow: hidden;
+  padding: 0;
   border: 0;
+  background: transparent;
   cursor: pointer;
-
-  img {
-    transition: transform 0.2s ease;
-  }
-
-  &:hover img,
-  &:focus-visible img {
-    transform: scale(1.05);
-  }
 
   &:focus-visible {
     outline: 2px solid stencilColor('color-primary');
@@ -254,11 +216,41 @@ button.cs-ugc-overview-thumb {
   }
 }
 
+.cs-ugc-overview-media {
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  background-color: stencilColor('color-greyLightest');
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+  }
+}
+
+.cs-ugc-overview-card:hover .cs-ugc-overview-media img {
+  transform: scale(1.04);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cs-ugc-overview-card:hover .cs-ugc-overview-media img {
+    transform: none;
+  }
+}
+
 .cs-ugc-overview-card-body {
   display: flex;
+  flex: 1; // fill the equal-height card so the meta footer can pin to the bottom
   flex-direction: column;
   gap: spacing('quarter');
-  padding: spacing('half');
+  padding: spacing('single');
+}
+
+.cs-ugc-overview-header {
+  display: flex;
+  align-items: center;
+  gap: spacing('half');
 }
 
 // Stars come from the shared icon sprite (icon--ratingFull/Empty fills in
@@ -281,27 +273,56 @@ button.cs-ugc-overview-thumb {
 
 .cs-ugc-overview-title {
   margin: 0;
-  font-size: stencilFontSize('smaller');
+  font-size: 1.0625rem;
+  font-weight: 700;
+  line-height: 1.3;
 }
 
+// Content-sized pill: the card body is a flex column, which would otherwise
+// stretch the inline-block badge to a full-width bar.
 .cs-ugc-overview-vehicle {
+  align-self: flex-start;
   margin: 0;
 }
 
 .cs-ugc-overview-text {
   margin: 0;
+  line-height: 1.5;
 }
 
+// Card-scoped 4-line clamp keeps card heights even; the lightbox review block
+// is not a .cs-ugc-overview-card, so the full text shows there.
+.cs-ugc-overview-card .cs-ugc-overview-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+}
+
+// margin-top: auto pushes the meta (and the product link after it) to the
+// bottom of the flex card body, absorbing the slack on shorter cards so rows
+// align cleanly instead of leaving a gap mid-card.
 .cs-ugc-overview-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: spacing('quarter');
-  justify-content: space-between;
-  margin: 0;
-  color: stencilColor('color-textSecondary');
+  align-items: center;
+  gap: spacing('half');
+  margin: auto 0 0;
+  padding-top: spacing('quarter');
+  font-size: 0.8125rem;
+  color: stencilColor('color-greyDark');
 }
 
+.cs-ugc-overview-author {
+  font-weight: 600;
+  color: stencilColor('color-textBase');
+}
+
+// Sits above the stretched card-open button so its own click navigates.
 .cs-ugc-overview-product {
+  position: relative;
+  z-index: 2;
+  align-self: flex-start;
   color: stencilColor('color-textLink');
   text-decoration: none;
 
@@ -318,14 +339,21 @@ button.cs-ugc-overview-thumb {
 
 .cs-ugc-overview-pagination {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: spacing('half');
+  gap: spacing('quarter');
   margin-top: spacing('single');
 }
 
+// Top control set sits above the wall — flip the margin to below it.
+.cs-ugc-overview-pagination--top {
+  margin-top: 0;
+  margin-bottom: spacing('single');
+}
+
 // Matches the .cs-reviews-page treatment on the product page: 44px touch
-// targets, bordered buttons, dimmed disabled state.
+// targets, bordered buttons, current-page emphasis, dimmed disabled state.
 .cs-ugc-overview-page {
   min-width: 44px;
   height: 44px;
@@ -341,15 +369,16 @@ button.cs-ugc-overview-thumb {
     color: stencilColor('color-primary');
   }
 
+  &.is-current {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+    font-weight: 700;
+  }
+
   &:disabled {
     opacity: 0.5;
     cursor: default;
   }
-}
-
-.cs-ugc-overview-page-status {
-  font-size: 0.875rem;
-  color: stencilColor('color-textSecondary');
 }
 
 // =============================================================================
@@ -357,48 +386,133 @@ button.cs-ugc-overview-thumb {
 // prev/next arrows stepping through the filtered set. Reuses the .cs-ugc-modal
 // shell + .cs-ugc-lightbox-* media styling from _cs-product.scss.
 // =============================================================================
+// The dialog is styled to read as an enlarged home wall card: a full-bleed media
+// strip with rounded top corners, then the review body with the card's own
+// padding. The base .cs-ugc-modal-dialog already gives the white surface, 0.75rem
+// radius, and shadow; here the shared dialog padding is dropped (at higher
+// specificity than .cs-ugc-lightbox-dialog) so the media reaches the edges. The
+// dialog keeps overflow visible — the prev/next arrows live just outside it — so
+// the media clips its own top corners rather than the dialog clipping them.
 .cs-ugc-overview-lightbox {
   align-items: center;
+
+  // Wider side gutters than the base modal so the prev/next arrows — which sit
+  // outside the card-like dialog — stay fully on-screen (2.5rem arrow + its gap).
+  padding-left: 3rem;
+  padding-right: 3rem;
+
+  // Legible on either a photo or the white body: a translucent dark disc with a
+  // white glyph, replacing the base modal's dark-on-transparent close.
+  .cs-ugc-modal-close {
+    color: #fff;
+    background: rgba(0, 0, 0, 0.45);
+
+    &:hover,
+    &:focus-visible {
+      color: #fff;
+      background: rgba(0, 0, 0, 0.6);
+    }
+  }
 }
 
 .cs-ugc-overview-lightbox-content {
   display: flex;
   flex-direction: column;
-  gap: spacing('single');
   width: 100%;
   max-height: 80vh;
   overflow-y: auto;
-
-  // Reserve side gutters so the floating prev/next arrows never overlap the
-  // content — most visible on a text-only review, where there is no image for
-  // the arrows to sit over (2.5rem arrow + its edge offset).
-  padding: 0 2.75rem;
 }
 
+// Media area: one displayed hero, plus a thumbnail strip to switch it when the
+// review carries more than one item. The hero clips its top corners to the
+// dialog radius (the dialog keeps overflow visible for the side arrows).
 .cs-ugc-overview-lightbox-media {
-  display: flex;
-  flex-direction: column;
-  gap: spacing('half');
   width: 100%;
 }
 
-.cs-ugc-overview-lightbox-media img,
-.cs-ugc-overview-lightbox-media video {
+// The displayed item is sized to fit within the dialog (object-fit + capped
+// height) so a tall photo is shown whole rather than cut off; the neutral fill
+// backs the letterbox on a portrait item.
+.cs-ugc-overview-lightbox-hero {
+  width: 100%;
+  overflow: hidden;
+  background: stencilColor('color-greyLightest');
+  border-radius: 0.75rem 0.75rem 0 0;
+}
+
+.cs-ugc-overview-lightbox-hero img,
+.cs-ugc-overview-lightbox-hero video {
   display: block;
   width: 100%;
   max-height: 60vh;
   object-fit: contain;
 }
 
+// Thumbnail switcher, sitting in the card body's gutter under the hero.
+.cs-ugc-overview-lightbox-thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('quarter');
+  padding: spacing('half') spacing('single') 0;
+}
+
+.cs-ugc-overview-lightbox-thumb {
+  position: relative;
+  width: 3.5rem;
+  height: 3.5rem;
+  padding: 0;
+  overflow: hidden;
+  background: none;
+  border: 2px solid transparent;
+  border-radius: 0.375rem;
+  cursor: pointer;
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &.is-active {
+    border-color: stencilColor('color-primary');
+  }
+
+  &:focus-visible {
+    outline: 2px solid stencilColor('color-primary');
+    outline-offset: 1px;
+  }
+}
+
+// Play triangle over a video thumbnail so it reads as video, not photo.
+.cs-ugc-overview-lightbox-thumb-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0.3rem 0 0.3rem 0.5rem;
+  border-color: transparent transparent transparent #fff;
+  transform: translate(-30%, -50%);
+  filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.7));
+}
+
+// The review body, with the home card body's padding. When there is no media it
+// is the first child, so it reserves top room for the overlaid close button.
 .cs-ugc-overview-lightbox-review {
   display: flex;
   flex-direction: column;
   gap: spacing('quarter');
   width: 100%;
+  padding: spacing('single');
   text-align: left;
 }
 
-.cs-ugc-overview-lightbox-title {
-  margin: 0;
-  font-size: 1.125rem;
+.cs-ugc-overview-lightbox-review:first-child {
+  padding-top: 3rem;
+}
+
+.cs-ugc-overview-lightbox-review .cs-ugc-overview-title {
+  font-size: 1.25rem;
 }

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1003,11 +1003,26 @@ $cs-fitment-active-hover: #05a;
   margin-top: spacing('single');
 }
 
+// Top page controls sit between the toolbar and the list. They paint in the
+// same pass as the list (no separate async shift), so they reserve no fixed
+// height and collapse fully when there's a single page — no gap below the
+// toolbar in the common case.
+.cs-reviews-pagination--top {
+  min-height: 0;
+  margin-top: 0;
+  margin-bottom: spacing('single');
+
+  &:empty {
+    margin-bottom: 0;
+  }
+}
+
 .cs-reviews-pages {
   display: flex;
   flex-wrap: wrap;
   gap: spacing('quarter');
   align-items: center;
+  justify-content: center;
 }
 
 .cs-reviews-page {
@@ -1267,11 +1282,25 @@ button.cs-ugc-vehicle-badge {
   margin-top: spacing('single');
 }
 
+// Top page controls sit between the toolbar and the list. They paint in the
+// same pass as the list, so they reserve no fixed height and collapse fully
+// when there's a single page — no gap below the toolbar in the common case.
+.cs-questions-pagination--top {
+  min-height: 0;
+  margin-top: 0;
+  margin-bottom: spacing('single');
+
+  &:empty {
+    margin-bottom: 0;
+  }
+}
+
 .cs-questions-pages {
   display: flex;
   flex-wrap: wrap;
   gap: spacing('quarter');
   align-items: center;
+  justify-content: center;
 }
 
 .cs-questions-page {
@@ -1965,21 +1994,41 @@ textarea.cs-ugc-input {
   }
 }
 
+// The dialog reads as an enlarged review card (matching the home wall lightbox):
+// full-bleed media on top, the owning review as the padded card body beneath.
 .cs-ugc-lightbox {
   align-items: center;
 
   // Above the gallery modal (.cs-ugc-modal base is 1000), so a tile clicked
   // inside it opens the viewer on top.
   z-index: 1010;
+
+  // Wider side gutters than the base modal so the prev/next arrows — which sit
+  // outside the dialog — stay fully on-screen (2.5rem arrow + its gap).
+  padding-left: 3rem;
+  padding-right: 3rem;
+
+  // Legible over the photo it always opens on: a translucent dark disc with a
+  // white glyph (matches the home review lightbox).
+  .cs-ugc-modal-close {
+    color: #fff;
+    background: rgba(0, 0, 0, 0.45);
+
+    &:hover,
+    &:focus-visible {
+      color: #fff;
+      background: rgba(0, 0, 0, 0.6);
+    }
+  }
 }
 
-// Full owning review rendered under the media for band / gallery-modal
-// tiles. Scrolls on its own so a long review never pushes the media off
-// screen.
+// Full owning review rendered under the media as the card body, with the home
+// card body's padding. Scrolls on its own so a long review never pushes the
+// media off screen.
 .cs-ugc-lightbox-review {
   width: 100%;
-  margin-top: spacing('half');
   max-height: 30vh;
+  padding: spacing('single');
   overflow-y: auto;
   text-align: left;
 
@@ -1989,33 +2038,46 @@ textarea.cs-ugc-input {
   }
 }
 
+// Card-like width; full-bleed contents (no padding) so the media reaches the
+// edges. The prev/next arrows live in the modal's side gutters, outside this box
+// — which is why the dialog keeps overflow visible and the media clips its own
+// corners instead.
 .cs-ugc-lightbox-dialog {
-  max-width: 48rem;
-  padding: spacing('double') spacing('half') spacing('half');
-
-  @include breakpoint('medium') {
-    padding: spacing('double') spacing('single') spacing('single');
-  }
+  max-width: 32rem;
+  padding: 0;
 }
 
-// Column stack: media on top, the owning review (when present) beneath.
+// Column stack: media on top, the owning review (when present) beneath, each
+// full width.
 .cs-ugc-lightbox-content {
   display: flex;
   flex-direction: column;
-  align-items: center;
   min-height: 4.5rem;
-
-  // Reserve side gutters so the floating prev/next arrows never overlap the
-  // content — including the review text below the media, and the empty space
-  // while media is still loading (2.5rem arrow + its edge offset).
-  padding: 0 2.75rem;
 }
 
+// Full-bleed media: spans the dialog edge to edge, rounding the corners it meets
+// (the top when a review body follows; all four when it is the only content).
 .cs-ugc-lightbox-img,
 .cs-ugc-lightbox-video {
   display: block;
-  max-width: 100%;
-  max-height: 60vh;
+  width: 100%;
+  height: auto;
+}
+
+// Scoped to the product lightbox — its content holds a single media item, so the
+// first/last-child corner rounding is unambiguous. The home lightbox reuses the
+// same .cs-ugc-lightbox-img/-video classes but stacks a review's full media set
+// inside its own rounded wrapper, so these must not reach it.
+.cs-ugc-lightbox .cs-ugc-lightbox-img:first-child,
+.cs-ugc-lightbox .cs-ugc-lightbox-video:first-child {
+  border-top-left-radius: 0.75rem;
+  border-top-right-radius: 0.75rem;
+}
+
+.cs-ugc-lightbox .cs-ugc-lightbox-img:last-child,
+.cs-ugc-lightbox .cs-ugc-lightbox-video:last-child {
+  border-bottom-left-radius: 0.75rem;
+  border-bottom-right-radius: 0.75rem;
 }
 
 // Prev/next arrows shared by the product review lightbox and the home overview
@@ -2058,10 +2120,16 @@ textarea.cs-ugc-input {
   }
 }
 
+// Sit just OUTSIDE the dialog's edges (right/left: 100% pushes each arrow fully
+// past the matching edge) so the dialog keeps a tight, card-like width and the
+// arrows read as separate controls beside it. The modal reserves matching side
+// gutters so they never clip off-screen.
 .cs-ugc-lightbox-arrow--prev {
-  left: spacing('half');
+  right: 100%;
+  margin-right: spacing('quarter');
 }
 
 .cs-ugc-lightbox-arrow--next {
-  right: spacing('half');
+  left: 100%;
+  margin-left: spacing('quarter');
 }

--- a/templates/components/products-cs/qa-cs.html
+++ b/templates/components/products-cs/qa-cs.html
@@ -16,8 +16,12 @@
             {{lang 'products.questions.submit.open'}}
         </button>
     </div>
+    {{!-- Page controls render both above and below the list (ugcProduct.js paints
+    every [data-questions-pagination]). The top set collapses to zero height via
+    :empty on a single page, so it adds no gap below the toolbar. --}}
+    <div class="cs-questions-pagination cs-questions-pagination--top" data-questions-pagination></div>
     <div id="product-questions"></div>
-    <div class="cs-questions-pagination" data-questions-pagination></div>
+    <div class="cs-questions-pagination cs-questions-pagination--bottom" data-questions-pagination></div>
 
     <div class="cs-ugc-modal" data-question-modal hidden>
         <div class="cs-ugc-modal-overlay" data-question-modal-close></div>

--- a/templates/components/products-cs/reviews-cs.html
+++ b/templates/components/products-cs/reviews-cs.html
@@ -43,8 +43,12 @@
             {{lang 'products.reviews.submit.open'}}
         </button>
     </div>
+    {{!-- Page controls are rendered both above and below the list (ugcProduct.js
+    paints every [data-reviews-pagination]). The top set collapses to zero height
+    via :empty when there's a single page, so it adds no gap below the toolbar. --}}
+    <div class="cs-reviews-pagination cs-reviews-pagination--top" data-reviews-pagination></div>
     <div id="product-reviews"></div>
-    <div class="cs-reviews-pagination" data-reviews-pagination></div>
+    <div class="cs-reviews-pagination cs-reviews-pagination--bottom" data-reviews-pagination></div>
 
     <div class="cs-ugc-modal" data-review-modal hidden>
         <div class="cs-ugc-modal-overlay" data-review-modal-close></div>


### PR DESCRIPTION
Brings the home overview review wall up to parity with the product page, modernizes both review lightboxes into enlarged "cards," and extracts the shared card primitives into one module. **No cs-ugc contract changes** — every field consumed is already in the §3.2.1 / §3.2.3 safe set. SRS §3.4.2 formally defers home-wall filtering to v1.1; this client-side divergence is accepted by the product owner.

## Shared — `ugcCard.js` (new)
- Extracts the card render primitives (sprite stars, score pill, Verified Purchaser / Edited badges, country flag, MM/DD/YYYY date) into one module used by **both** the product list and the home wall, so they render identically from one source of truth. Covered by `ugcCard.spec.js`.

## Home overview wall — `ugcOverview.js`, `_cs-home.scss`, `homeController.js`
- **12-per-page** responsive CSS grid (1 / 2 / 3 columns) with numbered pagination **above and below** the wall; smooth scroll-to-top on page change.
- **Client-side toolbar** mirroring the product reviews controls — sort (newest / oldest / highest / lowest), rating filter, verified-purchasers and with-media toggles — all composed over the **once-fetched** feed (no refetch), sorting a copy so the source feed is never mutated. The toolbar is painted once; sort/filter/page/chip changes repaint only the wall region, so controls keep focus and value.
- **Vehicle filter chip** moved into the toolbar's reserved chip slot ("For your &lt;vehicle&gt;" toggle / "Select your vehicle" prompt / no-match note) with the product page's CLS-safe visibility flip; re-resolves on a garage or registry change.
- **Click-to-open review lightbox** with prev/next review navigation, Esc / arrow keys, and focus restore to the opening card.
- Lightbox restyled as an **enlarged wall card**: full-bleed media, card-padded review body, a translucent close disc over the image (with a reserved spot when there's no media), and prev/next arrows moved into the modal's side gutters, **outside** the card.
- **Multi-media reviews**: one sized-to-fit hero (shown whole, never cut off) plus a **thumbnail strip** to switch it, instead of stacking the whole set. Hero swaps are surgical and the review's photos are preloaded on open, so switching no longer flashes.
- Wires the site `GlobalStateManager` into the home `UgcOverview`.

## Product reviews & Q&A — `ugcProduct.js`, `reviews-cs.html`, `qa-cs.html`, `_cs-product.scss`
- Page controls rendered **above and below** both the reviews and Q&A lists; pagination **centered** under each.
- Review media lightbox restyled to **match the home card**: full-bleed media rounding the corners it meets, close disc over the image, arrows in the modal's side gutters outside the card-width dialog. (Questions have no media lightbox, so nothing to match there.)

## Tests
- Expanded `ugcOverview.spec` (toolbar sort/filter/compose/reset, chip-in-slot states, hero + thumbnail switcher, flash-free swap) and `ugcProduct.spec`.
- **Full suite green (403)**; ESLint (airbnb) + stylelint pass via `npx grunt check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)