### PR TITLE
M9 UGC: windowed pagination for reviews, Q&A, and the home wall

### DIFF
--- a/assets/js/test-unit/theme/global/ugcPagination.spec.js
+++ b/assets/js/test-unit/theme/global/ugcPagination.spec.js
@@ -1,0 +1,40 @@
+import { pageWindow, PAGE_GAP } from '../../../theme/_addons/global/ugcPagination';
+
+describe('ugcPagination.pageWindow', () => {
+    it('lists every page when the count is small enough to fit', () => {
+        expect(pageWindow(1, 1)).toEqual([1]);
+        expect(pageWindow(1, 5)).toEqual([1, 2, 3, 4, 5]);
+        // radius 2 either side of a centered current still reaches both ends.
+        expect(pageWindow(4, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it('windows a large count with both ends anchored and a gap each side', () => {
+        expect(pageWindow(9, 200)).toEqual([1, PAGE_GAP, 7, 8, 9, 10, 11, PAGE_GAP, 200]);
+    });
+
+    it('omits the leading gap near the start', () => {
+        expect(pageWindow(1, 200)).toEqual([1, 2, 3, PAGE_GAP, 200]);
+        expect(pageWindow(3, 200)).toEqual([1, 2, 3, 4, 5, PAGE_GAP, 200]);
+    });
+
+    it('omits the trailing gap near the end', () => {
+        expect(pageWindow(200, 200)).toEqual([1, PAGE_GAP, 198, 199, 200]);
+        expect(pageWindow(198, 200)).toEqual([1, PAGE_GAP, 196, 197, 198, 199, 200]);
+    });
+
+    it('shows a lone hidden page instead of a one-page gap', () => {
+        // Page 2 is the only page between 1 and the window — show it, not '…'.
+        expect(pageWindow(5, 200)).toEqual([1, 2, 3, 4, 5, 6, 7, PAGE_GAP, 200]);
+        // Mirror on the trailing side: page 199 is the only one hidden.
+        expect(pageWindow(196, 200)).toEqual([1, PAGE_GAP, 194, 195, 196, 197, 198, 199, 200]);
+    });
+
+    it('clamps an out-of-range current into the page span', () => {
+        expect(pageWindow(0, 200)).toEqual(pageWindow(1, 200));
+        expect(pageWindow(999, 200)).toEqual(pageWindow(200, 200));
+    });
+
+    it('honours a custom radius', () => {
+        expect(pageWindow(10, 200, 1)).toEqual([1, PAGE_GAP, 9, 10, 11, PAGE_GAP, 200]);
+    });
+});

--- a/assets/js/test-unit/theme/product/ugcProduct.spec.js
+++ b/assets/js/test-unit/theme/product/ugcProduct.spec.js
@@ -480,6 +480,20 @@ describe('UgcProduct (slice 6b — sort, filter, pagination)', () => {
             expect(bottom.querySelector('[data-reviews-page="4"]')).toBeNull();
         });
 
+        it('windows the controls for a large page count instead of listing every page', async () => {
+            // 2000 / 10 => 200 pages: anchors only, the current window, and gaps.
+            const api = buildApi(okEnvelope({ total: 2000, page: 1, per_page: 10, items: [{ id: 1, rating: 5, date: '2026-01-01' }] }));
+            new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);
+            await flush();
+
+            const bottom = document.querySelector('.cs-reviews-pagination--bottom');
+            // First and last anchors present, a mid page collapsed into a gap.
+            expect(bottom.querySelector('[data-reviews-page="1"]')).not.toBeNull();
+            expect(bottom.querySelector('[data-reviews-page="200"]')).not.toBeNull();
+            expect(bottom.querySelector('[data-reviews-page="100"]')).toBeNull();
+            expect(bottom.querySelector('.cs-ugc-page-gap')).not.toBeNull();
+        });
+
         it('paints the same controls into both the top and bottom containers', async () => {
             const api = buildApi(okEnvelope({ total: 25, page: 1, per_page: 10, items: [{ id: 1, rating: 5, date: '2026-01-01' }] }));
             new UgcProduct(ARCHETYPE_ID, buildStateManager(), api);

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -26,6 +26,7 @@
 import ugcApi from './ugcApi';
 import { escapeHtml } from './search/utils';
 import { resolveGarageFitment } from './vehicleFitment';
+import { pageWindow, PAGE_GAP, PAGE_GAP_HTML } from './ugcPagination';
 import {
     starIcons,
     scoreBadge,
@@ -657,9 +658,13 @@ export default class UgcOverview {
         const buttons = [];
         buttons.push(this.pageButton('prev', this.page - 1, this.page <= 1, 'Previous'));
 
-        for (let page = 1; page <= pages; page += 1) {
-            buttons.push(this.pageButton(page, page, false, String(page), page === this.page));
-        }
+        pageWindow(this.page, pages).forEach((item) => {
+            if (item === PAGE_GAP) {
+                buttons.push(PAGE_GAP_HTML);
+                return;
+            }
+            buttons.push(this.pageButton(item, item, false, String(item), item === this.page));
+        });
 
         buttons.push(this.pageButton('next', this.page + 1, this.page >= pages, 'Next'));
 

--- a/assets/js/theme/_addons/global/ugcPagination.js
+++ b/assets/js/theme/_addons/global/ugcPagination.js
@@ -1,0 +1,61 @@
+/**
+ * @file ugcPagination
+ * @description Shared, pure pagination helper for the UGC surfaces — the product
+ * reviews/Q&A lists (ugcProduct.js) and the home overview wall (ugcOverview.js).
+ * Computes which page numbers a control should show so a feed of thousands of
+ * reviews renders a compact windowed control (1 … 7 8 9 10 11 … 200) rather than
+ * one button per page. Pure: numbers in, window out — no DOM.
+ */
+
+// Sentinel marking a collapsed run of hidden pages. Callers render PAGE_GAP_HTML
+// in its place — a non-interactive ellipsis between numbered buttons.
+export const PAGE_GAP = '…';
+
+// The ellipsis stand-in. aria-hidden because it carries no navigation; the
+// prev/next/number buttons are the operable controls. Sized in SCSS
+// (.cs-ugc-page-gap) to line up with the 44px page buttons.
+export const PAGE_GAP_HTML = '<span class="cs-ugc-page-gap" aria-hidden="true">…</span>';
+
+/**
+ * The page numbers to display for `current` within `pageCount`, always anchored
+ * by the first and last page and showing `radius` neighbours either side of the
+ * current page. A run of 2+ hidden pages collapses to a PAGE_GAP sentinel; a lone
+ * hidden page is shown rather than replaced (a gap never saves space over the one
+ * number it would hide).
+ * @param {number} current - 1-indexed current page (clamped into range).
+ * @param {number} pageCount - Total pages (assumed >= 1).
+ * @param {number} [radius] - Neighbours shown either side of current.
+ * @returns {Array<number|string>} Page numbers, with PAGE_GAP marking each gap.
+ */
+export function pageWindow(current, pageCount, radius = 2) {
+    if (pageCount <= 1) {
+        return [1];
+    }
+
+    const cur = Math.min(Math.max(1, current), pageCount);
+    const lo = Math.max(2, cur - radius);
+    const hi = Math.min(pageCount - 1, cur + radius);
+    const items = [1];
+
+    // Left side: nothing when the window reaches page 2, the lone page itself
+    // when exactly one is hidden, otherwise a gap.
+    if (lo === 3) {
+        items.push(2);
+    } else if (lo > 3) {
+        items.push(PAGE_GAP);
+    }
+
+    for (let page = lo; page <= hi; page += 1) {
+        items.push(page);
+    }
+
+    // Right side, mirrored against the last page.
+    if (hi === pageCount - 2) {
+        items.push(pageCount - 1);
+    } else if (hi < pageCount - 2) {
+        items.push(PAGE_GAP);
+    }
+
+    items.push(pageCount);
+    return items;
+}

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -136,6 +136,7 @@ import {
     countryFlag,
     formatReviewDate,
 } from '../../global/ugcCard';
+import { pageWindow, PAGE_GAP, PAGE_GAP_HTML } from '../../global/ugcPagination';
 
 const MAX_STARS = 5;
 
@@ -2215,9 +2216,13 @@ export default class UgcProduct {
 
         buttons.push(this._questionPageButton('prev', current - 1, current <= 1, 'Previous'));
 
-        for (let page = 1; page <= pageCount; page += 1) {
-            buttons.push(this._questionPageButton(page, page, false, String(page), page === current));
-        }
+        pageWindow(current, pageCount).forEach((item) => {
+            if (item === PAGE_GAP) {
+                buttons.push(PAGE_GAP_HTML);
+                return;
+            }
+            buttons.push(this._questionPageButton(item, item, false, String(item), item === current));
+        });
 
         buttons.push(this._questionPageButton('next', current + 1, current >= pageCount, 'Next'));
 
@@ -2327,9 +2332,13 @@ export default class UgcProduct {
 
         buttons.push(this._pageButton('prev', current - 1, current <= 1, 'Previous'));
 
-        for (let page = 1; page <= pageCount; page += 1) {
-            buttons.push(this._pageButton(page, page, false, String(page), page === current));
-        }
+        pageWindow(current, pageCount).forEach((item) => {
+            if (item === PAGE_GAP) {
+                buttons.push(PAGE_GAP_HTML);
+                return;
+            }
+            buttons.push(this._pageButton(item, item, false, String(item), item === current));
+        });
 
         buttons.push(this._pageButton('next', current + 1, current >= pageCount, 'Next'));
 

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -1052,6 +1052,18 @@ $cs-fitment-active-hover: #05a;
   }
 }
 
+// Ellipsis stand-in for a collapsed run of pages in the windowed pagination
+// controls (ugcPagination.js). Shared across reviews, Q&A, and the home wall —
+// sized to the 44px page buttons so the row stays aligned. Not interactive.
+.cs-ugc-page-gap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: spacing('single');
+  height: 44px;
+  color: stencilColor('color-textSecondary');
+}
+
 #product-rating {
   .cs-rating-stars {
     display: inline-flex;


### PR DESCRIPTION
Follow-up to #52. Fixes the unbounded pagination flagged there.

## Problem

All three UGC pagination controls (product reviews, Q&A, home wall) rendered one button per page via `for (page = 1; page <= pageCount)`. With thousands of reviews that's hundreds of 44px buttons wrapping over many rows — rendered both above *and* below the list. At ~10/page, 2,000 reviews = 200 buttons; the home wall aggregates site-wide reviews and is the most exposed.

## Change

New shared pure helper **`ugcPagination.pageWindow(current, pageCount, radius = 2)`** returns the page numbers to display:

- First and last page always anchored.
- `current ± 2` neighbours.
- A run of 2+ hidden pages collapses to a `PAGE_GAP` sentinel; a *lone* hidden page is shown instead (a gap never saves space over the single number it hides).

Example: `pageWindow(9, 200)` → `[1, …, 7, 8, 9, 10, 11, …, 200]`.

All three renderers map the window with their own button markup (unchanged class names / data attributes / aria) plus a shared non-interactive ellipsis span `.cs-ugc-page-gap`, sized to the 44px buttons. Storefront-only — no contract/data change; works off the existing `total` / `page` / `per_page` envelope.

## Tests

- `ugcPagination.spec.js` — pure-function cases (small no-op counts, both gaps, edge omissions, lone-page-instead-of-gap, clamping, custom radius).
- New integration test in `ugcProduct.spec.js` asserts the reviews renderer windows a 200-page count (anchors present, page 100 absent, gap span emitted).
- Small-count scenarios are a no-op, so existing pagination tests are unchanged.

`npx grunt check` green — ESLint, 411 Jest tests, stylelint (197 files).

## Boundary note (cs-ugc, not this PR)

Two items for the contract owner, not blockers for this fix:
1. `per_page` is server-driven — it sets the page *count*. Worth confirming the intended value.
2. Deep offset pagination (page 200) performance at thousands of rows is a cs-ugc-side concern if it ever surfaces.