### PR TITLE
DRY (1/4): lift garage-fitment-from-global-state into a shared helper

### DIFF
--- a/assets/js/test-unit/theme/global/vehicleFitment.spec.js
+++ b/assets/js/test-unit/theme/global/vehicleFitment.spec.js
@@ -2,6 +2,7 @@ import {
     generationLabel,
     generationFitmentId,
     resolveGarageFitment,
+    resolveGarageFitmentFromState,
     fitmentIdToLabel,
     buildArchetypeFitmentList,
     buildArchetypeFitmentTree,
@@ -85,6 +86,31 @@ describe('vehicleFitment', () => {
             const noName = { models: { cooper: { generations: { cooperf56: { fitment_id: 87 } } } } };
             const result = resolveGarageFitment(noName, { make: 'mini', model: 'cooper', generation: 'cooperf56' });
             expect(result).toEqual({ fitment_id: 87, label: 'mini cooper' });
+        });
+    });
+
+    describe('resolveGarageFitmentFromState', () => {
+        it('returns null for null/undefined global state', () => {
+            expect(resolveGarageFitmentFromState(null)).toBeNull();
+            expect(resolveGarageFitmentFromState(undefined)).toBeNull();
+        });
+
+        it('returns null when search.data.vehicle_registry is absent', () => {
+            const globalState = {
+                vehicle: { selected: { make: 'mini', model: 'cooper', generation: 'cooperf56' } },
+                search: { data: {} },
+            };
+            expect(resolveGarageFitmentFromState(globalState)).toBeNull();
+        });
+
+        it('resolves a complete selection to the same shape resolveGarageFitment returns', () => {
+            const garage = { make: 'mini', model: 'cooper', generation: 'cooperf56' };
+            const globalState = {
+                vehicle: { selected: garage },
+                search: { data: { vehicle_registry: registry } },
+            };
+            expect(resolveGarageFitmentFromState(globalState))
+                .toEqual(resolveGarageFitment(registry, garage));
         });
     });
 

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -25,7 +25,7 @@
 
 import ugcApi from './ugcApi';
 import { escapeHtml } from './search/utils';
-import { resolveGarageFitment } from './vehicleFitment';
+import { resolveGarageFitmentFromState } from './vehicleFitment';
 import { pageWindow, PAGE_GAP, PAGE_GAP_HTML } from './ugcPagination';
 import {
     starIcons,
@@ -237,12 +237,7 @@ export default class UgcOverview {
      * @param {Object} [globalState]
      */
     resolveFitmentFromGlobal(globalState) {
-        const vehicle = globalState && globalState.vehicle ? globalState.vehicle.selected : null;
-        const registry = globalState && globalState.search && globalState.search.data
-            ? globalState.search.data.vehicle_registry
-            : null;
-
-        const resolved = resolveGarageFitment(registry, vehicle);
+        const resolved = resolveGarageFitmentFromState(globalState);
         this.fitmentId = resolved ? resolved.fitment_id : null;
         this.fitmentLabel = resolved ? resolved.label : null;
     }

--- a/assets/js/theme/_addons/global/vehicleFitment.js
+++ b/assets/js/theme/_addons/global/vehicleFitment.js
@@ -79,6 +79,25 @@ export function resolveGarageFitment(registry, garage) {
 }
 
 /**
+ * Resolve the garage fitment straight off a GlobalStateManager snapshot. Extracts
+ * the persisted garage selection (`vehicle.selected`) and the search-JSON
+ * `vehicle_registry` (`search.data.vehicle_registry`) defensively, then delegates
+ * to `resolveGarageFitment`. The single source of the global-state → fitment read
+ * shared by the product garage filter and the home overview (SRS §3.4.1).
+ * @param {Object|null} globalState - A GlobalStateManager state snapshot.
+ * @returns {{fitment_id: (number|null), label: string}|null}
+ *   `null` when there is no garage selection or no matching registry path.
+ */
+export function resolveGarageFitmentFromState(globalState) {
+    const vehicle = globalState && globalState.vehicle ? globalState.vehicle.selected : null;
+    const registry = globalState && globalState.search && globalState.search.data
+        ? globalState.search.data.vehicle_registry
+        : null;
+
+    return resolveGarageFitment(registry, vehicle);
+}
+
+/**
  * Find the make (brand) display name for a model slug by reverse-lookup over the
  * registry's `brands` map: each brand's `models` array lists the model slugs it
  * owns. Returns the brand's `name`, or `null` when no brand claims the model.

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -123,7 +123,7 @@
  */
 
 import {
-    resolveGarageFitment,
+    resolveGarageFitmentFromState,
     fitmentIdToLabel,
     buildArchetypeFitmentList,
     buildArchetypeFitmentTree,
@@ -1737,12 +1737,7 @@ export default class UgcProduct {
      * @param {Object} [globalState]
      */
     resolveFitmentFromGlobal(globalState) {
-        const vehicle = globalState && globalState.vehicle ? globalState.vehicle.selected : null;
-        const registry = globalState && globalState.search && globalState.search.data
-            ? globalState.search.data.vehicle_registry
-            : null;
-
-        const resolved = resolveGarageFitment(registry, vehicle);
+        const resolved = resolveGarageFitmentFromState(globalState);
         this.fitmentId = resolved ? resolved.fitment_id : null;
         this.fitmentLabel = resolved ? resolved.label : null;
     }


### PR DESCRIPTION
Step **1/4** of the UGC DRY audit. Storefront-only, **no behavior change**.

Closes #55.

## What

`ugcProduct.js` and `ugcOverview.js` carried a byte-identical `resolveFitmentFromGlobal` body that pulled `vehicle.selected` + `search.data.vehicle_registry` off the global-state snapshot and called `resolveGarageFitment`. Lifted that read into a single pure function and collapsed both methods to assign from it.

## Changes

- **`assets/js/theme/_addons/global/vehicleFitment.js`** — new pure `resolveGarageFitmentFromState(globalState) → { fitment_id, label } | null`. Defensive `&&` extraction (no `??` — repo ESLint crashes on it), delegates to `resolveGarageFitment`, returns its result. JSDoc consistent with the file.
- **`assets/js/theme/_addons/product/ui/ugcProduct.js`** — import swapped `resolveGarageFitment` → `resolveGarageFitmentFromState`; `resolveFitmentFromGlobal` collapsed to a one-liner. JSDoc unchanged ("WITHOUT refetching… seed state"). `subscribeGlobalFitment` / `onGlobalFitmentChange` untouched.
- **`assets/js/theme/_addons/global/ugcOverview.js`** — same swap and collapse. JSDoc unchanged ("without re-rendering"). `subscribeGlobalFitment` / `onGlobalFitmentChange` untouched.
- **`assets/js/test-unit/theme/global/vehicleFitment.spec.js`** — new `resolveGarageFitmentFromState` describe: null/undefined state, missing `search.data.vehicle_registry`, and a resolvable selection asserted equal to what `resolveGarageFitment` returns.

The divergent template-method tail (`onGlobalFitmentChange`: home re-renders client-side, product refetches) is left per-class as the issue directs.

`resolveGarageFitment` is no longer referenced directly in either consumer (verified via grep) and was dropped from both imports.

## Verification

`npx grunt check` green: ESLint + stylelint clean, Jest **414 passed / 22 suites** — including the new resolver tests and the unchanged ugcProduct/ugcOverview suites.