### PR TITLE
DRY: shared UGC pagination renderer + hide-pagination helper + SCSS placeholders (#54)

### DIFF
--- a/assets/js/test-unit/theme/global/ugcPagination.spec.js
+++ b/assets/js/test-unit/theme/global/ugcPagination.spec.js
@@ -1,4 +1,10 @@
-import { pageWindow, PAGE_GAP } from '../../../theme/_addons/global/ugcPagination';
+import {
+    pageWindow,
+    PAGE_GAP,
+    PAGE_GAP_HTML,
+    pageButton,
+    renderPaginationNav,
+} from '../../../theme/_addons/global/ugcPagination';
 
 describe('ugcPagination.pageWindow', () => {
     it('lists every page when the count is small enough to fit', () => {
@@ -36,5 +42,102 @@ describe('ugcPagination.pageWindow', () => {
 
     it('honours a custom radius', () => {
         expect(pageWindow(10, 200, 1)).toEqual([1, PAGE_GAP, 9, 10, 11, PAGE_GAP, 200]);
+    });
+});
+
+describe('ugcPagination.pageButton', () => {
+    it('wires the class, data attribute, key, and label', () => {
+        const html = pageButton({
+            key: 3,
+            page: 3,
+            label: '3',
+            pageClass: 'cs-reviews-page',
+            dataAttr: 'data-reviews-page',
+        });
+        expect(html).toBe('<button type="button" class="cs-reviews-page" data-reviews-page="3" data-page-key="3">3</button>');
+    });
+
+    it('adds is-current and aria-current for the current page', () => {
+        const html = pageButton({
+            key: 2,
+            page: 2,
+            label: '2',
+            isCurrent: true,
+            pageClass: 'cs-questions-page',
+            dataAttr: 'data-questions-page',
+        });
+        expect(html).toBe('<button type="button" class="cs-questions-page is-current" data-questions-page="2" data-page-key="2" aria-current="page">2</button>');
+    });
+
+    it('renders the disabled attribute when disabled', () => {
+        const html = pageButton({
+            key: 'prev',
+            page: 0,
+            label: 'Previous',
+            disabled: true,
+            pageClass: 'cs-ugc-overview-page',
+            dataAttr: 'data-ugc-page',
+        });
+        expect(html).toBe('<button type="button" class="cs-ugc-overview-page" data-ugc-page="0" data-page-key="prev" disabled>Previous</button>');
+    });
+});
+
+describe('ugcPagination.renderPaginationNav', () => {
+    it('renders nothing when a single page covers everything', () => {
+        expect(renderPaginationNav({
+            current: 1,
+            pageCount: 1,
+            pageClass: 'cs-reviews-page',
+            dataAttr: 'data-reviews-page',
+            navClass: 'cs-reviews-pages',
+            ariaLabel: 'Reviews pagination, top of list',
+        })).toBe('');
+    });
+
+    it('emits prev, windowed numbers with gaps, and next inside the nav', () => {
+        const html = renderPaginationNav({
+            current: 9,
+            pageCount: 200,
+            pageClass: 'cs-reviews-page',
+            dataAttr: 'data-reviews-page',
+            navClass: 'cs-reviews-pages',
+            ariaLabel: 'Reviews pagination, bottom of list',
+        });
+
+        const container = document.createElement('div');
+        container.innerHTML = html;
+        const nav = container.firstElementChild;
+
+        expect(nav.tagName).toBe('NAV');
+        expect(nav.className).toBe('cs-reviews-pages');
+        expect(nav.getAttribute('aria-label')).toBe('Reviews pagination, bottom of list');
+
+        const buttons = Array.from(nav.querySelectorAll('button')).map(b => b.textContent);
+        // prev + windowed numbers (gaps are non-button spans) + next.
+        expect(buttons).toEqual(['Previous', '1', '7', '8', '9', '10', '11', '200', 'Next']);
+
+        // Two collapsed runs render as the shared ellipsis stand-in.
+        expect(nav.innerHTML).toContain(PAGE_GAP_HTML);
+        expect(nav.querySelectorAll('.cs-ugc-page-gap').length).toBe(2);
+
+        // Current page carries the marker; the boundary buttons are disabled at
+        // the right edges only when appropriate (here neither).
+        expect(nav.querySelector('.is-current').textContent).toBe('9');
+        expect(nav.querySelector('[data-page-key="prev"]').disabled).toBe(false);
+    });
+
+    it('disables prev on the first page and next on the last', () => {
+        const first = renderPaginationNav({
+            current: 1,
+            pageCount: 5,
+            pageClass: 'cs-questions-page',
+            dataAttr: 'data-questions-page',
+            navClass: 'cs-questions-pages',
+            ariaLabel: 'Questions pagination, top of list',
+        });
+        const container = document.createElement('div');
+        container.innerHTML = first;
+        expect(container.querySelector('[data-page-key="prev"]').disabled).toBe(true);
+        expect(container.querySelector('[data-page-key="next"]').disabled).toBe(false);
     });
 });

--- a/assets/js/theme/_addons/global/ugcOverview.js
+++ b/assets/js/theme/_addons/global/ugcOverview.js
@@ -26,7 +26,7 @@
 import ugcApi from './ugcApi';
 import { escapeHtml } from './search/utils';
 import { resolveGarageFitmentFromState } from './vehicleFitment';
-import { pageWindow, PAGE_GAP, PAGE_GAP_HTML } from './ugcPagination';
+import { renderPaginationNav } from './ugcPagination';
 import {
     starIcons,
     scoreBadge,
@@ -616,42 +616,16 @@ export default class UgcOverview {
     }
 
     buildPagination(total, position) {
-        const pages = pageCount(total);
-        if (pages <= 1) return '';
-
-        const buttons = [];
-        buttons.push(this.pageButton('prev', this.page - 1, this.page <= 1, 'Previous'));
-
-        pageWindow(this.page, pages).forEach((item) => {
-            if (item === PAGE_GAP) {
-                buttons.push(PAGE_GAP_HTML);
-                return;
-            }
-            buttons.push(this.pageButton(item, item, false, String(item), item === this.page));
-        });
-
-        buttons.push(this.pageButton('next', this.page + 1, this.page >= pages, 'Next'));
-
         // Distinct accessible names per landmark (axe landmark-unique) — the two
         // navs are otherwise identical.
-        return `<nav class="cs-ugc-overview-pagination cs-ugc-overview-pagination--${position}" aria-label="Reviews pagination, ${position} of wall">${buttons.join('')}</nav>`;
-    }
-
-    /**
-     * A single numbered/prev/next page button, matching the product module's
-     * `.cs-reviews-page` treatment (44px target, is-current/aria-current).
-     * @param {string|number} key - Stable key for the slot (prev/next/page no.).
-     * @param {number} page - The page the button targets.
-     * @param {boolean} disabled
-     * @param {string} label
-     * @param {boolean} [isCurrent]
-     * @returns {string}
-     */
-    pageButton(key, page, disabled, label, isCurrent = false) {
-        const current = isCurrent ? ' is-current' : '';
-        const aria = isCurrent ? ' aria-current="page"' : '';
-        const disabledAttr = disabled ? ' disabled' : '';
-        return `<button type="button" class="cs-ugc-overview-page${current}" data-ugc-page="${page}" data-page-key="${key}"${aria}${disabledAttr}>${label}</button>`;
+        return renderPaginationNav({
+            current: this.page,
+            pageCount: pageCount(total),
+            pageClass: 'cs-ugc-overview-page',
+            dataAttr: 'data-ugc-page',
+            navClass: `cs-ugc-overview-pagination cs-ugc-overview-pagination--${position}`,
+            ariaLabel: `Reviews pagination, ${position} of wall`,
+        });
     }
 
     /**

--- a/assets/js/theme/_addons/global/ugcPagination.js
+++ b/assets/js/theme/_addons/global/ugcPagination.js
@@ -59,3 +59,71 @@ export function pageWindow(current, pageCount, radius = 2) {
     items.push(pageCount);
     return items;
 }
+
+/**
+ * One numbered/prev/next page button. The class and `data-*-page` attribute are
+ * supplied by the caller so the same markup serves the reviews, Q&A, and home
+ * wall controls (which differ only in those two tokens).
+ * @param {Object} opts
+ * @param {string|number} opts.key - Stable slot key (prev/next/page number).
+ * @param {number} opts.page - The page the button targets.
+ * @param {string} opts.label - Visible button text.
+ * @param {boolean} [opts.disabled] - Renders the `disabled` attribute.
+ * @param {boolean} [opts.isCurrent] - Adds `is-current` + `aria-current="page"`.
+ * @param {string} opts.pageClass - Base class for the button.
+ * @param {string} opts.dataAttr - The `data-*-page` attribute name.
+ * @returns {string}
+ */
+export function pageButton({
+    key, page, label, disabled = false, isCurrent = false, pageClass, dataAttr,
+}) {
+    const current = isCurrent ? ' is-current' : '';
+    const aria = isCurrent ? ' aria-current="page"' : '';
+    const disabledAttr = disabled ? ' disabled' : '';
+    return `<button type="button" class="${pageClass}${current}" ${dataAttr}="${page}" data-page-key="${key}"${aria}${disabledAttr}>${label}</button>`;
+}
+
+/**
+ * The full windowed pagination `<nav>` for a control: a Previous button, the
+ * `pageWindow` numbers (gaps rendered as PAGE_GAP_HTML), and a Next button.
+ * Returns '' when a single page covers everything, so callers can treat the
+ * empty string as "nothing to show". The divergent per-surface wrapper details
+ * — dual class names, "of list" vs "of wall" scope, top/bottom position — are
+ * pre-resolved by the caller into `navClass` and `ariaLabel`.
+ * @param {Object} opts
+ * @param {number} opts.current - 1-indexed current page.
+ * @param {number} opts.pageCount - Total pages.
+ * @param {string} opts.pageClass - Base class passed through to each button.
+ * @param {string} opts.dataAttr - The `data-*-page` attribute name.
+ * @param {string} opts.navClass - Class(es) for the wrapping `<nav>`.
+ * @param {string} opts.ariaLabel - Accessible name for the `<nav>` landmark.
+ * @returns {string} Nav HTML, or '' when `pageCount <= 1`.
+ */
+export function renderPaginationNav({
+    current, pageCount, pageClass, dataAttr, navClass, ariaLabel,
+}) {
+    if (pageCount <= 1) {
+        return '';
+    }
+
+    const buttons = [];
+    buttons.push(pageButton({
+        key: 'prev', page: current - 1, label: 'Previous', disabled: current <= 1, pageClass, dataAttr,
+    }));
+
+    pageWindow(current, pageCount).forEach((item) => {
+        if (item === PAGE_GAP) {
+            buttons.push(PAGE_GAP_HTML);
+            return;
+        }
+        buttons.push(pageButton({
+            key: item, page: item, label: String(item), isCurrent: item === current, pageClass, dataAttr,
+        }));
+    });
+
+    buttons.push(pageButton({
+        key: 'next', page: current + 1, label: 'Next', disabled: current >= pageCount, pageClass, dataAttr,
+    }));
+
+    return `<nav class="${navClass}" aria-label="${ariaLabel}">${buttons.join('')}</nav>`;
+}

--- a/assets/js/theme/_addons/product/ui/ugcProduct.js
+++ b/assets/js/theme/_addons/product/ui/ugcProduct.js
@@ -137,7 +137,7 @@ import {
     formatReviewDate,
     vehicleBadge,
 } from '../../global/ugcCard';
-import { pageWindow, PAGE_GAP, PAGE_GAP_HTML } from '../../global/ugcPagination';
+import { renderPaginationNav } from '../../global/ugcPagination';
 
 const MAX_STARS = 5;
 
@@ -2200,42 +2200,26 @@ export default class UgcProduct {
             : 0;
 
         if (pageCount <= 1) {
-            this.questionsPaginationElements.forEach((el) => {
-                el.innerHTML = '';
-                el.style.visibility = 'hidden';
-            });
+            this._hidePagination(this.questionsPaginationElements);
             return;
         }
 
         const current = this.questionQuery.page;
-        const buttons = [];
-
-        buttons.push(this._questionPageButton('prev', current - 1, current <= 1, 'Previous'));
-
-        pageWindow(current, pageCount).forEach((item) => {
-            if (item === PAGE_GAP) {
-                buttons.push(PAGE_GAP_HTML);
-                return;
-            }
-            buttons.push(this._questionPageButton(item, item, false, String(item), item === current));
-        });
-
-        buttons.push(this._questionPageButton('next', current + 1, current >= pageCount, 'Next'));
 
         // Distinct accessible names per landmark (axe landmark-unique) — the two
         // navs are otherwise identical.
         this.questionsPaginationElements.forEach((el) => {
             const position = el.classList.contains('cs-questions-pagination--top') ? 'top' : 'bottom';
-            el.innerHTML = `<nav class="cs-questions-pages" aria-label="Questions pagination, ${position} of list">${buttons.join('')}</nav>`;
+            el.innerHTML = renderPaginationNav({
+                current,
+                pageCount,
+                pageClass: 'cs-questions-page',
+                dataAttr: 'data-questions-page',
+                navClass: 'cs-questions-pages',
+                ariaLabel: `Questions pagination, ${position} of list`,
+            });
             el.style.visibility = 'visible';
         });
-    }
-
-    _questionPageButton(key, page, disabled, label, isCurrent = false) {
-        const current = isCurrent ? ' is-current' : '';
-        const aria = isCurrent ? ' aria-current="page"' : '';
-        const disabledAttr = disabled ? ' disabled' : '';
-        return `<button type="button" class="cs-questions-page${current}" data-questions-page="${page}" data-page-key="${key}"${aria}${disabledAttr}>${label}</button>`;
     }
 
     renderQuestionsError() {
@@ -2243,10 +2227,7 @@ export default class UgcProduct {
             this.questionsElement.innerHTML = `<p class="cs-questions-error">${MESSAGES.questionsError}</p>`;
         }
 
-        this.questionsPaginationElements.forEach((el) => {
-            el.innerHTML = '';
-            el.style.visibility = 'hidden';
-        });
+        this._hidePagination(this.questionsPaginationElements);
     }
 
     /**
@@ -2316,42 +2297,33 @@ export default class UgcProduct {
         const pageCount = this.perPage > 0 ? Math.ceil(this.total / this.perPage) : 0;
 
         if (pageCount <= 1) {
-            this.paginationElements.forEach((el) => {
-                el.innerHTML = '';
-                el.style.visibility = 'hidden';
-            });
+            this._hidePagination(this.paginationElements);
             return;
         }
 
         const current = this.query.page;
-        const buttons = [];
-
-        buttons.push(this._pageButton('prev', current - 1, current <= 1, 'Previous'));
-
-        pageWindow(current, pageCount).forEach((item) => {
-            if (item === PAGE_GAP) {
-                buttons.push(PAGE_GAP_HTML);
-                return;
-            }
-            buttons.push(this._pageButton(item, item, false, String(item), item === current));
-        });
-
-        buttons.push(this._pageButton('next', current + 1, current >= pageCount, 'Next'));
 
         // Distinct accessible names per landmark (axe landmark-unique) — the two
         // navs are otherwise identical.
         this.paginationElements.forEach((el) => {
             const position = el.classList.contains('cs-reviews-pagination--top') ? 'top' : 'bottom';
-            el.innerHTML = `<nav class="cs-reviews-pages" aria-label="Reviews pagination, ${position} of list">${buttons.join('')}</nav>`;
+            el.innerHTML = renderPaginationNav({
+                current,
+                pageCount,
+                pageClass: 'cs-reviews-page',
+                dataAttr: 'data-reviews-page',
+                navClass: 'cs-reviews-pages',
+                ariaLabel: `Reviews pagination, ${position} of list`,
+            });
             el.style.visibility = 'visible';
         });
     }
 
-    _pageButton(key, page, disabled, label, isCurrent = false) {
-        const current = isCurrent ? ' is-current' : '';
-        const aria = isCurrent ? ' aria-current="page"' : '';
-        const disabledAttr = disabled ? ' disabled' : '';
-        return `<button type="button" class="cs-reviews-page${current}" data-reviews-page="${page}" data-page-key="${key}"${aria}${disabledAttr}>${label}</button>`;
+    _hidePagination(elements) {
+        elements.forEach((el) => {
+            el.innerHTML = '';
+            el.style.visibility = 'hidden';
+        });
     }
 
     /**
@@ -2949,10 +2921,7 @@ export default class UgcProduct {
             this.listElement.innerHTML = `<p class="cs-reviews-error">${MESSAGES.loadError}</p>`;
         }
 
-        this.paginationElements.forEach((el) => {
-            el.innerHTML = '';
-            el.style.visibility = 'hidden';
-        });
+        this._hidePagination(this.paginationElements);
 
         // The reviews list is unavailable, so hide the overview panel with it
         // and re-arm the gallery load for the next successful render.

--- a/assets/scss/custom/_cs-home.scss
+++ b/assets/scss/custom/_cs-home.scss
@@ -338,11 +338,8 @@
 }
 
 .cs-ugc-overview-pagination {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: spacing('quarter');
+  @extend %cs-ugc-pagination-nav;
+
   margin-top: spacing('single');
 }
 
@@ -352,34 +349,8 @@
   margin-bottom: spacing('single');
 }
 
-// Matches the .cs-reviews-page treatment on the product page: 44px touch
-// targets, bordered buttons, current-page emphasis, dimmed disabled state.
 .cs-ugc-overview-page {
-  min-width: 44px;
-  height: 44px;
-  padding: 0 spacing('half');
-  border: 1px solid stencilColor('color-greyLightest');
-  border-radius: spacing('half'); // matches .cs-product-archetype button (_custom.scss:59)
-  background: stencilColor('color-white');
-  color: stencilColor('color-textBase');
-  cursor: pointer;
-
-  &:hover:not(:disabled),
-  &:focus-visible {
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-primary');
-  }
-
-  &.is-current {
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-primary');
-    font-weight: 700;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: default;
-  }
+  @extend %cs-ugc-pagination-button;
 }
 
 // =============================================================================

--- a/assets/scss/custom/_cs-product.scss
+++ b/assets/scss/custom/_cs-product.scss
@@ -799,39 +799,19 @@ $cs-fitment-active-hover: #05a;
 // Sort/filter toolbar (SRS §3.4.1 / §3.2.1). Mobile-first: controls stack and
 // wrap; a horizontal row on desktop.
 .cs-reviews-toolbar {
-  display: flex;
-  flex-direction: column;
-  gap: spacing('half');
-  margin-bottom: spacing('single');
-
-  @include breakpoint('medium') {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: spacing('single');
-  }
+  @extend %cs-ugc-toolbar;
 }
 
 .cs-reviews-control {
-  display: flex;
-  flex-direction: column;
-  gap: spacing('quarter');
-  font-size: 0.875rem;
+  @extend %cs-ugc-control;
 
-  // 44px min-height centers the checkbox against the selects' control row
-  // (the toolbar bottom-aligns items, so a text-height toggle would sink to
-  // the selects' baseline).
   &--toggle {
-    flex-direction: row;
-    align-items: center;
-    gap: spacing('half');
-    min-height: 44px;
+    @extend %cs-ugc-control-toggle;
   }
 }
 
 .cs-reviews-control-label {
-  color: stencilColor('color-textSecondary');
-  font-weight: 600;
+  @extend %cs-ugc-control-label;
 }
 
 // "For your <vehicle>" fitment filter chip (SRS §3.4.1). The slot reserves the
@@ -1018,38 +998,11 @@ $cs-fitment-active-hover: #05a;
 }
 
 .cs-reviews-pages {
-  display: flex;
-  flex-wrap: wrap;
-  gap: spacing('quarter');
-  align-items: center;
-  justify-content: center;
+  @extend %cs-ugc-pagination-nav;
 }
 
 .cs-reviews-page {
-  min-width: 44px;
-  height: 44px;
-  padding: 0 spacing('half');
-  border: 1px solid stencilColor('color-greyLightest');
-  background: #fff;
-  color: stencilColor('color-textBase');
-  cursor: pointer;
-
-  &:hover:not(:disabled),
-  &:focus-visible {
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-primary');
-  }
-
-  &.is-current {
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-primary');
-    font-weight: 700;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: default;
-  }
+  @extend %cs-ugc-pagination-button;
 }
 
 // Ellipsis stand-in for a collapsed run of pages in the windowed pagination
@@ -1266,38 +1219,19 @@ button.cs-ugc-vehicle-badge {
 }
 
 .cs-questions-toolbar {
-  display: flex;
-  flex-direction: column;
-  gap: spacing('half');
-  margin-bottom: spacing('single');
-
-  @include breakpoint('medium') {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: spacing('single');
-  }
+  @extend %cs-ugc-toolbar;
 }
 
 .cs-questions-control {
-  display: flex;
-  flex-direction: column;
-  gap: spacing('quarter');
-  font-size: 0.875rem;
+  @extend %cs-ugc-control;
 
-  // Mirrors .cs-reviews-control--toggle: 44px min-height centers the
-  // checkbox against the select's control row.
   &--toggle {
-    flex-direction: row;
-    align-items: center;
-    gap: spacing('half');
-    min-height: 44px;
+    @extend %cs-ugc-control-toggle;
   }
 }
 
 .cs-questions-control-label {
-  color: stencilColor('color-textSecondary');
-  font-weight: 600;
+  @extend %cs-ugc-control-label;
 }
 
 // Visuals come from the shared .cs-form-select class (the add-to-cart option
@@ -1322,38 +1256,11 @@ button.cs-ugc-vehicle-badge {
 }
 
 .cs-questions-pages {
-  display: flex;
-  flex-wrap: wrap;
-  gap: spacing('quarter');
-  align-items: center;
-  justify-content: center;
+  @extend %cs-ugc-pagination-nav;
 }
 
 .cs-questions-page {
-  min-width: 44px;
-  height: 44px;
-  padding: 0 spacing('half');
-  border: 1px solid stencilColor('color-greyLightest');
-  background: #fff;
-  color: stencilColor('color-textBase');
-  cursor: pointer;
-
-  &:hover:not(:disabled),
-  &:focus-visible {
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-primary');
-  }
-
-  &.is-current {
-    border-color: stencilColor('color-primary');
-    color: stencilColor('color-primary');
-    font-weight: 700;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: default;
-  }
+  @extend %cs-ugc-pagination-button;
 }
 
 .cs-question {

--- a/assets/scss/custom/_custom.scss
+++ b/assets/scss/custom/_custom.scss
@@ -76,6 +76,94 @@ h6 {
 }
 
 // -----------------------------------------------------------------------------
+// Shared UGC pagination + toolbar primitives. The reviews, Q&A, and home-wall
+// controls render byte-identical markup (ugcPagination.js) and carried
+// byte-identical SCSS — folded here so the three named classes can't drift.
+// Defined in _custom.scss because it imports before both cs-home and cs-product
+// (theme.scss), so the placeholders are in scope for every consumer.
+// -----------------------------------------------------------------------------
+
+// Numbered/prev/next page button: 44px target, bordered, current-page emphasis,
+// dimmed disabled state. Owns its border-radius and background so all three
+// consumers are explicit (reviews/Q&A previously inherited the radius from
+// .cs-product-archetype button above — same spacing('half') value).
+%cs-ugc-pagination-button {
+  min-width: 44px;
+  height: 44px;
+  padding: 0 spacing('half');
+  border: 1px solid stencilColor('color-greyLightest');
+  border-radius: spacing('half');
+  background: #fff;
+  color: stencilColor('color-textBase');
+  cursor: pointer;
+
+  &:hover:not(:disabled),
+  &:focus-visible {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+  }
+
+  &.is-current {
+    border-color: stencilColor('color-primary');
+    color: stencilColor('color-primary');
+    font-weight: 700;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+// The flex row wrapping the page buttons (wrap + centered, quarter-spacing gap).
+%cs-ugc-pagination-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing('quarter');
+  align-items: center;
+  justify-content: center;
+}
+
+// Reviews/Q&A toolbar: stacked on mobile, a wrapping bottom-aligned row on
+// desktop.
+%cs-ugc-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('half');
+  margin-bottom: spacing('single');
+
+  @include breakpoint('medium') {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: spacing('single');
+  }
+}
+
+// A single labelled control within the toolbar.
+%cs-ugc-control {
+  display: flex;
+  flex-direction: column;
+  gap: spacing('quarter');
+  font-size: 0.875rem;
+}
+
+// The checkbox-toggle variant: 44px min-height centers the checkbox against the
+// selects' control row (the toolbar bottom-aligns items, so a text-height
+// toggle would sink to the selects' baseline).
+%cs-ugc-control-toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: spacing('half');
+  min-height: 44px;
+}
+
+%cs-ugc-control-label {
+  color: stencilColor('color-textSecondary');
+  font-weight: 600;
+}
+
+// -----------------------------------------------------------------------------
 //
 //                                  Utility Classes
 //


### PR DESCRIPTION
Closes #54 — step **3/4** of the UGC DRY audit. Storefront-only, no behavior change (byte-identical rendered HTML, visually-identical compiled CSS).

## JS — shared pagination renderer (`ugcPagination.js`)
The three UGC pagination controls (reviews, Q&A, home wall) each carried a copy of the windowed-button loop PR #53 triplicated, plus a near-identical page-button helper. Lifted into `ugcPagination.js`:
- `pageButton({ key, page, label, disabled, isCurrent, pageClass, dataAttr })` — markup builder.
- `renderPaginationNav({ current, pageCount, pageClass, dataAttr, navClass, ariaLabel })` — windows via `pageWindow`, returns the `<nav>` (or `''` when `pageCount <= 1`).

All three call sites collapse to config + paint. `ugcProduct.renderPagination`/`renderQuestionsPagination` and `ugcOverview.buildPagination` now call the shared builder; `_pageButton`, `_questionPageButton`, and overview's `pageButton` are deleted.

**Signature deviation from the issue's sketch (deliberate):** the issue proposed `renderPaginationNav({ total, perPage, navLabelNoun, ... })`. That can't express the home wall's nav divergence — it uses a dual class `cs-ugc-overview-pagination cs-ugc-overview-pagination--{position}`, aria scope "of **wall**" (vs "of **list**"), and takes `position` as a param, whereas the product navs derive position per-element from `classList`. So the helper instead takes already-resolved `navClass` + `ariaLabel` strings (composed at each call site, where the position logic lives) and a `pageCount` (product computes from `perPage`, overview from its `pageCount()` import). The helper stays genuinely shared; the divergent wrapper logic stays per-site.

## JS — `_hidePagination` helper
The 3-line clear-and-hide `forEach` appeared 4× in `ugcProduct.js` (both `<=1` branches, `renderListError`, `renderQuestionsError`). Now a single `_hidePagination(elements)`.

## SCSS — shared placeholders (`_custom.scss`)
Added `%cs-ugc-pagination-button`, `%cs-ugc-pagination-nav`, `%cs-ugc-toolbar`, `%cs-ugc-control`, `%cs-ugc-control-toggle`, `%cs-ugc-control-label` (in `_custom.scss`, imported first so both `_cs-home.scss` and `_cs-product.scss` can `@extend` them). The duplicated reviews/Q&A/overview bodies are replaced by `@extend`.

## Byte-identical points verified (non-obvious)
1. **Page-button radius** — reviews/Q&A had no explicit `border-radius`; they inherited `spacing('half')` from `.cs-product-archetype button` (`_custom.scss:64`). The placeholder now sets it explicitly to the same `spacing('half')` — computed value unchanged. The overview already set it explicitly to resolve the same inconsistency PR #52 noted.
2. **Overview button background** — was `stencilColor('color-white')`, now `#fff` via the placeholder. Under the live config (`config.json` `color-white` = `#ffffff`) these are identical. Note: two **inactive** `config.json` variation previews define `color-white` as `#333`/`#4f3f2f`, so the overview button background was theme-variation-dependent before and is now a fixed `#fff`. No rendered difference under the active config; flagging for awareness.
3. **`@extend` cascade** — grep-verified no later rule overrides `background`/`border` on any of the six consumer selectors, so hoisting shared declarations into `_custom.scss` doesn't change which rule wins; the `.cs-ugc-overview-pagination--top` margin override still follows.

## Tests
`npx grunt check` green: ESLint + **420 Jest** (22 suites) + stylelint (197 files). Added render-level tests for `pageButton` and `renderPaginationNav` in `ugcPagination.spec.js`. The pre-existing windowed-render integration tests in `ugcProduct.spec.js` / `ugcOverview.spec.js` — which assert the byte-level pagination HTML — pass unchanged (the strongest no-behavior-change proof).

> Note: targets the `cs-ugc-frontend` integration branch, so #54 won't auto-close on merge — expected.
