### PR TITLE
DRY: consolidate UGC vehicleBadge primitive + drop dead wrappers (#57)

### DIFF
--- a/assets/js/test-unit/theme/global/ugcCard.spec.js
+++ b/assets/js/test-unit/theme/global/ugcCard.spec.js
@@ -6,6 +6,7 @@ import {
     editedBadge,
     countryFlag,
     formatReviewDate,
+    vehicleBadge,
 } from '../../../theme/_addons/global/ugcCard';
 
 const countOf = (html, needle) => html.split(needle).length - 1;
@@ -71,6 +72,46 @@ describe('ugcCard shared primitives', () => {
             expect(formatReviewDate('')).toBe('');
             expect(formatReviewDate(null)).toBe('');
             expect(formatReviewDate('not-a-date')).toBe('');
+        });
+    });
+
+    describe('vehicleBadge', () => {
+        it('renders a static <p> with the modifier and escaped label by default', () => {
+            const html = vehicleBadge('MINI Cooper F56', { modifier: 'cs-ugc-overview-vehicle' });
+            expect(html).toContain('<p class="cs-ugc-vehicle-badge cs-ugc-overview-vehicle">');
+            expect(html).toContain('MINI Cooper F56');
+            expect(html).not.toContain('<button');
+            expect(html).not.toContain('data-fitment-filter');
+        });
+
+        it('renders a clickable <button> with filter data for a positive fitmentId', () => {
+            const html = vehicleBadge('MINI Cooper F56', {
+                modifier: 'cs-review-vehicle', fitmentId: 42, clickable: true,
+            });
+            expect(html).toContain('<button type="button"');
+            expect(html).toContain('data-fitment-filter="42"');
+            expect(html).toContain('data-fitment-label="MINI Cooper F56"');
+        });
+
+        it('falls back to a static <p> when clickable but the fitmentId is missing or not positive', () => {
+            expect(vehicleBadge('MINI Cooper F56', { clickable: true, fitmentId: null })).toContain('<p');
+            expect(vehicleBadge('MINI Cooper F56', { clickable: true, fitmentId: 0 })).toContain('<p');
+            expect(vehicleBadge('MINI Cooper F56', { clickable: true, fitmentId: -1 })).toContain('<p');
+            expect(vehicleBadge('MINI Cooper F56', { clickable: true, fitmentId: 'nope' })).toContain('<p');
+        });
+
+        it('returns empty for a null / undefined / empty label', () => {
+            expect(vehicleBadge(null)).toBe('');
+            expect(vehicleBadge(undefined)).toBe('');
+            expect(vehicleBadge('')).toBe('');
+        });
+
+        it('escapes the label internally (no XSS via vehicle_label)', () => {
+            const html = vehicleBadge('<img src=x onerror=alert(1)>', {
+                fitmentId: 7, clickable: true,
+            });
+            expect(html).not.toContain('<img');
+            expect(html).toContain('&lt;img');
         });
     });
 });

--- a/assets/js/test-unit/theme/global/ugcOverview.spec.js
+++ b/assets/js/test-unit/theme/global/ugcOverview.spec.js
@@ -1,6 +1,4 @@
 import UgcOverview, {
-    buildStarIcons,
-    buildVehicleBadge,
     paginate,
     pageCount,
 } from '../../../theme/_addons/global/ugcOverview';
@@ -62,43 +60,6 @@ describe('ugcOverview pure helpers', () => {
 
         it('is at least 1 even when empty', () => {
             expect(pageCount(0)).toBe(1);
-        });
-    });
-
-    describe('buildVehicleBadge', () => {
-        it('renders the system-generated vehicle_label inside the badge', () => {
-            const html = buildVehicleBadge('MINI Cooper F56');
-            expect(html).toContain('cs-ugc-vehicle-badge');
-            expect(html).toContain('MINI Cooper F56');
-        });
-
-        it('escapes the label (no XSS via vehicle_label)', () => {
-            const html = buildVehicleBadge('<img src=x onerror=alert(1)>');
-            expect(html).not.toContain('<img');
-            expect(html).toContain('&lt;img');
-        });
-
-        it('omits the badge entirely when there is no vehicle (null / empty / missing)', () => {
-            expect(buildVehicleBadge(null)).toBe('');
-            expect(buildVehicleBadge(undefined)).toBe('');
-            expect(buildVehicleBadge('')).toBe('');
-        });
-    });
-
-    describe('buildStarIcons', () => {
-        const countOf = (html, needle) => html.split(needle).length - 1;
-
-        it('renders five sprite stars split by rating', () => {
-            const html = buildStarIcons(3);
-            expect(countOf(html, '#icon-star')).toBe(5);
-            expect(countOf(html, 'icon--ratingFull')).toBe(3);
-            expect(countOf(html, 'icon--ratingEmpty')).toBe(2);
-        });
-
-        it('renders all empty stars for a zero rating', () => {
-            const html = buildStarIcons(0);
-            expect(countOf(html, 'icon--ratingFull')).toBe(0);
-            expect(countOf(html, 'icon--ratingEmpty')).toBe(5);
         });
     });
 });

