### PR TITLE
M9 UGC: UI touchups — pagination radius, review-chip scroll, reviews/Q&A gutter

### DIFF
--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -1903,6 +1903,14 @@ export default class UgcProduct {
         }
 
         this._refilter();
+
+        // The filter resets the list to page 1, so the reader would otherwise be
+        // stranded mid-list — bring the clicked card's section header into view,
+        // matching the bottom page controls' scroll.
+        const anchor = badge.classList.contains('cs-question-vehicle')
+            ? this.questionsToolbarElement
+            : this.toolbarElement;
+        this._scrollSectionToTop(anchor);
     }
 
     /**

--- a/assets/scss/custom/_cs-home.scss
+++ b/assets/scss/custom/_cs-home.scss
@@ -359,6 +359,7 @@
   height: 44px;
   padding: 0 spacing('half');
   border: 1px solid stencilColor('color-greyLightest');
+  border-radius: spacing('half'); // matches .cs-product-archetype button (_custom.scss:59)
   background: stencilColor('color-white');
   color: stencilColor('color-textBase');
   cursor: pointer;

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1073,6 +1073,20 @@ $cs-fitment-active-hover: #05a;
   }
 }
 
+// Per-item side gutter for the reviews / Q&A content blocks (mirrors .pdpRow's
+// approach — the gutter lives on the content piece itself, not a shared wrapper,
+// so any single item can still opt into full width). Padding rather than margin
+// because the medium rule centers these via margin: 0 auto. Mobile-first: half
+// on mobile, single from the medium breakpoint up.
+.cs-reviews,
+.cs-questions {
+  padding: 0 spacing('half');
+
+  @include breakpoint('medium') {
+    padding: 0 spacing('single');
+  }
+}
+
 // Contrast pass: full stars keep the theme fill (brand red in the active
 // CravenSpeed variation); empties lighten so full vs empty separate cleanly.
 // Meta text steps up to greyDark below.


### PR DESCRIPTION
Three small storefront-only UI touchups on the M9 UGC surfaces. No contract/data changes.

## Changes

1. **Home pagination border-radius.** The home review-wall pagination buttons (`.cs-ugc-overview-page`) were square because they sit outside `.cs-product-archetype`, whose `button` rule (`_custom.scss:59`) is where the product reviews pagination picks up its radius. Added the matching `border-radius: spacing('half')` explicitly.

2. **Scroll on review/question vehicle-chip filter.** Clicking a review or question's vehicle badge filters the list to that vehicle and resets to page 1 — but unlike the bottom page controls it didn't scroll, stranding the reader mid-list. `onVehicleBadgeClick` now calls `_scrollSectionToTop` on the clicked card's section (reviews vs Q&A).

3. **Reviews/Q&A side gutter.** The `.cs-reviews` / `.cs-questions` content blocks had no mobile side gutter. Added a per-item gutter (padding `half` on mobile → `single` at `medium`), mirroring `.pdpRow` — gutter on the content piece itself, not a shared wrapper, so full-width items stay possible. Padding (not margin) since the medium rule centers these via `margin: 0 auto`.

## Verification

`npx grunt check` green — ESLint, 403 Jest tests, stylelint (197 files).

## Follow-up (separate PR)

Pagination renders every page number with no windowing — at thousands of reviews that's a wall of hundreds of 44px buttons (reviews, Q&A, and the home wall all share the pattern). Windowed pagination (`1 … 8 [9] 10 … 200`) will follow in its own PR. `per_page` sizing / deep-pagination performance to be raised with cs-ugc as boundary questions.