--- a/assets/js/theme/_addons/global/ugcApi.js
+++ b/assets/js/theme/_addons/global/ugcApi.js
@@ -102,6 +102,18 @@ export class UgcApi {
     }
 
     /**
+     * The §3.6 fallback result for a network/transport failure (the fetch itself
+     * rejected — no HTTP status to branch on). Shared by `get` and `post`.
+     * @param {Error} error
+     * @returns {Object}
+     */
+    _networkError(error) {
+        return {
+            ok: false, status: 0, message: MESSAGES.generic, error: error.message,
+        };
+    }
+
+    /**
      * Issue a GET, de-duping identical concurrent requests. Resolves to the
      * normalized result shape; network/parse failures resolve as ok:false too.
      * @param {string} path - Path under the API base, e.g. '/reviews/12'.
@@ -118,9 +130,7 @@ export class UgcApi {
                 const response = await this.fetch(url, { cache: 'no-cache' });
                 return await this.handleResponse(response);
             } catch (error) {
-                return {
-                    ok: false, status: 0, message: MESSAGES.generic, error: error.message,
-                };
+                return this._networkError(error);
             } finally {
                 this.pendingRequests.delete(url);
             }
@@ -147,9 +157,7 @@ export class UgcApi {
             });
             return await this.handleResponse(response);
         } catch (error) {
-            return {
-                ok: false, status: 0, message: MESSAGES.generic, error: error.message,
-            };
+            return this._networkError(error);
         }
     }
 

--- a/assets/js/theme/_addons/global/ugcCard.js
+++ b/assets/js/theme/_addons/global/ugcCard.js
@@ -9,8 +9,12 @@
  *
  * None of these escape free-text: star/score/verified/edited render fixed markup
  * or numbers, the country code is validated to `[a-z]{2}` before interpolation,
- * and the date is machine-formatted. Callers escape any free-text upstream.
+ * and the date is machine-formatted. Callers escape any free-text upstream. The
+ * exception is `vehicleBadge`, which takes a free-text `label` and escapes it
+ * internally (both its text and attribute contexts).
  */
+
+import { escapeHtml } from './search/utils';
 
 export const MAX_STARS = 5;
 
@@ -110,4 +114,38 @@ export function formatReviewDate(value) {
         month: '2-digit',
         day: '2-digit',
     });
+}
+
+/**
+ * The structured-vehicle badge from a review's/question's system-generated
+ * `vehicle_label` (SRS §3.2.4 — e.g. "MINI Cooper F56 2014 to 2024"). A null /
+ * empty label renders nothing (no empty element to reserve space for), so a
+ * universal product or an opted-out submitter simply has no badge.
+ *
+ * Unlike the sibling primitives, the label is free text, so it is escaped here:
+ * `escapeHtml` covers `& < > " '`, making the single escaped value safe for both
+ * the text content and the `data-fitment-label` attribute.
+ *
+ * When `clickable` is set and `fitmentId` resolves to a positive integer, the
+ * badge is a `<button data-fitment-filter>` that drives the click-to-filter
+ * interaction (issue #45); otherwise it is a static `<p>`.
+ * @param {string|null|undefined} label - The system-generated `vehicle_label`.
+ * @param {Object} [options]
+ * @param {string} [options.modifier] - Surface-specific class (e.g. cs-review-vehicle).
+ * @param {number|string|null} [options.fitmentId] - The item's `fitment_id`.
+ * @param {boolean} [options.clickable] - Whether the badge filters on click.
+ * @returns {string}
+ */
+export function vehicleBadge(label, { modifier = '', fitmentId = null, clickable = false } = {}) {
+    if (!label) {
+        return '';
+    }
+
+    const safe = escapeHtml(label);
+    const id = parseInt(fitmentId, 10);
+    if (clickable && Number.isInteger(id) && id > 0) {
+        return `<button type="button" class="cs-ugc-vehicle-badge ${modifier}" data-fitment-filter="${id}" data-fitment-label="${safe}">${safe}</button>`;
+    }
+
+    return `<p class="cs-ugc-vehicle-badge ${modifier}">${safe}</p>`;
 }

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -34,6 +34,7 @@ import {
     editedBadge,
     countryFlag,
     formatReviewDate,
+    vehicleBadge,
     MAX_STARS,
 } from './ugcCard';
 
@@ -76,38 +77,6 @@ function reviewRating(review) {
  */
 function hasMedia(review) {
     return Array.isArray(review.media) && review.media.length > 0;
-}
-
-/**
- * Build the 5-star strip from the shared icon sprite — the same
- * icon--ratingFull / icon--ratingEmpty + #icon-star markup the product page
- * renders (ugcProduct.js), so stars look identical on both surfaces. The
- * sprite is injected unconditionally in layout/base.html, so #icon-star is
- * available on the home page.
- * @param {number} rating - Whole stars, 0-5.
- * @returns {string}
- */
-export function buildStarIcons(rating) {
-    return starIcons(rating);
-}
-
-/**
- * Build the structured-vehicle badge from a review's system-generated
- * `vehicle_label` (cs-ugc SRS §3.4.2 / §3.2.1 — the display label the storefront
- * resolved at submit, e.g. "MINI Cooper F56"). Display-only on the home wall in
- * v1; garage-aware filtering of the wall is deferred to v1.1. A review with no
- * vehicle (universal product, or the submitter opted out) carries a `null` /
- * absent label — the badge is then omitted entirely (not an empty element), so
- * there is nothing to reserve space for.
- * @param {string|null|undefined} label
- * @returns {string}
- */
-export function buildVehicleBadge(label) {
-    if (!label) {
-        return '';
-    }
-
-    return `<p class="cs-ugc-vehicle-badge cs-ugc-overview-vehicle">${escapeHtml(label)}</p>`;
 }
 
 /**
@@ -609,7 +578,7 @@ export default class UgcOverview {
                 ${scoreBadge(rating)}
             </div>
             ${title ? `<h3 class="cs-ugc-overview-title">${title}</h3>` : ''}
-            ${buildVehicleBadge(review.vehicle_label)}
+            ${vehicleBadge(review.vehicle_label, { modifier: 'cs-ugc-overview-vehicle' })}
             <p class="cs-ugc-overview-text">${body}</p>
             <p class="cs-ugc-overview-meta">
                 <span class="cs-ugc-overview-author">${author}</span>

--- a/assets/js/theme/_addons/global/vehicleFitment.js
+++ b/assets/js/theme/_addons/global/vehicleFitment.js
@@ -39,6 +39,18 @@ export function generationFitmentId(node) {
 }
 
 /**
+ * Compose the canonical `vehicle_label` from its make/model/generation parts —
+ * the SRS §3.2.4 rule: node names joined by single spaces, with empty parts
+ * dropped. The single source of the full-label join shared by `fitmentIdToLabel`
+ * and `buildArchetypeFitmentList`.
+ * @param {Array<string|null|undefined>} parts
+ * @returns {string}
+ */
+export function composeVehicleLabel(parts) {
+    return parts.filter(Boolean).join(' ');
+}
+
+/**
  * Resolve the visitor's garage selection to its fitment identity from the search
  * JSON's `vehicle_registry`. The registry's `models` map is keyed by bare model
  * slug and each model's `generations` map by bare generation slug — the same
@@ -147,9 +159,7 @@ export function fitmentIdToLabel(registry, fitmentId) {
                     const makeName = makeNameForModel(registry, modelSlug);
                     const modelName = model.name || modelSlug;
                     const genName = generationLabel(node);
-                    return [makeName, modelName, genName]
-                        .filter(part => part)
-                        .join(' ');
+                    return composeVehicleLabel([makeName, modelName, genName]);
                 }
             }
         }
@@ -211,7 +221,7 @@ export function buildArchetypeFitmentList(archetypeData) {
                             makeLabel,
                             modelLabel,
                             generationLabel: genLabel,
-                            label: `${makeLabel} ${modelLabel} ${genLabel}`,
+                            label: composeVehicleLabel([makeLabel, modelLabel, genLabel]),
                             fitment_id: generationFitmentId(genNode),
                         });
                     }

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -135,6 +135,7 @@ import {
     editedBadge,
     countryFlag,
     formatReviewDate,
+    vehicleBadge,
 } from '../../global/ugcCard';
 import { pageWindow, PAGE_GAP, PAGE_GAP_HTML } from '../../global/ugcPagination';
 
@@ -2258,7 +2259,7 @@ export default class UgcProduct {
     _buildQuestion(question) {
         const author = this._escape(question.author) || MESSAGES.anonymous;
         const body = this._escape(question.body);
-        const date = this._formatDate(question.date);
+        const date = formatReviewDate(question.date);
         const answerAuthor = this._escape(question.staff_answer_author) || 'CravenSpeed';
         const answer = question.staff_answer
             ? `<div class="cs-question-answer"><strong>${answerAuthor}:</strong> ${this._escape(question.staff_answer)}</div>`
@@ -2270,7 +2271,7 @@ export default class UgcProduct {
                     <span class="cs-question-author">${author}</span>
                     ${date ? `<span class="cs-question-date">${date}</span>` : ''}
                 </p>
-                ${this._vehicleBadge(question.vehicle_label, question.fitment_id, 'cs-question-vehicle')}
+                ${vehicleBadge(question.vehicle_label, { modifier: 'cs-question-vehicle', fitmentId: question.fitment_id, clickable: true })}
                 <p class="cs-question-body">${body}</p>
                 ${answer}
             </article>`;
@@ -2970,53 +2971,11 @@ export default class UgcProduct {
         return count === 1 ? '1 review' : `${count} reviews`;
     }
 
-    /**
-     * Build a structured-vehicle badge (issue #45). When `clickable` and the
-     * item carries a positive `fitment_id`, it renders a `<button>` that filters
-     * the list to that vehicle on click; otherwise a static `<p>` (the SRS
-     * guarantees `vehicle_label` is null whenever `fitment_id` is, so that branch
-     * is also the defensive fallback). Empty string when there is no vehicle
-     * label. The lightbox review passes `clickable=false` — there is no list to
-     * filter from inside the media modal.
-     * @param {string} rawLabel - The item's `vehicle_label` (unescaped).
-     * @param {number|string} fitmentId - The item's `fitment_id`.
-     * @param {string} modifier - The card-specific class (cs-review-vehicle / cs-question-vehicle).
-     * @param {boolean} [clickable] - Whether the badge filters on click.
-     * @returns {string}
-     */
-    _vehicleBadge(rawLabel, fitmentId, modifier, clickable = true) {
-        const label = this._escape(rawLabel);
-        if (!label) {
-            return '';
-        }
-
-        const id = parseInt(fitmentId, 10);
-        if (clickable && Number.isInteger(id) && id > 0) {
-            return `<button type="button" class="cs-ugc-vehicle-badge ${modifier}" data-fitment-filter="${id}" data-fitment-label="${this._escapeAttr(rawLabel)}">${label}</button>`;
-        }
-
-        return `<p class="cs-ugc-vehicle-badge ${modifier}">${label}</p>`;
-    }
-
-    /**
-     * Render a small country flag from the review's ISO-3166 alpha-2 `country`
-     * (SRS §3.2.1, derived server-side from the submission IP; null on imported
-     * or un-geolocated rows). Served as SVG from flagcdn.com and lazy-loaded.
-     * Returns '' when there is no valid two-letter code, so older reviews simply
-     * show no flag. The code is validated to `[a-z]{2}`, so it is safe to
-     * interpolate into the URL/alt without further escaping.
-     * @param {string} code - The review's `country`.
-     * @returns {string}
-     */
-    _countryFlag(code) {
-        return countryFlag(code);
-    }
-
     _buildReview(review, includeMedia = true, clickableVehicle = true) {
         const author = this._escape(review.author) || MESSAGES.anonymous;
         const title = this._escape(review.title);
         const body = this._escape(review.body);
-        const date = this._formatDate(review.date);
+        const date = formatReviewDate(review.date);
         const verified = verifiedBadge(review.verified_purchaser);
         // Public disclosure that staff edited this review's content (SRS §3.2.1
         // `edited` / §3.1.1, cs-ugc #145). Strict `=== true` so a missing field
@@ -3041,19 +3000,15 @@ export default class UgcProduct {
                 </div>
                 <p class="cs-review-meta">
                     <span class="cs-review-author">${author}</span>
-                    ${this._countryFlag(review.country)}
+                    ${countryFlag(review.country)}
                     ${verified}
                     ${edited}
                 </p>
-                ${this._vehicleBadge(review.vehicle_label, review.fitment_id, 'cs-review-vehicle', clickableVehicle)}
+                ${vehicleBadge(review.vehicle_label, { modifier: 'cs-review-vehicle', fitmentId: review.fitment_id, clickable: clickableVehicle })}
                 <p class="cs-review-body">${body}</p>
                 ${media}
                 ${staff}
             </article>`;
-    }
-
-    _formatDate(value) {
-        return formatReviewDate(value);
     }
 
     _escape(value) {


### PR DESCRIPTION
Step **2/4** of the UGC DRY audit. Storefront-only, **no behavior change** — every rendered fragment is byte-identical to the prior implementations. Closes #57 (manual close on merge into the integration branch, as these PRs target `cs-ugc-frontend` not `master`).

## Acceptance criteria

### 1. Vehicle badge → the missing `ugcCard.js` primitive
- [x] Added `vehicleBadge(label, { modifier, fitmentId, clickable })` to `ugcCard.js` (`assets/js/theme/_addons/global/ugcCard.js:116`) beside the sibling badge primitives.
- [x] Escapes its free-text `label` internally via `escapeHtml` (covers `& < > " '`) — equivalent to product's old `_escape` (text) + `_escapeAttr` (attr) split. In element text, also escaping quotes renders identically; for `data-fitment-label`, `escapeHtml` covers `"` and `'`.
- [x] Kept the #45 clickable `<button data-fitment-filter>` branch; static `<p>` otherwise; `''` for a null/empty label.
- [x] File-header note amended to flag `vehicleBadge` as the escaping exception; JSDoc documents `clickable` and the null-label behavior.
- [x] Both surfaces consume it; both duplicate implementations deleted — `ugcProduct.js` `_vehicleBadge` and `ugcOverview.js` `buildVehicleBadge`.

### 2. Dead pass-through wrappers removed
- [x] `ugcOverview.js` `buildStarIcons` — was already dead (wall renders via `starIcons` directly); export deleted.
- [x] `ugcProduct.js` `_countryFlag` → inlined to `countryFlag` at its one call site; method deleted.
- [x] `ugcProduct.js` `_formatDate` → inlined to `formatReviewDate` at both call sites (question + review); method deleted.

### 3. Minor nits
- [x] `vehicleFitment.js` `composeVehicleLabel(parts)` (`filter(Boolean).join(' ')`, SRS §3.2.4) added and used in `fitmentIdToLabel` and `buildArchetypeFitmentList`. `resolveGarageFitment`'s 2-part make+model label left untouched.
- [x] `ugcApi.js` `_networkError(error)` helper dedupes the identical `get`/`post` catch-block fallback.

## Tests
- [x] `ugcCard.spec.js` — new `vehicleBadge` describe: static `<p>`, clickable `<button>` with positive `fitmentId` (asserts `data-fitment-filter` + `data-fitment-label`), non-positive/missing fitment falls back to `<p>`, null/undefined/`''` label → `''`, XSS escape.
- [x] `ugcOverview.spec.js` — removed the `buildVehicleBadge` / `buildStarIcons` describes and their import entries (coverage moved to `ugcCard.spec.js` / already covered by `starIcons`); all other overview tests unchanged.
- [x] `npx grunt check` green: ESLint + 414 Jest tests (22 suites) + stylelint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)